### PR TITLE
ci: mainマージ時にSupabase Cloudへ自動マイグレーション

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ NEXT_PUBLIC_DEFAULT_TEAM_ID=your-team-id
 # LINE LIFF (ミニアプリ)
 NEXT_PUBLIC_LIFF_ID=your-liff-id
 LINE_CHANNEL_ID=your-line-channel-id
+
+# Supabase Cloud (GitHub Actions マイグレーション用)
+# GitHub Secrets に設定:
+#   SUPABASE_ACCESS_TOKEN  — https://supabase.com/dashboard/account/tokens で発行
+#   SUPABASE_PROJECT_REF   — Supabase プロジェクト設定の Reference ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ on:
     paths-ignore:
       - "**/*.md"
       - "docs/**"
-      - "supabase/**"
   workflow_dispatch:
 
 # Supply chain security: Minimal permissions
@@ -107,3 +106,25 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+  migrate:
+    name: Database Migration
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [build]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: supabase/setup-cli@53fcbb272661e3f8efb38c5e4cd3b5e8e46f3755 # v2.2.1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Run migrations
+        run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- mainにマージした時にSupabase Cloudへ自動でマイグレーションを実行するGitHub Actionsジョブを追加
- `supabase/**` をCI paths-ignoreから削除（マイグレーション変更もCIを通す）

### 仕組み
1. mainプッシュ時、build成功後に `migrate` ジョブが実行される
2. `supabase link` でプロジェクトに接続
3. `supabase db push` で未適用マイグレーションを実行

### 必要なGitHub Secrets設定
| Secret | 取得方法 |
|---|---|
| `SUPABASE_ACCESS_TOKEN` | https://supabase.com/dashboard/account/tokens で発行 |
| `SUPABASE_PROJECT_REF` | Supabaseプロジェクト設定 → General → Reference ID |

## Test plan
- [ ] GitHub Secretsを設定後、mainマージでマイグレーションが自動実行される
- [ ] マイグレーションファイルがない場合はスキップされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)