### PR TITLE
feat: Cloudscape Design System 導入 + AppLayout で全UIリニューアル

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,9 @@
       "name": "@match-engine/web",
       "version": "0.1.0",
       "dependencies": {
+        "@cloudscape-design/collection-hooks": "^1.0.89",
+        "@cloudscape-design/components": "^3.0.1265",
+        "@cloudscape-design/global-styles": "^1.0.56",
         "@line/liff": "^2.28.0",
         "@match-engine/core": "workspace:*",
         "@supabase/ssr": "^0.9.0",
@@ -54,6 +57,8 @@
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
@@ -72,7 +77,37 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
+    "@cloudscape-design/collection-hooks": ["@cloudscape-design/collection-hooks@1.0.89", "", { "dependencies": { "@cloudscape-design/component-toolkit": "^1.0.0-beta" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-6qdknAOyB1NLdZtEahxIZju8b3vbZH6uR64kLUNcqiS9BVsSdEC9gUtYRrepRrcBh8i6Lh0yzSnHZm1Z7aQGyw=="],
+
+    "@cloudscape-design/component-toolkit": ["@cloudscape-design/component-toolkit@1.0.0-beta.154", "", { "dependencies": { "tslib": "^2.3.1", "weekstart": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-wGLG9MwPHAxyGMYFm6AncYJsYpNcezAbj9HJ63z5chW6FlTaQQOQrKs5TGd042wW4Sq/20HN+B3NSt7/tPYGxQ=="],
+
+    "@cloudscape-design/components": ["@cloudscape-design/components@3.0.1265", "", { "dependencies": { "@cloudscape-design/collection-hooks": "^1.0.0", "@cloudscape-design/component-toolkit": "^1.0.0-beta", "@cloudscape-design/test-utils-core": "^1.0.0", "@cloudscape-design/theming-runtime": "^1.0.0", "@dnd-kit/core": "^6.0.8", "@dnd-kit/sortable": "^7.0.2", "@dnd-kit/utilities": "^3.2.1", "ace-builds": "^1.34.0", "clsx": "^1.1.0", "d3-shape": "^1.3.7", "date-fns": "^2.25.0", "intl-messageformat": "^10.3.1", "mnth": "^2.0.0", "react-is": "^18.2.0", "react-transition-group": "^4.4.2", "tslib": "^2.4.0", "weekstart": "^1.1.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-1D5mpY3E7J6V4ez+SiGKo4x8jV1jn9rTygz+QjR0HImUU2LUxTvpk77ePZmQ2eax5o2Y7c7KIOoOBI3svQRTUw=="],
+
+    "@cloudscape-design/global-styles": ["@cloudscape-design/global-styles@1.0.56", "", {}, "sha512-J88d+4Pu/t7o3qPhlOqxuZU2PJCsINrv4Fk8TZxsEE/58J6p2JeizRoceU8RaSQw5xeT9DQVyLwahc/miwH/Gg=="],
+
+    "@cloudscape-design/test-utils-core": ["@cloudscape-design/test-utils-core@1.0.80", "", { "dependencies": { "css-selector-tokenizer": "^0.8.0", "css.escape": "^1.5.1" } }, "sha512-BKlMvuJc4q/5glG+a1smdp73B46Q9eOcuZ/nRWWPwILKkgL6RbrjpKHVPcwUmLLPsVMEwJl4tLVNGJsCnmmedg=="],
+
+    "@cloudscape-design/theming-runtime": ["@cloudscape-design/theming-runtime@1.0.105", "", { "dependencies": { "@material/material-color-utilities": "^0.3.0", "tslib": "^2.4.0" } }, "sha512-gbSNPZExhT51DIBlhYrsrh/UsnGRfE1VCYyErMGwKHlXLNCb8tF3U1sUDamzYc19cN93YHGnjUZomxr7fCLT/w=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@7.0.2", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.0", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.7", "react": ">=16.8.0" } }, "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
+
     "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
+    "@formatjs/ecma402-abstract": ["@formatjs/ecma402-abstract@2.3.6", "", { "dependencies": { "@formatjs/fast-memoize": "2.2.7", "@formatjs/intl-localematcher": "0.6.2", "decimal.js": "^10.4.3", "tslib": "^2.8.0" } }, "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw=="],
+
+    "@formatjs/fast-memoize": ["@formatjs/fast-memoize@2.2.7", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ=="],
+
+    "@formatjs/icu-messageformat-parser": ["@formatjs/icu-messageformat-parser@2.11.4", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/icu-skeleton-parser": "1.8.16", "tslib": "^2.8.0" } }, "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw=="],
+
+    "@formatjs/icu-skeleton-parser": ["@formatjs/icu-skeleton-parser@1.8.16", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "tslib": "^2.8.0" } }, "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ=="],
+
+    "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.6.2", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -236,6 +271,8 @@
 
     "@match-engine/web": ["@match-engine/web@workspace:packages/web"],
 
+    "@material/material-color-utilities": ["@material/material-color-utilities@0.3.0", "", {}, "sha512-ztmtTd6xwnuh2/xu+Vb01btgV8SQWYCaK56CkRK8gEkWe5TuDyBcYJ0wgkMRn+2VcE9KUmhvkz+N9GHrqw/C0g=="],
+
     "@next/env": ["@next/env@16.2.1", "", {}, "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q=="],
@@ -314,6 +351,8 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "ace-builds": ["ace-builds@1.43.6", "", {}, "sha512-L1ddibQ7F3vyXR2k2fg+I8TQTPWVA6CKeDQr/h2+8CeyTp3W6EQL8xNFZRTztuP8xNOAqL3IYPqdzs31GCjDvg=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "axios": ["axios@1.14.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ=="],
@@ -328,15 +367,33 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
+    "clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
+    "css-selector-tokenizer": ["css-selector-tokenizer@0.8.0", "", { "dependencies": { "cssesc": "^3.0.0", "fastparse": "^1.1.2" } }, "sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "date-fns": ["date-fns@2.30.0", "", { "dependencies": { "@babel/runtime": "^7.21.0" } }, "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -349,6 +406,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "fastparse": ["fastparse@1.1.2", "", {}, "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="],
 
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 
@@ -372,7 +431,11 @@
 
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
+    "intl-messageformat": ["intl-messageformat@10.7.18", "", { "dependencies": { "@formatjs/ecma402-abstract": "2.3.6", "@formatjs/fast-memoize": "2.2.7", "@formatjs/icu-messageformat-parser": "2.11.4", "tslib": "^2.8.0" } }, "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -398,6 +461,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -406,19 +471,29 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "mnth": ["mnth@2.0.0", "", { "dependencies": { "@babel/runtime": "^7.8.0" } }, "sha512-3ZH4UWBGpAwCKdfjynLQpUDVZWMe6vRHwarIpMdGLUp89CVR9hjzgyWERtMyqx+fPEqQ/PsAxFwvwPxLFxW40A=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "next": ["next@16.2.1", "", { "dependencies": { "@next/env": "16.2.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.1", "@next/swc-darwin-x64": "16.2.1", "@next/swc-linux-arm64-gnu": "16.2.1", "@next/swc-linux-arm64-musl": "16.2.1", "@next/swc-linux-x64-gnu": "16.2.1", "@next/swc-linux-x64-musl": "16.2.1", "@next/swc-win32-arm64-msvc": "16.2.1", "@next/swc-win32-x64-msvc": "16.2.1", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -444,11 +519,15 @@
 
     "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
+    "weekstart": ["weekstart@1.1.0", "", {}, "sha512-ZO3I7c7J9nwGN1PZKZeBYAsuwWEsCOZi5T68cQoVNYrzrpp5Br0Bgi0OF4l8kH/Ez7nKfxa5mSsXjsgris3+qg=="],
+
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@cloudscape-design/component-toolkit/weekstart": ["weekstart@2.0.0", "", {}, "sha512-HjYc14IQUwDcnGICuc8tVtqAd6EFpoAQMqgrqcNtWWZB+F1b7iTq44GzwM1qvnH4upFgbhJsaNHuK93NOFheSg=="],
 
     "@line/bot-sdk/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
@@ -465,6 +544,8 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "@line/bot-sdk/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,6 +9,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@cloudscape-design/collection-hooks": "^1.0.89",
+    "@cloudscape-design/components": "^3.0.1265",
+    "@cloudscape-design/global-styles": "^1.0.56",
     "@line/liff": "^2.28.0",
     "@match-engine/core": "workspace:*",
     "@supabase/ssr": "^0.9.0",

--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -1,8 +1,54 @@
-import { GameStatusBadge } from "@/components/StatusBadge";
 import { TransitionButtons } from "@/components/TransitionButtons";
 import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
 import { getAvailableTransitions } from "@match-engine/core";
 import type { GameStatus } from "@match-engine/core";
+
+const STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  COLLECTING: "info",
+  CONFIRMED: "success",
+  COMPLETED: "success",
+  SETTLED: "stopped",
+  CANCELLED: "error",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: "下書き",
+  COLLECTING: "出欠収集中",
+  CONFIRMED: "確定",
+  COMPLETED: "完了",
+  SETTLED: "精算済み",
+  CANCELLED: "中止",
+};
+
+const RSVP_STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  AVAILABLE: "success",
+  UNAVAILABLE: "error",
+  MAYBE: "warning",
+  NO_RESPONSE: "pending",
+};
+
+const RSVP_LABELS: Record<string, string> = {
+  AVAILABLE: "参加",
+  UNAVAILABLE: "不参加",
+  MAYBE: "未定",
+  NO_RESPONSE: "未回答",
+};
 
 export default async function GameDetailPage({
   params,
@@ -20,9 +66,11 @@ export default async function GameDetailPage({
 
   if (!game) {
     return (
-      <div className="py-12 text-center text-gray-500">
-        試合が見つかりません
-      </div>
+      <ContentLayout header={<Header variant="h1">試合詳細</Header>}>
+        <Box textAlign="center" color="text-status-inactive" padding="xxl">
+          試合が見つかりません
+        </Box>
+      </ContentLayout>
     );
   }
 
@@ -34,102 +82,122 @@ export default async function GameDetailPage({
   const transitions = getAvailableTransitions(game.status as GameStatus);
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">{game.title}</h1>
-        <div className="mt-2 flex items-center gap-3">
-          <GameStatusBadge status={game.status as GameStatus} />
-          <span className="text-sm text-gray-500">{game.game_type}</span>
-        </div>
-      </div>
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          info={
+            <StatusIndicator type={STATUS_TYPE[game.status] ?? "info"}>
+              {STATUS_LABELS[game.status] ?? game.status}
+            </StatusIndicator>
+          }
+        >
+          {game.title}
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Container header={<Header variant="h2">試合情報</Header>}>
+          <ColumnLayout columns={2} variant="text-grid">
+            <KeyValuePairs
+              items={[
+                { label: "試合日", value: game.game_date ?? "未定" },
+                { label: "開始時刻", value: game.start_time ?? "未定" },
+                { label: "グラウンド", value: game.ground_name ?? "未定" },
+                { label: "最低人数", value: `${game.min_players}人` },
+              ]}
+            />
+            <KeyValuePairs
+              items={[
+                {
+                  label: "参加",
+                  value: (
+                    <Box color="text-status-success">
+                      {game.available_count}人
+                    </Box>
+                  ),
+                },
+                {
+                  label: "不参加",
+                  value: (
+                    <Box color="text-status-error">
+                      {game.unavailable_count}人
+                    </Box>
+                  ),
+                },
+                {
+                  label: "未回答",
+                  value: (
+                    <Box color="text-status-inactive">
+                      {game.no_response_count}人
+                    </Box>
+                  ),
+                },
+                { label: "種別", value: game.game_type },
+              ]}
+            />
+          </ColumnLayout>
+        </Container>
 
-      <dl className="grid grid-cols-2 gap-4 rounded-lg border bg-white p-4 text-sm">
-        <Dt label="試合日" value={game.game_date ?? "未定"} />
-        <Dt label="開始" value={game.start_time ?? "未定"} />
-        <Dt label="グラウンド" value={game.ground_name ?? "未定"} />
-        <Dt label="最低人数" value={`${game.min_players}人`} />
-        <Dt
-          label="出欠"
-          value={`参加${game.available_count} / 不参加${game.unavailable_count} / 未回答${game.no_response_count}`}
-        />
-      </dl>
+        <Container header={<Header variant="h2">アクション</Header>}>
+          <TransitionButtons
+            gameId={game.id}
+            currentStatus={game.status}
+            transitions={transitions}
+          />
+        </Container>
 
-      {/* 状態遷移 */}
-      <section className="rounded-lg border bg-white p-4">
-        <h2 className="mb-3 text-sm font-semibold">アクション</h2>
-        <TransitionButtons
-          gameId={game.id}
-          currentStatus={game.status}
-          transitions={transitions}
-        />
-      </section>
-
-      {/* 出欠一覧（閲覧のみ — 回答はLINEアプリから） */}
-      {rsvps && rsvps.length > 0 && (
-        <section>
-          <h2 className="mb-3 text-sm font-semibold">出欠状況</h2>
-          <div className="overflow-hidden rounded-lg border bg-white">
-            <table className="w-full text-left text-sm">
-              <thead className="border-b bg-gray-50 text-xs text-gray-500">
-                <tr>
-                  <th className="px-4 py-2">名前</th>
-                  <th className="px-4 py-2">区分</th>
-                  <th className="px-4 py-2">回答</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {rsvps.map((r) => {
-                  const member = r.members as {
+        {rsvps && rsvps.length > 0 && (
+          <Table
+            header={
+              <Header
+                variant="h2"
+                counter={`(${rsvps.length})`}
+                description="出欠の回答はLINEアプリから行えます"
+              >
+                出欠状況
+              </Header>
+            }
+            columnDefinitions={[
+              {
+                id: "name",
+                header: "名前",
+                cell: (item) => {
+                  const member = item.members as {
                     name: string;
                     tier: string;
                   } | null;
-                  const labels: Record<string, string> = {
-                    AVAILABLE: "参加",
-                    UNAVAILABLE: "不参加",
-                    MAYBE: "未定",
-                    NO_RESPONSE: "未回答",
-                  };
-                  const colors: Record<string, string> = {
-                    AVAILABLE: "bg-green-100 text-green-700",
-                    UNAVAILABLE: "bg-red-100 text-red-700",
-                    MAYBE: "bg-yellow-100 text-yellow-700",
-                    NO_RESPONSE: "bg-gray-100 text-gray-600",
-                  };
-                  return (
-                    <tr key={r.id}>
-                      <td className="px-4 py-2 font-medium">
-                        {member?.name ?? "—"}
-                      </td>
-                      <td className="px-4 py-2 text-gray-500">
-                        {member?.tier ?? "—"}
-                      </td>
-                      <td className="px-4 py-2">
-                        <span
-                          className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${colors[r.response] ?? ""}`}
-                        >
-                          {labels[r.response] ?? r.response}
-                        </span>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-          <p className="mt-2 text-xs text-gray-400">
-            出欠の回答はLINEアプリから行えます
-          </p>
-        </section>
-      )}
-    </div>
-  );
-}
-
-function Dt({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <dt className="text-gray-500">{label}</dt>
-      <dd className="mt-0.5 font-medium">{value}</dd>
-    </div>
+                  return member?.name ?? "—";
+                },
+              },
+              {
+                id: "tier",
+                header: "区分",
+                cell: (item) => {
+                  const member = item.members as {
+                    name: string;
+                    tier: string;
+                  } | null;
+                  return member?.tier ?? "—";
+                },
+              },
+              {
+                id: "response",
+                header: "回答",
+                cell: (item) => (
+                  <StatusIndicator
+                    type={RSVP_STATUS_TYPE[item.response] ?? "pending"}
+                  >
+                    {RSVP_LABELS[item.response] ?? item.response}
+                  </StatusIndicator>
+                ),
+              },
+            ]}
+            items={rsvps}
+            variant="embedded"
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
   );
 }

--- a/packages/web/src/app/(manager)/games/new/page.tsx
+++ b/packages/web/src/app/(manager)/games/new/page.tsx
@@ -1,8 +1,28 @@
 "use client";
 
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import DateInput from "@cloudscape-design/components/date-input";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import Form from "@cloudscape-design/components/form";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Select from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Textarea from "@cloudscape-design/components/textarea";
+import TimeInput from "@cloudscape-design/components/time-input";
 import type { GameType } from "@match-engine/core";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+
+const GAME_TYPE_OPTIONS = [
+  { label: "練習", value: "PRACTICE" },
+  { label: "練習試合", value: "FRIENDLY" },
+  { label: "リーグ戦", value: "LEAGUE" },
+  { label: "トーナメント", value: "TOURNAMENT" },
+];
 
 export default function NewGamePage() {
   const router = useRouter();
@@ -14,12 +34,11 @@ export default function NewGamePage() {
   const [minPlayers, setMinPlayers] = useState("9");
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async () => {
     setSubmitting(true);
-    setResult(null);
+    setError(null);
 
     try {
       const res = await fetch("/api/games", {
@@ -43,127 +62,120 @@ export default function NewGamePage() {
         return;
       }
       const err = await res.json();
-      setResult(`エラー: ${err.error}`);
+      setError(`エラー: ${err.error}`);
     } catch {
-      setResult("通信エラーが発生しました");
+      setError("通信エラーが発生しました");
     } finally {
       setSubmitting(false);
     }
   };
 
   return (
-    <div className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-2xl font-bold">試合作成</h1>
-
-      <form onSubmit={handleSubmit} className="space-y-5">
-        <Field label="タイトル">
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            required
-            placeholder="例: 4/5 vs ○○さん"
-            className="input"
-          />
-        </Field>
-
-        <Field label="種別">
-          <select
-            value={gameType}
-            onChange={(e) => setGameType(e.target.value as GameType)}
-            className="input"
-          >
-            <option value="PRACTICE">練習</option>
-            <option value="FRIENDLY">練習試合</option>
-            <option value="LEAGUE">リーグ戦</option>
-            <option value="TOURNAMENT">トーナメント</option>
-          </select>
-        </Field>
-
-        <Field label="試合日">
-          <input
-            type="date"
-            value={gameDate}
-            onChange={(e) => setGameDate(e.target.value)}
-            className="input"
-          />
-        </Field>
-
-        <Field label="開始時刻">
-          <input
-            type="time"
-            value={startTime}
-            onChange={(e) => setStartTime(e.target.value)}
-            className="input"
-          />
-        </Field>
-
-        <Field label="グラウンド">
-          <input
-            type="text"
-            value={groundName}
-            onChange={(e) => setGroundName(e.target.value)}
-            placeholder="例: 八部公園野球場"
-            className="input"
-          />
-        </Field>
-
-        <Field label="最低人数">
-          <input
-            type="number"
-            value={minPlayers}
-            onChange={(e) => setMinPlayers(e.target.value)}
-            min="1"
-            className="input"
-          />
-        </Field>
-
-        <Field label="メモ">
-          <textarea
-            value={note}
-            onChange={(e) => setNote(e.target.value)}
-            className="input"
-            rows={3}
-          />
-        </Field>
-
-        <button
-          type="submit"
-          disabled={submitting}
-          className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+    <ContentLayout header={<Header variant="h1">試合作成</Header>}>
+      {error && (
+        <Flashbar
+          items={[
+            {
+              type: "error",
+              content: error,
+              dismissible: true,
+              onDismiss: () => setError(null),
+              id: "error",
+            },
+          ]}
+        />
+      )}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <Form
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button variant="link" onClick={() => router.push("/")}>
+                キャンセル
+              </Button>
+              <Button
+                variant="primary"
+                formAction="submit"
+                loading={submitting}
+              >
+                試合を作成
+              </Button>
+            </SpaceBetween>
+          }
         >
-          {submitting ? "作成中..." : "試合を作成"}
-        </button>
+          <Container header={<Header variant="h2">試合情報</Header>}>
+            <SpaceBetween size="l">
+              <FormField label="タイトル">
+                <Input
+                  value={title}
+                  onChange={({ detail }) => setTitle(detail.value)}
+                  placeholder="例: 4/5 vs ○○さん"
+                />
+              </FormField>
 
-        {result && (
-          <p
-            className={`rounded-lg p-3 text-sm ${
-              result.startsWith("エラー") || result.startsWith("通信")
-                ? "bg-red-50 text-red-700"
-                : "bg-green-50 text-green-700"
-            }`}
-          >
-            {result}
-          </p>
-        )}
+              <FormField label="種別">
+                <Select
+                  selectedOption={
+                    GAME_TYPE_OPTIONS.find((o) => o.value === gameType) ?? null
+                  }
+                  onChange={({ detail }) =>
+                    setGameType(
+                      (detail.selectedOption.value as GameType) ?? "FRIENDLY",
+                    )
+                  }
+                  options={GAME_TYPE_OPTIONS}
+                />
+              </FormField>
+
+              <FormField label="試合日">
+                <DateInput
+                  value={gameDate}
+                  onChange={({ detail }) => setGameDate(detail.value)}
+                  placeholder="YYYY/MM/DD"
+                />
+              </FormField>
+
+              <FormField label="開始時刻">
+                <TimeInput
+                  value={startTime}
+                  onChange={({ detail }) => setStartTime(detail.value)}
+                  format="hh:mm"
+                  placeholder="HH:mm"
+                />
+              </FormField>
+
+              <FormField label="グラウンド">
+                <Input
+                  value={groundName}
+                  onChange={({ detail }) => setGroundName(detail.value)}
+                  placeholder="例: 八部公園野球場"
+                />
+              </FormField>
+
+              <FormField label="最低人数">
+                <Input
+                  type="number"
+                  value={minPlayers}
+                  onChange={({ detail }) => setMinPlayers(detail.value)}
+                  inputMode="numeric"
+                />
+              </FormField>
+
+              <FormField label="メモ">
+                <Textarea
+                  value={note}
+                  onChange={({ detail }) => setNote(detail.value)}
+                  rows={3}
+                />
+              </FormField>
+            </SpaceBetween>
+          </Container>
+        </Form>
       </form>
-    </div>
-  );
-}
-
-function Field({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <label className="block">
-      <span className="mb-1 block text-sm font-medium text-gray-700">
-        {label}
-      </span>
-      {children}
-    </label>
+    </ContentLayout>
   );
 }

--- a/packages/web/src/app/(manager)/layout.tsx
+++ b/packages/web/src/app/(manager)/layout.tsx
@@ -1,26 +1,68 @@
+"use client";
+
+import AppLayout from "@cloudscape-design/components/app-layout";
+import SideNavigation from "@cloudscape-design/components/side-navigation";
+import TopNavigation from "@cloudscape-design/components/top-navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+
 export default function ManagerLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [navOpen, setNavOpen] = useState(true);
+
   return (
     <>
-      <header className="border-b border-gray-200 bg-white">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-          <a href="/" className="text-lg font-bold">
-            試合成立エンジン
-          </a>
-          <nav className="flex gap-4 text-sm">
-            <a href="/" className="hover:text-blue-600">
-              ダッシュボード
-            </a>
-            <a href="/games/new" className="hover:text-blue-600">
-              試合作成
-            </a>
-          </nav>
-        </div>
-      </header>
-      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+      <div id="top-nav">
+        <TopNavigation
+          identity={{
+            href: "/",
+            title: "試合成立エンジン",
+          }}
+          utilities={[
+            {
+              type: "button",
+              text: "試合作成",
+              onClick: () => router.push("/games/new"),
+            },
+          ]}
+        />
+      </div>
+
+      <AppLayout
+        navigation={
+          <SideNavigation
+            activeHref={pathname}
+            onFollow={(e) => {
+              e.preventDefault();
+              router.push(e.detail.href);
+            }}
+            header={{ text: "メニュー", href: "/" }}
+            items={[
+              { type: "link", text: "ダッシュボード", href: "/" },
+              { type: "link", text: "試合作成", href: "/games/new" },
+              { type: "divider" },
+              {
+                type: "section",
+                text: "管理",
+                items: [
+                  { type: "link", text: "チーム", href: "/teams" },
+                  { type: "link", text: "助っ人", href: "/helpers" },
+                ],
+              },
+            ]}
+          />
+        }
+        navigationOpen={navOpen}
+        onNavigationChange={({ detail }) => setNavOpen(detail.open)}
+        content={children}
+        toolsHide
+        headerSelector="#top-nav"
+      />
     </>
   );
 }

--- a/packages/web/src/app/(manager)/page.tsx
+++ b/packages/web/src/app/(manager)/page.tsx
@@ -1,5 +1,10 @@
 import { DashboardView } from "@/components/DashboardView";
 import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -27,19 +32,20 @@ export default async function DashboardPage() {
   const confirmed = games?.filter((g) => g.status === "CONFIRMED") ?? [];
 
   return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold">ダッシュボード</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          試合成立エンジン — 現在の状況
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <SummaryCard label="進行中" value={active.length} />
-        <SummaryCard label="確定済み" value={confirmed.length} />
-        <SummaryCard label="全試合" value={games?.length ?? 0} />
-      </div>
+    <ContentLayout
+      header={
+        <Header variant="h1" description="試合成立エンジン — 現在の状況">
+          ダッシュボード
+        </Header>
+      }
+    >
+      <Box margin={{ bottom: "l" }}>
+        <ColumnLayout columns={3}>
+          <KpiCard label="進行中" value={active.length} />
+          <KpiCard label="確定済み" value={confirmed.length} />
+          <KpiCard label="全試合" value={games?.length ?? 0} />
+        </ColumnLayout>
+      </Box>
 
       <DashboardView
         games={(games ?? []).map((g) => ({
@@ -60,15 +66,17 @@ export default async function DashboardPage() {
           game_type: g.game_type,
         }))}
       />
-    </div>
+    </ContentLayout>
   );
 }
 
-function SummaryCard({ label, value }: { label: string; value: number }) {
+function KpiCard({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-4">
-      <p className="text-xs text-gray-500">{label}</p>
-      <p className="mt-1 text-2xl font-bold text-gray-900">{value}</p>
-    </div>
+    <Container>
+      <Box variant="awsui-key-label">{label}</Box>
+      <Box variant="h1" tagOverride="p">
+        {value}
+      </Box>
+    </Container>
   );
 }

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { CloudscapeProvider } from "@/components/CloudscapeProvider";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -13,7 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ja">
-      <body className="min-h-screen bg-gray-50 text-gray-900">{children}</body>
+      <body className="min-h-screen">
+        <CloudscapeProvider>{children}</CloudscapeProvider>
+      </body>
     </html>
   );
 }

--- a/packages/web/src/components/CloudscapeProvider.tsx
+++ b/packages/web/src/components/CloudscapeProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import "@cloudscape-design/global-styles/index.css";
+import type { ReactNode } from "react";
+
+export function CloudscapeProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/packages/web/src/components/DashboardView.tsx
+++ b/packages/web/src/components/DashboardView.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import type { GameStatus } from "@match-engine/core";
-import { useState } from "react";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import Tabs from "@cloudscape-design/components/tabs";
 import { Calendar } from "./Calendar";
 import type { CalendarGame } from "./Calendar";
-import { GameStatusBadge } from "./StatusBadge";
 
 interface GameRow {
   id: string;
@@ -22,90 +24,94 @@ interface DashboardViewProps {
   calendarGames: CalendarGame[];
 }
 
+const GAME_TYPE_LABELS: Record<string, string> = {
+  PRACTICE: "練習",
+  FRIENDLY: "練習試合",
+  LEAGUE: "リーグ戦",
+  TOURNAMENT: "トーナメント",
+};
+
+const STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  COLLECTING: "info",
+  CONFIRMED: "success",
+  COMPLETED: "success",
+  SETTLED: "stopped",
+  CANCELLED: "error",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: "下書き",
+  COLLECTING: "出欠収集中",
+  CONFIRMED: "確定",
+  COMPLETED: "完了",
+  SETTLED: "精算済み",
+  CANCELLED: "中止",
+};
+
 export function DashboardView({ games, calendarGames }: DashboardViewProps) {
-  const [view, setView] = useState<"table" | "calendar">("calendar");
-
   return (
-    <section>
-      <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-lg font-semibold">試合一覧</h2>
-        <div className="flex rounded-lg border border-gray-200 p-0.5 text-xs">
-          <button
-            type="button"
-            onClick={() => setView("calendar")}
-            className={`rounded-md px-3 py-1.5 font-medium transition-colors ${
-              view === "calendar"
-                ? "bg-gray-900 text-white"
-                : "text-gray-500 hover:text-gray-700"
-            }`}
-          >
-            カレンダー
-          </button>
-          <button
-            type="button"
-            onClick={() => setView("table")}
-            className={`rounded-md px-3 py-1.5 font-medium transition-colors ${
-              view === "table"
-                ? "bg-gray-900 text-white"
-                : "text-gray-500 hover:text-gray-700"
-            }`}
-          >
-            一覧
-          </button>
-        </div>
-      </div>
-
-      {view === "calendar" ? (
-        <Calendar games={calendarGames} />
-      ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-          <table className="w-full text-left text-sm">
-            <thead className="border-b bg-gray-50 text-xs uppercase text-gray-500">
-              <tr>
-                <th className="px-4 py-3">タイトル</th>
-                <th className="px-4 py-3">種別</th>
-                <th className="px-4 py-3">ステータス</th>
-                <th className="px-4 py-3">試合日</th>
-                <th className="px-4 py-3">出欠</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {games.map((g) => (
-                <tr key={g.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-medium">
-                    <a
-                      href={`/games/${g.id}`}
-                      className="text-blue-600 hover:underline"
-                    >
-                      {g.title}
-                    </a>
-                  </td>
-                  <td className="px-4 py-3 text-gray-500">{g.game_type}</td>
-                  <td className="px-4 py-3">
-                    <GameStatusBadge status={g.status as GameStatus} />
-                  </td>
-                  <td className="px-4 py-3">{g.game_date ?? "未定"}</td>
-                  <td className="px-4 py-3">
-                    <span className="text-green-600">{g.available_count}</span>/
-                    <span className="text-red-600">{g.unavailable_count}</span>/
-                    <span className="text-gray-400">{g.no_response_count}</span>
-                  </td>
-                </tr>
-              ))}
-              {games.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={5}
-                    className="px-4 py-8 text-center text-gray-400"
-                  >
-                    試合がありません
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </section>
+    <Tabs
+      tabs={[
+        {
+          id: "calendar",
+          label: "カレンダー",
+          content: <Calendar games={calendarGames} />,
+        },
+        {
+          id: "table",
+          label: "一覧",
+          content: (
+            <Table
+              header={<Header counter={`(${games.length})`}>試合一覧</Header>}
+              columnDefinitions={[
+                {
+                  id: "title",
+                  header: "タイトル",
+                  cell: (item) => (
+                    <Link href={`/games/${item.id}`}>{item.title}</Link>
+                  ),
+                  sortingField: "title",
+                },
+                {
+                  id: "game_type",
+                  header: "種別",
+                  cell: (item) =>
+                    GAME_TYPE_LABELS[item.game_type] ?? item.game_type,
+                },
+                {
+                  id: "status",
+                  header: "ステータス",
+                  cell: (item) => (
+                    <StatusIndicator type={STATUS_TYPE[item.status] ?? "info"}>
+                      {STATUS_LABELS[item.status] ?? item.status}
+                    </StatusIndicator>
+                  ),
+                },
+                {
+                  id: "game_date",
+                  header: "試合日",
+                  cell: (item) => item.game_date ?? "未定",
+                  sortingField: "game_date",
+                },
+                {
+                  id: "rsvp",
+                  header: "出欠",
+                  cell: (item) =>
+                    `参加${item.available_count} / 不参加${item.unavailable_count} / 未${item.no_response_count}`,
+                },
+              ]}
+              items={games}
+              empty="試合がありません"
+              variant="full-page"
+              stickyHeader
+            />
+          ),
+        },
+      ]}
+    />
   );
 }

--- a/packages/web/src/components/StatusBadge.tsx
+++ b/packages/web/src/components/StatusBadge.tsx
@@ -1,12 +1,16 @@
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import type { GameStatus, NegotiationStatus } from "@match-engine/core";
 
-const GAME_STATUS_COLORS: Record<GameStatus, string> = {
-  DRAFT: "bg-gray-100 text-gray-700",
-  COLLECTING: "bg-blue-100 text-blue-700",
-  CONFIRMED: "bg-green-200 text-green-800",
-  COMPLETED: "bg-emerald-100 text-emerald-700",
-  SETTLED: "bg-teal-100 text-teal-700",
-  CANCELLED: "bg-red-100 text-red-700",
+const GAME_STATUS_TYPE: Record<
+  GameStatus,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  COLLECTING: "info",
+  CONFIRMED: "success",
+  COMPLETED: "success",
+  SETTLED: "stopped",
+  CANCELLED: "error",
 };
 
 const GAME_STATUS_LABELS: Record<GameStatus, string> = {
@@ -18,13 +22,16 @@ const GAME_STATUS_LABELS: Record<GameStatus, string> = {
   CANCELLED: "中止",
 };
 
-const NEGOTIATION_STATUS_COLORS: Record<NegotiationStatus, string> = {
-  DRAFT: "bg-gray-100 text-gray-700",
-  SENT: "bg-blue-100 text-blue-700",
-  REPLIED: "bg-yellow-100 text-yellow-700",
-  ACCEPTED: "bg-green-100 text-green-700",
-  DECLINED: "bg-red-100 text-red-700",
-  CANCELLED: "bg-gray-200 text-gray-600",
+const NEGOTIATION_STATUS_TYPE: Record<
+  NegotiationStatus,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  SENT: "info",
+  REPLIED: "warning",
+  ACCEPTED: "success",
+  DECLINED: "error",
+  CANCELLED: "stopped",
 };
 
 const NEGOTIATION_STATUS_LABELS: Record<NegotiationStatus, string> = {
@@ -38,11 +45,9 @@ const NEGOTIATION_STATUS_LABELS: Record<NegotiationStatus, string> = {
 
 export function GameStatusBadge({ status }: { status: GameStatus }) {
   return (
-    <span
-      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${GAME_STATUS_COLORS[status] ?? ""}`}
-    >
+    <StatusIndicator type={GAME_STATUS_TYPE[status] ?? "info"}>
       {GAME_STATUS_LABELS[status] ?? status}
-    </span>
+    </StatusIndicator>
   );
 }
 
@@ -52,10 +57,8 @@ export function NegotiationStatusBadge({
   status: NegotiationStatus;
 }) {
   return (
-    <span
-      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${NEGOTIATION_STATUS_COLORS[status] ?? ""}`}
-    >
+    <StatusIndicator type={NEGOTIATION_STATUS_TYPE[status] ?? "info"}>
       {NEGOTIATION_STATUS_LABELS[status] ?? status}
-    </span>
+    </StatusIndicator>
   );
 }

--- a/packages/web/src/components/TransitionButtons.tsx
+++ b/packages/web/src/components/TransitionButtons.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -11,13 +15,10 @@ const TRANSITION_LABELS: Record<string, string> = {
   CANCELLED: "中止",
 };
 
-const TRANSITION_STYLES: Record<string, string> = {
-  CONFIRMED: "bg-green-600 text-white hover:bg-green-700",
-  CANCELLED: "bg-red-100 text-red-700 hover:bg-red-200",
-  COMPLETED: "bg-emerald-600 text-white hover:bg-emerald-700",
+const TRANSITION_VARIANT: Record<string, "primary" | "normal" | "link"> = {
+  CONFIRMED: "primary",
+  COMPLETED: "primary",
 };
-
-const DEFAULT_STYLE = "bg-blue-600 text-white hover:bg-blue-700";
 
 interface TransitionButtonsProps {
   gameId: string;
@@ -61,28 +62,40 @@ export function TransitionButtons({
 
   if (transitions.length === 0) {
     return (
-      <p className="text-sm text-gray-500">この状態からの遷移はありません</p>
+      <Box color="text-status-inactive">この状態からの遷移はありません</Box>
     );
   }
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap gap-2">
+    <SpaceBetween size="s">
+      {error && (
+        <Flashbar
+          items={[
+            {
+              type: "error",
+              content: error,
+              dismissible: true,
+              onDismiss: () => setError(null),
+              id: "transition-error",
+            },
+          ]}
+        />
+      )}
+      <SpaceBetween direction="horizontal" size="xs">
         {transitions.map((t) => (
-          <button
+          <Button
             key={t}
-            type="button"
-            disabled={pending !== null}
+            variant={
+              t === "CANCELLED" ? "normal" : (TRANSITION_VARIANT[t] ?? "normal")
+            }
+            loading={pending === t}
+            disabled={pending !== null && pending !== t}
             onClick={() => handleTransition(t)}
-            className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
-              TRANSITION_STYLES[t] ?? DEFAULT_STYLE
-            }`}
           >
-            {pending === t ? "処理中..." : (TRANSITION_LABELS[t] ?? `→ ${t}`)}
-          </button>
+            {TRANSITION_LABELS[t] ?? `→ ${t}`}
+          </Button>
         ))}
-      </div>
-      {error && <p className="text-sm text-red-600">{error}</p>}
-    </div>
+      </SpaceBetween>
+    </SpaceBetween>
   );
 }


### PR DESCRIPTION
## Summary
- Cloudscape Design System (`@cloudscape-design/components`, `global-styles`, `collection-hooks`) を導入
- 管理画面の全UIを Cloudscape コンポーネントで統一:
  - `AppLayout` + `TopNavigation` + `SideNavigation` でプロフェッショナルなレイアウト
  - ダッシュボード: `Container` KPI + `Table` + `Tabs`
  - 試合詳細: `KeyValuePairs` + `StatusIndicator` + `Table`
  - 試合作成: `Form` + `FormField` + `DateInput` + `TimeInput` + `Select`
  - 遷移ボタン: `Button` + `Flashbar`
  - ステータス表示: `StatusIndicator`

## Test plan
- [x] `make check` (lint + typecheck + test) 全パス確認済み
- [ ] 各ページの表示確認（ダッシュボード、試合詳細、試合作成）
- [ ] サイドナビゲーションの動作確認
- [ ] レスポンシブ表示の確認

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n