### PR TITLE
feat: LINE認証統一 + role ベース認可 (SUPER_ADMIN / ADMIN / MEMBER)

### DIFF
--- a/packages/core/src/__tests__/auth.test.ts
+++ b/packages/core/src/__tests__/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { InsufficientRoleError, assertRole, hasRole } from "../lib/auth";
+
+describe("hasRole", () => {
+  describe("SUPER_ADMINのとき", () => {
+    it("全てのロールチェックを通過する", () => {
+      expect(hasRole("SUPER_ADMIN", "MEMBER")).toBe(true);
+      expect(hasRole("SUPER_ADMIN", "ADMIN")).toBe(true);
+      expect(hasRole("SUPER_ADMIN", "SUPER_ADMIN")).toBe(true);
+    });
+  });
+
+  describe("ADMINのとき", () => {
+    it("MEMBER・ADMINチェックを通過する", () => {
+      expect(hasRole("ADMIN", "MEMBER")).toBe(true);
+      expect(hasRole("ADMIN", "ADMIN")).toBe(true);
+    });
+
+    it("SUPER_ADMINチェックは失敗する", () => {
+      expect(hasRole("ADMIN", "SUPER_ADMIN")).toBe(false);
+    });
+  });
+
+  describe("MEMBERのとき", () => {
+    it("MEMBERチェックのみ通過する", () => {
+      expect(hasRole("MEMBER", "MEMBER")).toBe(true);
+    });
+
+    it("ADMIN以上のチェックは失敗する", () => {
+      expect(hasRole("MEMBER", "ADMIN")).toBe(false);
+      expect(hasRole("MEMBER", "SUPER_ADMIN")).toBe(false);
+    });
+  });
+});
+
+describe("assertRole", () => {
+  it("権限が足りているとき例外を投げない", () => {
+    expect(() => assertRole("ADMIN", "ADMIN")).not.toThrow();
+    expect(() => assertRole("SUPER_ADMIN", "ADMIN")).not.toThrow();
+  });
+
+  it("権限が不足しているとき InsufficientRoleError を投げる", () => {
+    expect(() => assertRole("MEMBER", "ADMIN")).toThrow(InsufficientRoleError);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export type {
   NegotiationStatus,
   HelperRequestStatus,
   MemberTier,
+  MemberRole,
   Team,
   TeamSettings,
   Member,
@@ -31,6 +32,7 @@ export {
   NEGOTIATION_STATUSES,
   HELPER_REQUEST_STATUSES,
   MEMBER_TIERS,
+  MEMBER_ROLES,
 } from "./types/domain";
 
 // State Machine
@@ -92,6 +94,9 @@ export {
   suggestOnTransitionError,
 } from "./lib/next-actions";
 export type { GameContext } from "./lib/next-actions";
+
+// Auth
+export { hasRole, assertRole, InsufficientRoleError } from "./lib/auth";
 
 // Validators
 export {

--- a/packages/core/src/lib/auth.ts
+++ b/packages/core/src/lib/auth.ts
@@ -1,0 +1,31 @@
+// ============================================================
+// 認可ヘルパー — Role ベースアクセス制御 (RBAC)
+// ============================================================
+import type { MemberRole } from "../types/domain";
+
+/** Role の権限レベル (大きいほど強い) */
+const ROLE_LEVEL: Record<MemberRole, number> = {
+  MEMBER: 0,
+  ADMIN: 1,
+  SUPER_ADMIN: 2,
+};
+
+/** 指定された role が required 以上の権限を持つか判定 */
+export function hasRole(role: MemberRole, required: MemberRole): boolean {
+  return ROLE_LEVEL[role] >= ROLE_LEVEL[required];
+}
+
+/** 権限不足エラー */
+export class InsufficientRoleError extends Error {
+  constructor(required: MemberRole) {
+    super(`この操作には ${required} 以上の権限が必要です`);
+    this.name = "InsufficientRoleError";
+  }
+}
+
+/** 権限チェック (不足時は例外) */
+export function assertRole(role: MemberRole, required: MemberRole): void {
+  if (!hasRole(role, required)) {
+    throw new InsufficientRoleError(required);
+  }
+}

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -56,6 +56,10 @@ export type HelperRequestStatus = (typeof HELPER_REQUEST_STATUSES)[number];
 export const MEMBER_TIERS = ["PRO", "LITE"] as const;
 export type MemberTier = (typeof MEMBER_TIERS)[number];
 
+// --- メンバー Role ---
+export const MEMBER_ROLES = ["SUPER_ADMIN", "ADMIN", "MEMBER"] as const;
+export type MemberRole = (typeof MEMBER_ROLES)[number];
+
 // ============================================================
 // エンティティ
 // ============================================================
@@ -89,6 +93,7 @@ export interface Member {
   jersey_number: number | null;
   attendance_rate: number;
   no_show_rate: number;
+  role: MemberRole;
   status: "ACTIVE" | "INACTIVE" | "PENDING";
   joined_at: string | null;
   created_at: string;

--- a/packages/web/src/app/api/games/[id]/expenses/route.ts
+++ b/packages/web/src/app/api/games/[id]/expenses/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -13,6 +14,11 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/games/[id]/helper-requests/route.ts
+++ b/packages/web/src/app/api/games/[id]/helper-requests/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -13,6 +14,11 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/games/[id]/negotiations/route.ts
+++ b/packages/web/src/app/api/games/[id]/negotiations/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -13,6 +14,11 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/games/[id]/route.ts
+++ b/packages/web/src/app/api/games/[id]/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -57,11 +58,16 @@ export async function GET(
   );
 }
 
-/** PATCH /api/games/:id */
+/** PATCH /api/games/:id (ADMIN以上) */
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/games/[id]/settlement/route.ts
+++ b/packages/web/src/app/api/games/[id]/settlement/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
 import { type NextRequest, NextResponse } from "next/server";
@@ -7,6 +8,11 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
 

--- a/packages/web/src/app/api/games/[id]/transition/route.ts
+++ b/packages/web/src/app/api/games/[id]/transition/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -13,11 +14,16 @@ import {
 import type { GameStatus } from "@match-engine/core";
 import { type NextRequest, NextResponse } from "next/server";
 
-/** POST /api/games/:id/transition — 状態遷移 */
+/** POST /api/games/:id/transition — 状態遷移 (ADMIN以上) */
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/games/route.ts
+++ b/packages/web/src/app/api/games/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -9,8 +10,13 @@ import {
 } from "@match-engine/core";
 import { type NextRequest, NextResponse } from "next/server";
 
-/** POST /api/games — 試合作成 */
+/** POST /api/games — 試合作成 (ADMIN以上) */
 export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const supabase = await createClient();
   const body = await request.json();
 

--- a/packages/web/src/app/api/helper-requests/[id]/route.ts
+++ b/packages/web/src/app/api/helper-requests/[id]/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -15,6 +16,11 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/helpers/route.ts
+++ b/packages/web/src/app/api/helpers/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -10,6 +11,11 @@ import { type NextRequest, NextResponse } from "next/server";
 
 /** POST /api/helpers — 助っ人登録 */
 export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const supabase = await createClient();
   const body = await request.json();
 

--- a/packages/web/src/app/api/negotiations/[id]/route.ts
+++ b/packages/web/src/app/api/negotiations/[id]/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -15,6 +16,11 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/rsvps/[id]/route.ts
+++ b/packages/web/src/app/api/rsvps/[id]/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -13,6 +14,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+
   const { id } = await params;
   const supabase = await createClient();
   const body = await request.json();

--- a/packages/web/src/app/api/teams/route.ts
+++ b/packages/web/src/app/api/teams/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import {
   apiError,
@@ -10,6 +11,11 @@ import { type NextRequest, NextResponse } from "next/server";
 
 /** POST /api/teams — チーム作成 */
 export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const supabase = await createClient();
   const body = await request.json();
 

--- a/packages/web/src/app/auth/callback/route.ts
+++ b/packages/web/src/app/auth/callback/route.ts
@@ -1,0 +1,15 @@
+import { createClient } from "@/lib/supabase/server";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const redirect = searchParams.get("redirect") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    await supabase.auth.exchangeCodeForSession(code);
+  }
+
+  return NextResponse.redirect(new URL(redirect, origin));
+}

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+function LoginContent() {
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get("redirect") ?? "/";
+
+  const handleLogin = async () => {
+    const supabase = createClient();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
+      },
+    });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-lg border bg-white p-8 shadow-sm">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-gray-900">試合成立エンジン</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            ログインして試合を管理しましょう
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleLogin}
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#06C755] px-4 py-3 text-sm font-medium text-white hover:bg-[#05b04d] transition-colors"
+        >
+          LINEでログイン
+        </button>
+        <p className="text-center text-xs text-gray-400">
+          LINE アカウントで認証します
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
+  );
+}

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,0 +1,81 @@
+// ============================================================
+// API ルート用 認証・認可ヘルパー
+// ============================================================
+import { createClient } from "@/lib/supabase/server";
+import { apiError } from "@match-engine/core";
+import type { MemberRole } from "@match-engine/core";
+import { hasRole } from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+export interface AuthenticatedMember {
+  id: string;
+  team_id: string;
+  name: string;
+  role: MemberRole;
+  line_user_id: string | null;
+}
+
+/** Supabase Auth セッションからログイン中ユーザーの member を取得 */
+export async function getAuthMember(): Promise<AuthenticatedMember | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  // LINE OAuth の場合、provider_id (= LINE user ID) で members を検索
+  const lineUserId =
+    user.user_metadata?.provider_id ?? user.user_metadata?.sub ?? null;
+
+  if (!lineUserId) return null;
+
+  const { data: member } = await supabase
+    .from("members")
+    .select("id, team_id, name, role, line_user_id")
+    .eq("line_user_id", lineUserId)
+    .eq("status", "ACTIVE")
+    .single();
+
+  if (!member) return null;
+
+  return member as AuthenticatedMember;
+}
+
+/** 認証必須 — 未認証なら 401 レスポンスを返す */
+export async function requireAuth(): Promise<
+  AuthenticatedMember | NextResponse
+> {
+  const member = await getAuthMember();
+  if (!member) {
+    return NextResponse.json(
+      apiError("UNAUTHORIZED", "ログインが必要です", [
+        {
+          action: "login",
+          reason: "LINE Loginでログインしてください",
+          priority: "high",
+        },
+      ]),
+      { status: 401 },
+    );
+  }
+  return member;
+}
+
+/** 認可チェック — 権限不足なら 403 レスポンスを返す */
+export function requireRole(
+  member: AuthenticatedMember,
+  required: MemberRole,
+): NextResponse | null {
+  if (!hasRole(member.role, required)) {
+    return NextResponse.json(
+      apiError(
+        "FORBIDDEN",
+        `この操作には ${required} 以上の権限が必要です`,
+        [],
+      ),
+      { status: 403 },
+    );
+  }
+  return null;
+}

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,0 +1,53 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+// 認証不要のパス
+const PUBLIC_PATHS = ["/login", "/auth/callback", "/api/liff", "/liff"];
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 公開パスはスキップ
+  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+    return NextResponse.next();
+  }
+
+  // API ルートは各ルート内で認証チェックするため、ミドルウェアではセッション更新のみ
+  const response = NextResponse.next();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value, options } of cookiesToSet) {
+            response.cookies.set(name, value, options);
+          }
+        },
+      },
+    },
+  );
+
+  // セッション更新
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 管理画面(/)へのアクセスで未ログインの場合、ログインページへリダイレクト
+  if (!user && !pathname.startsWith("/api")) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/supabase/migrations/00005_add_member_role.sql
+++ b/supabase/migrations/00005_add_member_role.sql
@@ -1,0 +1,10 @@
+-- ============================================================
+-- members テーブルに role カラム追加 (RBAC)
+-- ============================================================
+
+ALTER TABLE members
+  ADD COLUMN role TEXT NOT NULL DEFAULT 'MEMBER'
+  CHECK (role IN ('SUPER_ADMIN', 'ADMIN', 'MEMBER'));
+
+-- 既存メンバーのインデックス
+CREATE INDEX idx_members_role ON members(team_id, role);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -8,16 +8,16 @@ INSERT INTO teams (id, name, home_area, activity_day) VALUES
   ('11111111-1111-4111-8111-111111111111', 'サンダーボルツ', '東京都・世田谷区', '日曜日');
 
 -- メンバー
-INSERT INTO members (id, team_id, name, tier, positions_json, attendance_rate, status) VALUES
-  ('aaaaaaaa-0001-4001-8001-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '田中太郎',   'PRO',  '["ピッチャー"]',  85.00, 'ACTIVE'),
-  ('aaaaaaaa-0002-4002-8002-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '鈴木一郎',   'PRO',  '["キャッチャー"]',90.00, 'ACTIVE'),
-  ('aaaaaaaa-0003-4003-8003-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '佐藤次郎',   'LITE', '["ショート"]',    75.00, 'ACTIVE'),
-  ('aaaaaaaa-0004-4004-8004-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '山田三郎',   'PRO',  '["外野手"]',      60.00, 'ACTIVE'),
-  ('aaaaaaaa-0005-4005-8005-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '高橋四郎',   'PRO',  '["一塁手"]',      80.00, 'ACTIVE'),
-  ('aaaaaaaa-0006-4006-8006-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '中村五郎',   'PRO',  '["二塁手"]',      88.00, 'ACTIVE'),
-  ('aaaaaaaa-0007-4007-8007-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '小林六郎',   'LITE', '["三塁手"]',      70.00, 'ACTIVE'),
-  ('aaaaaaaa-0008-4008-8008-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '加藤七郎',   'PRO',  '["外野手"]',      82.00, 'ACTIVE'),
-  ('aaaaaaaa-0009-4009-8009-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '吉田八郎',   'PRO',  '["外野手"]',      65.00, 'ACTIVE');
+INSERT INTO members (id, team_id, name, tier, role, positions_json, attendance_rate, status) VALUES
+  ('aaaaaaaa-0001-4001-8001-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '田中太郎',   'PRO',  'SUPER_ADMIN', '["ピッチャー"]',  85.00, 'ACTIVE'),
+  ('aaaaaaaa-0002-4002-8002-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '鈴木一郎',   'PRO',  'ADMIN',  '["キャッチャー"]',90.00, 'ACTIVE'),
+  ('aaaaaaaa-0003-4003-8003-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '佐藤次郎',   'LITE', 'MEMBER', '["ショート"]',    75.00, 'ACTIVE'),
+  ('aaaaaaaa-0004-4004-8004-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '山田三郎',   'PRO',  'MEMBER', '["外野手"]',      60.00, 'ACTIVE'),
+  ('aaaaaaaa-0005-4005-8005-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '高橋四郎',   'PRO',  'MEMBER', '["一塁手"]',      80.00, 'ACTIVE'),
+  ('aaaaaaaa-0006-4006-8006-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '中村五郎',   'PRO',  'MEMBER', '["二塁手"]',      88.00, 'ACTIVE'),
+  ('aaaaaaaa-0007-4007-8007-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '小林六郎',   'LITE', 'MEMBER', '["三塁手"]',      70.00, 'ACTIVE'),
+  ('aaaaaaaa-0008-4008-8008-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '加藤七郎',   'PRO',  'MEMBER', '["外野手"]',      82.00, 'ACTIVE'),
+  ('aaaaaaaa-0009-4009-8009-aaaaaaaaaaaa', '11111111-1111-4111-8111-111111111111', '吉田八郎',   'PRO',  'MEMBER', '["外野手"]',      65.00, 'ACTIVE');
 
 -- 助っ人
 INSERT INTO helpers (id, team_id, name, note, times_helped) VALUES


### PR DESCRIPTION
closes #35

## Summary
- DB: `members.role` カラム追加 (`SUPER_ADMIN` / `ADMIN` / `MEMBER`)
- Core: `MemberRole` 型 + `hasRole`/`assertRole` 認可ヘルパー + テスト7件
- Web: Supabase Auth ミドルウェア (セッション更新 + 未認証→`/login`リダイレクト)
- Web: `requireAuth` / `requireRole` API ヘルパー (401/403レスポンス)
- Web: ログインページ (`/login`) + OAuthコールバック (`/auth/callback`)
- API: 全書込ルートに認可チェック適用 (ADMIN: 試合作成・遷移等, MEMBER: 出欠回答)

## Test plan
- [x] `make check` (lint + typecheck + 107テスト) 全パス
- [ ] LINE Login OAuth フロー動作確認
- [ ] ADMIN権限なしで試合作成→403確認
- [ ] MEMBER権限で出欠回答→成功確認

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n