### PR TITLE
fix(ci): install-ci簡素化 + hooks絶対パス除去

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /home/user/baseball-leagure-manager && make before-commit 2>&1 || echo 'HOOK_FAILED: make before-commit failed. Fix all issues before completing the task.'",
+            "command": "make before-commit 2>&1 || echo 'HOOK_FAILED: make before-commit failed. Fix all issues before completing the task.'",
             "timeout": 60000
           }
         ]

--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,8 @@ lint-check: ## Biome lint + format チェック (CI用、修正しない)
 install: ## 依存関係インストール
 	bun install
 
-install-ci: ## CI用インストール (frozen lockfile, lifecycle scripts無効 + 信頼パッケージのみ実行)
-	bun install --frozen-lockfile --ignore-scripts
-	bun pm trust @biomejs/biome --all
-	$(BIOME) --version
+install-ci: ## CI用インストール (frozen lockfile, trustedDependenciesのみpostinstall許可)
+	bun install --frozen-lockfile
 
 clean: ## ビルド成果物を削除
 	rm -rf packages/web/.next


### PR DESCRIPTION
## Summary

- **install-ci**: `--ignore-scripts` + `bun pm trust` を廃止。`trustedDependencies` (package.json) で Biome のみ postinstall 許可し、`bun install --frozen-lockfile` だけでOKに
- **hooks**: 絶対パス `/home/user/...` を除去して環境非依存に

## Test plan

- [ ] `make before-commit` がローカルで全パスすること (済)
- [ ] CI の Lint / Type Check / Test / Build が全パスすること

https://claude.ai/code/session_01YKUa4yTDkeZsBJcKCXNS4F