### PR TITLE
fix: v2マイグレーションでgamesテーブルが作成されない問題を修正

### DIFF
--- a/supabase/migrations/00002_v2_schema.sql
+++ b/supabase/migrations/00002_v2_schema.sql
@@ -3,6 +3,27 @@
 -- data-model.md に基づく全面リビルド
 -- ============================================================
 
+-- ===== 0. v1 スキーマの削除 =====
+-- v1 テーブルを依存関係の逆順で削除してから v2 テーブルを作成する
+
+DROP TRIGGER IF EXISTS trg_ground_watch_targets_updated_at ON ground_watch_targets;
+DROP TRIGGER IF EXISTS trg_negotiations_updated_at ON negotiations;
+DROP TRIGGER IF EXISTS trg_opponent_teams_updated_at ON opponent_teams;
+DROP TRIGGER IF EXISTS trg_match_requests_updated_at ON match_requests;
+DROP TRIGGER IF EXISTS trg_members_updated_at ON members;
+DROP TRIGGER IF EXISTS trg_teams_updated_at ON teams;
+
+DROP TABLE IF EXISTS confirmations CASCADE;
+DROP TABLE IF EXISTS ground_availability_snapshots CASCADE;
+DROP TABLE IF EXISTS ground_watch_targets CASCADE;
+DROP TABLE IF EXISTS availability_responses CASCADE;
+DROP TABLE IF EXISTS negotiations CASCADE;
+DROP TABLE IF EXISTS opponent_teams CASCADE;
+DROP TABLE IF EXISTS match_requests CASCADE;
+DROP TABLE IF EXISTS audit_logs CASCADE;
+DROP TABLE IF EXISTS members CASCADE;
+DROP TABLE IF EXISTS teams CASCADE;
+
 -- ===== 1. チーム管理 =====
 
 CREATE TABLE teams (

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,59 +1,56 @@
 -- ============================================================
--- シードデータ（ローカル開発用）
+-- シードデータ（ローカル開発用） - v2 スキーマ対応
 -- ============================================================
 
 -- チーム
-INSERT INTO teams (id, name, home_area, level_band) VALUES
-  ('11111111-1111-1111-1111-111111111111', 'サンダーボルツ', '東京都・世田谷区', 'INTERMEDIATE');
+INSERT INTO teams (id, name, home_area, activity_day) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'サンダーボルツ', '東京都・世田谷区', '日曜日');
 
 -- メンバー
-INSERT INTO members (id, team_id, name, positions_json, contact_type, contact_value, attendance_rate, status) VALUES
-  ('aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '田中太郎',   '["ピッチャー"]',  'LINE',  'tanaka-line',  85.00, 'ACTIVE'),
-  ('aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '鈴木一郎',   '["キャッチャー"]','LINE',  'suzuki-line',  90.00, 'ACTIVE'),
-  ('aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '佐藤次郎',   '["ショート"]',    'EMAIL', 'sato@example.com', 75.00, 'ACTIVE'),
-  ('aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '山田三郎',   '["外野手"]',      'LINE',  'yamada-line',  60.00, 'ACTIVE'),
-  ('aaaaaaaa-0005-0005-0005-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '高橋四郎',   '["一塁手"]',      'LINE',  'takahashi-line', 80.00, 'ACTIVE'),
-  ('aaaaaaaa-0006-0006-0006-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '中村五郎',   '["二塁手"]',      'EMAIL', 'nakamura@example.com', 88.00, 'ACTIVE'),
-  ('aaaaaaaa-0007-0007-0007-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '小林六郎',   '["三塁手"]',      'LINE',  'kobayashi-line', 70.00, 'ACTIVE'),
-  ('aaaaaaaa-0008-0008-0008-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '加藤七郎',   '["外野手"]',      'LINE',  'kato-line',    82.00, 'ACTIVE'),
-  ('aaaaaaaa-0009-0009-0009-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '吉田八郎',   '["外野手"]',      'LINE',  'yoshida-line', 65.00, 'ACTIVE');
+INSERT INTO members (id, team_id, name, tier, positions_json, attendance_rate, status) VALUES
+  ('aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '田中太郎',   'PRO',  '["ピッチャー"]',  85.00, 'ACTIVE'),
+  ('aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '鈴木一郎',   'PRO',  '["キャッチャー"]',90.00, 'ACTIVE'),
+  ('aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '佐藤次郎',   'LITE', '["ショート"]',    75.00, 'ACTIVE'),
+  ('aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '山田三郎',   'PRO',  '["外野手"]',      60.00, 'ACTIVE'),
+  ('aaaaaaaa-0005-0005-0005-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '高橋四郎',   'PRO',  '["一塁手"]',      80.00, 'ACTIVE'),
+  ('aaaaaaaa-0006-0006-0006-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '中村五郎',   'PRO',  '["二塁手"]',      88.00, 'ACTIVE'),
+  ('aaaaaaaa-0007-0007-0007-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '小林六郎',   'LITE', '["三塁手"]',      70.00, 'ACTIVE'),
+  ('aaaaaaaa-0008-0008-0008-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '加藤七郎',   'PRO',  '["外野手"]',      82.00, 'ACTIVE'),
+  ('aaaaaaaa-0009-0009-0009-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '吉田八郎',   'PRO',  '["外野手"]',      65.00, 'ACTIVE');
 
--- 試合リクエスト
-INSERT INTO match_requests (id, team_id, title, desired_dates_json, preferred_time_slots_json, area, level_requirement, needs_ground, budget_limit, status, confidence_score) VALUES
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '5月第2週 練習試合', '["2026-05-09","2026-05-10"]', '["9:00-12:00"]', '東京都・世田谷区', 'INTERMEDIATE', true,  5000, 'NEGOTIATING', 55),
-  ('bbbbbbbb-0002-0002-0002-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '5月第3週 対戦希望', '["2026-05-16","2026-05-17"]', '["13:00-17:00"]','東京都・杉並区',   NULL,           true,  NULL, 'OPEN',        10),
-  ('bbbbbbbb-0003-0003-0003-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '4月 確定済み試合',  '["2026-04-12"]',              '["9:00-12:00"]', '東京都・大田区',   'INTERMEDIATE', false, 3000, 'CONFIRMED',  100);
+-- 助っ人
+INSERT INTO helpers (id, team_id, name, note, times_helped) VALUES
+  ('hhhhhhhh-0001-0001-0001-hhhhhhhhhhhh', '11111111-1111-1111-1111-111111111111', '外山助太', '佐藤さんの友人', 3);
 
 -- 対戦相手チーム
-INSERT INTO opponent_teams (id, name, area, level_band, contact_channel) VALUES
-  ('cccccccc-0001-0001-0001-cccccccccccc', 'レッドソックス', '東京都・目黒区',   'INTERMEDIATE', 'LINE'),
-  ('cccccccc-0002-0002-0002-cccccccccccc', 'ブルージェイズ', '東京都・渋谷区',   'ADVANCED',     'EMAIL'),
-  ('cccccccc-0003-0003-0003-cccccccccccc', 'イーグルス',     '東京都・新宿区',   'INTERMEDIATE', 'LINE');
+INSERT INTO opponent_teams (id, team_id, name, area, contact_name) VALUES
+  ('cccccccc-0001-0001-0001-cccccccccccc', '11111111-1111-1111-1111-111111111111', 'レッドソックス', '東京都・目黒区', '山本監督'),
+  ('cccccccc-0002-0002-0002-cccccccccccc', '11111111-1111-1111-1111-111111111111', 'ブルージェイズ', '東京都・渋谷区', '伊藤キャプテン'),
+  ('cccccccc-0003-0003-0003-cccccccccccc', '11111111-1111-1111-1111-111111111111', 'イーグルス',     '東京都・新宿区', '木村代表');
+
+-- グラウンド
+INSERT INTO grounds (id, team_id, name, municipality, source_url, cost_per_slot, is_hardball_ok) VALUES
+  ('eeeeeeee-0001-0001-0001-eeeeeeeeeeee', '11111111-1111-1111-1111-111111111111', '世田谷区立総合運動場', '東京都世田谷区', 'https://example.com/setagaya', 5000, false),
+  ('eeeeeeee-0002-0002-0002-eeeeeeeeeeee', '11111111-1111-1111-1111-111111111111', '砧公園野球場',         '東京都世田谷区', 'https://example.com/kinuta',   3000, false);
+
+-- 試合
+INSERT INTO games (id, team_id, title, game_type, status, game_date, start_time, end_time, ground_id, ground_name, opponent_team_id, min_players, rsvp_deadline) VALUES
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '5月第2週 練習試合', 'FRIENDLY', 'COLLECTING', '2026-05-10', '09:00', '12:00', 'eeeeeeee-0001-0001-0001-eeeeeeeeeeee', '世田谷区立総合運動場', 'cccccccc-0002-0002-0002-cccccccccccc', 9, '2026-05-07 23:59:00+09'),
+  ('bbbbbbbb-0002-0002-0002-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '5月第3週 対戦希望', 'FRIENDLY', 'DRAFT',      '2026-05-17', '13:00', '17:00', NULL,                                   NULL,                   NULL,                                   9, NULL),
+  ('bbbbbbbb-0003-0003-0003-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111', '4月 確定済み試合',  'FRIENDLY', 'CONFIRMED',  '2026-04-12', '09:00', '12:00', 'eeeeeeee-0002-0002-0002-eeeeeeeeeeee', '砧公園野球場',         'cccccccc-0001-0001-0001-cccccccccccc', 9, '2026-04-09 23:59:00+09');
+
+-- 出欠（5月第2週 練習試合向け）
+INSERT INTO rsvps (game_id, member_id, response, responded_at) VALUES
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', 'AVAILABLE',   now()),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa', 'AVAILABLE',   now()),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa', 'MAYBE',       now()),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa', 'UNAVAILABLE', now()),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0005-0005-0005-aaaaaaaaaaaa', 'NO_RESPONSE', NULL),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0006-0006-0006-aaaaaaaaaaaa', 'AVAILABLE',   now()),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0007-0007-0007-aaaaaaaaaaaa', 'NO_RESPONSE', NULL),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0008-0008-0008-aaaaaaaaaaaa', 'AVAILABLE',   now()),
+  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0009-0009-0009-aaaaaaaaaaaa', 'NO_RESPONSE', NULL);
 
 -- 交渉
-INSERT INTO negotiations (id, match_request_id, opponent_team_id, proposed_dates_json, generated_message, reply_message, status) VALUES
-  ('dddddddd-0001-0001-0001-dddddddddddd', 'bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'cccccccc-0001-0001-0001-cccccccccccc', '["2026-05-09","2026-05-10"]', 'お世話になります。5月9日または10日に練習試合をお願いできますでしょうか。', NULL, 'SENT'),
-  ('dddddddd-0002-0002-0002-dddddddddddd', 'bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'cccccccc-0002-0002-0002-cccccccccccc', '["2026-05-10"]', '5月10日に練習試合のお誘いです。', '承知しました！10日午前でお願いします。', 'ACCEPTED'),
-  ('dddddddd-0003-0003-0003-dddddddddddd', 'bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'cccccccc-0003-0003-0003-cccccccccccc', '["2026-05-09"]', '5月9日に練習試合いかがでしょうか。', '申し訳ありません、その日は予定があります。', 'DECLINED');
-
--- グラウンド監視対象
-INSERT INTO ground_watch_targets (id, team_id, name, source_url, area, active) VALUES
-  ('eeeeeeee-0001-0001-0001-eeeeeeeeeeee', '11111111-1111-1111-1111-111111111111', '世田谷区立総合運動場', 'https://example.com/setagaya', '東京都・世田谷区', true),
-  ('eeeeeeee-0002-0002-0002-eeeeeeeeeeee', '11111111-1111-1111-1111-111111111111', '砧公園野球場',         'https://example.com/kinuta',   '東京都・世田谷区', true);
-
--- グラウンド空き情報スナップショット
-INSERT INTO ground_availability_snapshots (ground_watch_target_id, snapshot_time, availability_json, hash) VALUES
-  ('eeeeeeee-0001-0001-0001-eeeeeeeeeeee', '2026-03-29 10:00:00+09', '{"slots": [{"date": "2026-05-09", "time": "9:00-12:00"}, {"date": "2026-05-10", "time": "13:00-17:00"}]}', 'hash-setagaya-1'),
-  ('eeeeeeee-0002-0002-0002-eeeeeeeeeeee', '2026-03-29 10:00:00+09', '{"slots": []}', 'hash-kinuta-1');
-
--- 出欠回答（5月第2週 練習試合向け）
-INSERT INTO availability_responses (match_request_id, member_id, response) VALUES
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0001-0001-0001-aaaaaaaaaaaa', 'AVAILABLE'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0002-0002-0002-aaaaaaaaaaaa', 'AVAILABLE'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0003-0003-0003-aaaaaaaaaaaa', 'MAYBE'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0004-0004-0004-aaaaaaaaaaaa', 'UNAVAILABLE'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0005-0005-0005-aaaaaaaaaaaa', 'UNKNOWN'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0006-0006-0006-aaaaaaaaaaaa', 'AVAILABLE'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0007-0007-0007-aaaaaaaaaaaa', 'UNKNOWN'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0008-0008-0008-aaaaaaaaaaaa', 'AVAILABLE'),
-  ('bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'aaaaaaaa-0009-0009-0009-aaaaaaaaaaaa', 'UNKNOWN');
+INSERT INTO negotiations (id, game_id, opponent_team_id, status, proposed_dates_json, message_sent, reply_received) VALUES
+  ('dddddddd-0001-0001-0001-dddddddddddd', 'bbbbbbbb-0001-0001-0001-bbbbbbbbbbbb', 'cccccccc-0002-0002-0002-cccccccccccc', 'ACCEPTED', '["2026-05-10"]', '5月10日に練習試合のお誘いです。', '承知しました！10日午前でお願いします。');


### PR DESCRIPTION
## Summary
- v2マイグレーション(`00002_v2_schema.sql`)がv1で作成済みのテーブル(`teams`, `members`等)と衝突し、`CREATE TABLE`が失敗して`games`テーブルが作成されなかった問題を修正
- v2マイグレーションの先頭にv1テーブル・トリガーの`DROP ... IF EXISTS CASCADE`文を追加
- シードデータ(`seed.sql`)をv1スキーマ(`match_requests`, `contact_type`等)からv2スキーマ(`games`, `rsvps`, `grounds`等)に全面更新

## Test plan
- [x] `make check` (lint + typecheck + test) 全パス確認済み
- [ ] `supabase db reset` でマイグレーションが正常に完了すること
- [ ] 試合登録機能が動作すること

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced game and grounds management system
  * Improved RSVP and availability tracking workflow
  * Added helper functionality support

* **Chores**
  * Database schema upgraded to v2 with optimized data structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->