### PR TITLE
feat: Cloudscape 管理画面ページ追加 + Cron ジョブ基盤

### DIFF
--- a/packages/web/src/app/(manager)/games/[id]/expenses/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/expenses/page.tsx
@@ -1,0 +1,182 @@
+import Box from "@cloudscape-design/components/box";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+
+import { createClient } from "@/lib/supabase/server";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  GROUND: "グラウンド",
+  UMPIRE: "審判",
+  BALL: "ボール代",
+  DRINK: "飲料",
+  TOURNAMENT_FEE: "大会費",
+  OTHER: "その他",
+};
+
+const SETTLEMENT_STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  NOTIFIED: "info",
+  SETTLED: "success",
+};
+
+const SETTLEMENT_STATUS_LABELS: Record<string, string> = {
+  DRAFT: "下書き",
+  NOTIFIED: "通知済み",
+  SETTLED: "精算済み",
+};
+
+export default async function ExpensesPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: game } = await supabase
+    .from("games")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!game) {
+    return (
+      <ContentLayout header={<Header variant="h1">経費・精算</Header>}>
+        <Box textAlign="center" color="text-status-inactive" padding="xxl">
+          試合が見つかりません
+        </Box>
+      </ContentLayout>
+    );
+  }
+
+  const { data: expenses } = await supabase
+    .from("expenses")
+    .select("*, members:paid_by(name)")
+    .eq("game_id", id);
+
+  const { data: settlement } = await supabase
+    .from("settlements")
+    .select("*")
+    .eq("game_id", id)
+    .single();
+
+  return (
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          description={<Link href={`/games/${id}`}>← 試合詳細に戻る</Link>}
+        >
+          {game.title} — 経費・精算
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {expenses && expenses.length > 0 ? (
+          <Table
+            header={
+              <Header variant="h2" counter={`(${expenses.length})`}>
+                経費一覧
+              </Header>
+            }
+            columnDefinitions={[
+              {
+                id: "category",
+                header: "カテゴリ",
+                cell: (item) => CATEGORY_LABELS[item.category] ?? item.category,
+              },
+              {
+                id: "amount",
+                header: "金額",
+                cell: (item) => `¥${Number(item.amount).toLocaleString()}`,
+              },
+              {
+                id: "paid_by",
+                header: "支払者",
+                cell: (item) => {
+                  const member = item.members as { name: string } | null;
+                  return member?.name ?? "—";
+                },
+              },
+              {
+                id: "split_with_opponent",
+                header: "対戦相手と折半",
+                cell: (item) => (item.split_with_opponent ? "はい" : "いいえ"),
+              },
+              {
+                id: "note",
+                header: "備考",
+                cell: (item) => item.note ?? "—",
+              },
+            ]}
+            items={expenses}
+            variant="embedded"
+          />
+        ) : (
+          <Container header={<Header variant="h2">経費一覧</Header>}>
+            <Box textAlign="center" color="text-status-inactive" padding="l">
+              経費が登録されていません
+            </Box>
+          </Container>
+        )}
+
+        {settlement ? (
+          <Container header={<Header variant="h2">精算サマリ</Header>}>
+            <KeyValuePairs
+              items={[
+                {
+                  label: "合計費用",
+                  value: `¥${Number(settlement.total_cost).toLocaleString()}`,
+                },
+                {
+                  label: "対戦相手負担",
+                  value: `¥${Number(settlement.opponent_share).toLocaleString()}`,
+                },
+                {
+                  label: "チーム負担",
+                  value: `¥${Number(settlement.team_cost).toLocaleString()}`,
+                },
+                {
+                  label: "一人あたり",
+                  value: `¥${Number(settlement.per_member).toLocaleString()}`,
+                },
+                {
+                  label: "参加人数",
+                  value: `${settlement.member_count}人`,
+                },
+                {
+                  label: "ステータス",
+                  value: (
+                    <StatusIndicator
+                      type={
+                        SETTLEMENT_STATUS_TYPE[settlement.status] ?? "pending"
+                      }
+                    >
+                      {SETTLEMENT_STATUS_LABELS[settlement.status] ??
+                        settlement.status}
+                    </StatusIndicator>
+                  ),
+                },
+              ]}
+            />
+          </Container>
+        ) : (
+          <Container header={<Header variant="h2">精算サマリ</Header>}>
+            <Box textAlign="center" color="text-status-inactive" padding="l">
+              精算データがありません
+            </Box>
+          </Container>
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -6,6 +6,7 @@ import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table from "@cloudscape-design/components/table";
@@ -140,11 +141,16 @@ export default async function GameDetailPage({
         </Container>
 
         <Container header={<Header variant="h2">アクション</Header>}>
-          <TransitionButtons
-            gameId={game.id}
-            currentStatus={game.status}
-            transitions={transitions}
-          />
+          <SpaceBetween size="s">
+            <TransitionButtons
+              gameId={game.id}
+              currentStatus={game.status}
+              transitions={transitions}
+            />
+            {(game.status === "COMPLETED" || game.status === "SETTLED") && (
+              <Link href={`/games/${game.id}/expenses`}>支出・精算を管理</Link>
+            )}
+          </SpaceBetween>
         </Container>
 
         {rsvps && rsvps.length > 0 && (

--- a/packages/web/src/app/(manager)/layout.tsx
+++ b/packages/web/src/app/(manager)/layout.tsx
@@ -6,6 +6,8 @@ import TopNavigation from "@cloudscape-design/components/top-navigation";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 
+const DEFAULT_TEAM_ID = process.env.NEXT_PUBLIC_DEFAULT_TEAM_ID ?? "";
+
 export default function ManagerLayout({
   children,
 }: {
@@ -48,10 +50,23 @@ export default function ManagerLayout({
               { type: "divider" },
               {
                 type: "section",
-                text: "管理",
+                text: "チーム管理",
                 items: [
-                  { type: "link", text: "チーム", href: "/teams" },
-                  { type: "link", text: "助っ人", href: "/helpers" },
+                  {
+                    type: "link",
+                    text: "メンバー",
+                    href: `/teams/${DEFAULT_TEAM_ID}`,
+                  },
+                  {
+                    type: "link",
+                    text: "助っ人",
+                    href: `/teams/${DEFAULT_TEAM_ID}/helpers`,
+                  },
+                  {
+                    type: "link",
+                    text: "対戦相手",
+                    href: `/teams/${DEFAULT_TEAM_ID}/opponents`,
+                  },
                 ],
               },
             ]}

--- a/packages/web/src/app/(manager)/teams/[id]/helpers/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/helpers/page.tsx
@@ -1,0 +1,91 @@
+import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import Cards from "@cloudscape-design/components/cards";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+
+export default async function HelpersPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: team } = await supabase
+    .from("teams")
+    .select("name")
+    .eq("id", id)
+    .single();
+
+  const { data: helpers } = await supabase
+    .from("helpers")
+    .select("*")
+    .eq("team_id", id)
+    .order("reliability_score", { ascending: false });
+
+  return (
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          description={team?.name ?? ""}
+          actions={<Link href={`/teams/${id}`}>チームに戻る</Link>}
+        >
+          助っ人管理
+        </Header>
+      }
+    >
+      <Cards
+        header={
+          <Header counter={`(${helpers?.length ?? 0})`}>助っ人一覧</Header>
+        }
+        cardDefinition={{
+          header: (item) => item.name,
+          sections: [
+            {
+              id: "reliability",
+              header: "信頼度",
+              content: (item) => {
+                const score = Number(item.reliability_score);
+                const type =
+                  score >= 0.8 ? "success" : score >= 0.5 ? "warning" : "error";
+                return (
+                  <StatusIndicator
+                    type={type as "success" | "warning" | "error"}
+                  >
+                    {(score * 100).toFixed(0)}%
+                  </StatusIndicator>
+                );
+              },
+            },
+            {
+              id: "times_helped",
+              header: "参加回数",
+              content: (item) => `${item.times_helped}回`,
+            },
+            {
+              id: "note",
+              header: "メモ",
+              content: (item) => item.note || "—",
+            },
+            {
+              id: "contact",
+              header: "連絡先",
+              content: (item) =>
+                item.line_user_id ? "LINE" : item.email ? "メール" : "—",
+            },
+          ],
+        }}
+        items={helpers ?? []}
+        empty={
+          <Box textAlign="center" color="text-body-secondary" padding="xxl">
+            助っ人が登録されていません
+          </Box>
+        }
+      />
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/opponents/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/opponents/page.tsx
@@ -1,0 +1,89 @@
+import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import Table from "@cloudscape-design/components/table";
+
+export default async function OpponentsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: team } = await supabase
+    .from("teams")
+    .select("name")
+    .eq("id", id)
+    .single();
+
+  const { data: opponents } = await supabase
+    .from("opponent_teams")
+    .select("*")
+    .eq("team_id", id)
+    .order("times_played", { ascending: false });
+
+  return (
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          description={team?.name ?? ""}
+          actions={<Link href={`/teams/${id}`}>チームに戻る</Link>}
+        >
+          対戦相手
+        </Header>
+      }
+    >
+      <Table
+        header={
+          <Header counter={`(${opponents?.length ?? 0})`}>対戦相手一覧</Header>
+        }
+        columnDefinitions={[
+          {
+            id: "name",
+            header: "チーム名",
+            cell: (item) => item.name,
+            sortingField: "name",
+          },
+          {
+            id: "area",
+            header: "エリア",
+            cell: (item) => item.area ?? "—",
+          },
+          {
+            id: "contact_name",
+            header: "連絡先",
+            cell: (item) => item.contact_name ?? "—",
+          },
+          {
+            id: "times_played",
+            header: "対戦回数",
+            cell: (item) => `${item.times_played}回`,
+            sortingField: "times_played",
+          },
+          {
+            id: "last_played_at",
+            header: "最終対戦",
+            cell: (item) => item.last_played_at ?? "—",
+          },
+          {
+            id: "note",
+            header: "メモ",
+            cell: (item) => item.note ?? "—",
+          },
+        ]}
+        items={opponents ?? []}
+        empty={
+          <Box textAlign="center" color="text-body-secondary" padding="xxl">
+            対戦相手が登録されていません
+          </Box>
+        }
+        variant="full-page"
+        stickyHeader
+      />
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/page.tsx
@@ -1,0 +1,146 @@
+import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import Cards from "@cloudscape-design/components/cards";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+
+const ROLE_LABELS: Record<string, string> = {
+  SUPER_ADMIN: "管理者(代表)",
+  ADMIN: "管理者",
+  MEMBER: "メンバー",
+};
+
+const ROLE_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  SUPER_ADMIN: "success",
+  ADMIN: "info",
+  MEMBER: "pending",
+};
+
+export default async function TeamDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: team } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (!team) {
+    return (
+      <ContentLayout header={<Header variant="h1">チーム詳細</Header>}>
+        <Box textAlign="center" color="text-status-inactive" padding="xxl">
+          チームが見つかりません
+        </Box>
+      </ContentLayout>
+    );
+  }
+
+  const { data: members } = await supabase
+    .from("members")
+    .select("*")
+    .eq("team_id", id)
+    .eq("status", "ACTIVE")
+    .order("role")
+    .order("name");
+
+  return (
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Link href={`/teams/${id}/helpers`} variant="primary">
+                助っ人管理
+              </Link>
+              <Link href={`/teams/${id}/opponents`} variant="primary">
+                対戦相手
+              </Link>
+            </SpaceBetween>
+          }
+        >
+          {team.name}
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Container header={<Header variant="h2">チーム情報</Header>}>
+          <ColumnLayout columns={2} variant="text-grid">
+            <KeyValuePairs
+              items={[
+                { label: "活動エリア", value: team.home_area },
+                { label: "活動日", value: team.activity_day ?? "未設定" },
+              ]}
+            />
+            <KeyValuePairs
+              items={[
+                {
+                  label: "メンバー数",
+                  value: `${members?.length ?? 0}人`,
+                },
+              ]}
+            />
+          </ColumnLayout>
+        </Container>
+
+        <Cards
+          header={
+            <Header counter={`(${members?.length ?? 0})`}>メンバー</Header>
+          }
+          cardDefinition={{
+            header: (item) => item.name,
+            sections: [
+              {
+                id: "role",
+                header: "ロール",
+                content: (item) => (
+                  <StatusIndicator type={ROLE_TYPE[item.role] ?? "pending"}>
+                    {ROLE_LABELS[item.role] ?? item.role}
+                  </StatusIndicator>
+                ),
+              },
+              {
+                id: "positions",
+                header: "ポジション",
+                content: (item) => {
+                  const positions = item.positions_json as string[];
+                  return positions?.join(", ") || "—";
+                },
+              },
+              {
+                id: "attendance",
+                header: "出席率",
+                content: (item) => `${item.attendance_rate}%`,
+              },
+              {
+                id: "tier",
+                header: "区分",
+                content: (item) => item.tier,
+              },
+            ],
+          }}
+          items={members ?? []}
+          empty={
+            <Box textAlign="center" color="text-body-secondary" padding="xxl">
+              メンバーがいません
+            </Box>
+          }
+        />
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/api/cron/check-fulfillment/route.ts
+++ b/packages/web/src/app/api/cron/check-fulfillment/route.ts
@@ -1,0 +1,92 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+/** POST /api/cron/check-fulfillment — 人数充足チェック・助っ人リクエスト自動キャンセル */
+export async function POST(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json(apiError("UNAUTHORIZED", "Invalid CRON_SECRET"), {
+      status: 401,
+    });
+  }
+
+  const supabase = await createClient();
+
+  const body = await request.json();
+  const gameId = body.game_id;
+
+  if (!gameId) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "game_id is required"),
+      { status: 400 },
+    );
+  }
+
+  const { data: game, error: gameError } = await supabase
+    .from("games")
+    .select("id, min_players, version")
+    .eq("id", gameId)
+    .single();
+
+  if (gameError || !game) {
+    return NextResponse.json(apiError("NOT_FOUND", "Game not found"), {
+      status: 404,
+    });
+  }
+
+  const { count: availableCount } = await supabase
+    .from("rsvps")
+    .select("id", { count: "exact", head: true })
+    .eq("game_id", gameId)
+    .eq("response", "AVAILABLE");
+
+  const { count: acceptedHelperCount } = await supabase
+    .from("helper_requests")
+    .select("id", { count: "exact", head: true })
+    .eq("game_id", gameId)
+    .eq("status", "ACCEPTED");
+
+  const totalAvailable = (availableCount ?? 0) + (acceptedHelperCount ?? 0);
+  const fulfilled = totalAvailable >= game.min_players;
+  let cancelledCount = 0;
+
+  if (fulfilled) {
+    const { data: pendingRequests } = await supabase
+      .from("helper_requests")
+      .select("id")
+      .eq("game_id", gameId)
+      .eq("status", "PENDING");
+
+    if (pendingRequests && pendingRequests.length > 0) {
+      const ids = pendingRequests.map((r) => r.id);
+
+      const { error: cancelError } = await supabase
+        .from("helper_requests")
+        .update({ status: "CANCELLED", cancel_reason: "FULFILLED" })
+        .in("id", ids);
+
+      if (!cancelError) {
+        cancelledCount = ids.length;
+      }
+    }
+
+    await writeAuditLog(supabase, {
+      actor_type: "SYSTEM",
+      actor_id: "SYSTEM",
+      action: "CRON:FULFILLMENT_CHECK",
+      target_type: "game",
+      target_id: gameId,
+      after_json: { totalAvailable, cancelledCount, fulfilled },
+    });
+  }
+
+  return NextResponse.json(
+    apiSuccess({
+      fulfilled,
+      totalAvailable,
+      needed: game.min_players,
+      cancelledCount,
+    }),
+  );
+}

--- a/packages/web/src/app/api/cron/process-deadlines/route.ts
+++ b/packages/web/src/app/api/cron/process-deadlines/route.ts
@@ -1,0 +1,54 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+/** POST /api/cron/process-deadlines — 締切到達ゲームを CONFIRMED に遷移 */
+export async function POST(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json(apiError("UNAUTHORIZED", "Invalid CRON_SECRET"), {
+      status: 401,
+    });
+  }
+
+  const supabase = await createClient();
+
+  const { data: games, error } = await supabase
+    .from("games")
+    .select("id, version")
+    .eq("status", "COLLECTING")
+    .lte("rsvp_deadline", new Date().toISOString());
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 500,
+    });
+  }
+
+  let processedCount = 0;
+
+  for (const game of games ?? []) {
+    const { error: updateError } = await supabase
+      .from("games")
+      .update({ status: "CONFIRMED", version: game.version + 1 })
+      .eq("id", game.id);
+
+    if (updateError) {
+      console.error(`ゲーム ${game.id} の更新失敗:`, updateError);
+      continue;
+    }
+
+    await writeAuditLog(supabase, {
+      actor_type: "SYSTEM",
+      actor_id: "SYSTEM",
+      action: "CRON:DEADLINE_PROCESSED",
+      target_type: "game",
+      target_id: game.id,
+      after_json: { previous_version: game.version },
+    });
+
+    processedCount++;
+  }
+
+  return NextResponse.json(apiSuccess({ processedCount }));
+}

--- a/packages/web/src/app/api/cron/send-reminders/route.ts
+++ b/packages/web/src/app/api/cron/send-reminders/route.ts
@@ -1,0 +1,78 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess } from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+const REMINDER_HOURS = [24, 48, 72] as const;
+
+/** POST /api/cron/send-reminders — 締切前リマインダーを通知ログに挿入 */
+export async function POST(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json(apiError("UNAUTHORIZED", "Invalid CRON_SECRET"), {
+      status: 401,
+    });
+  }
+
+  const supabase = await createClient();
+
+  const { data: games, error } = await supabase
+    .from("games")
+    .select("id, team_id, rsvp_deadline")
+    .eq("status", "COLLECTING")
+    .not("rsvp_deadline", "is", null);
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 500,
+    });
+  }
+
+  const now = new Date();
+  let remindersQueued = 0;
+
+  for (const game of games ?? []) {
+    const deadline = new Date(game.rsvp_deadline);
+
+    for (const hours of REMINDER_HOURS) {
+      const reminderTime = new Date(
+        deadline.getTime() - hours * 60 * 60 * 1000,
+      );
+
+      if (now < reminderTime) continue;
+
+      const marker = `${hours}h`;
+
+      const { data: existing } = await supabase
+        .from("notification_logs")
+        .select("id")
+        .eq("game_id", game.id)
+        .eq("notification_type", "REMINDER")
+        .like("content", `%${marker}%`)
+        .limit(1);
+
+      if (existing && existing.length > 0) continue;
+
+      const { error: insertError } = await supabase
+        .from("notification_logs")
+        .insert({
+          team_id: game.team_id,
+          game_id: game.id,
+          recipient_type: "MEMBER",
+          notification_type: "REMINDER",
+          content: `締切${marker}前リマインダー`,
+        });
+
+      if (insertError) {
+        console.error(
+          `リマインダー挿入失敗 (game=${game.id}, ${marker}):`,
+          insertError,
+        );
+        continue;
+      }
+
+      remindersQueued++;
+    }
+  }
+
+  return NextResponse.json(apiSuccess({ remindersQueued }));
+}

--- a/packages/web/src/app/api/teams/[id]/members/route.ts
+++ b/packages/web/src/app/api/teams/[id]/members/route.ts
@@ -1,0 +1,27 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/teams/:id/members — メンバー一覧 */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("members")
+    .select("*")
+    .eq("team_id", id)
+    .order("role", { ascending: true })
+    .order("name", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data ?? [], []));
+}

--- a/packages/web/src/app/api/teams/[id]/opponents/route.ts
+++ b/packages/web/src/app/api/teams/[id]/opponents/route.ts
@@ -1,0 +1,26 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/teams/:id/opponents — 対戦相手一覧 */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("opponent_teams")
+    .select("*")
+    .eq("team_id", id)
+    .order("times_played", { ascending: false });
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data ?? [], []));
+}


### PR DESCRIPTION
closes #43, closes #50, closes #40

## Summary
### 管理画面 (Cloudscape Cards/Table)
- `/teams/[id]` — チーム詳細 + メンバー Cards 表示 (Role バッジ付き)
- `/teams/[id]/helpers` — 助っ人管理 Cards (信頼度・参加回数)
- `/teams/[id]/opponents` — 対戦相手 Table (対戦回数・エリア)
- `/games/[id]/expenses` — 支出一覧 Table + 精算サマリー
- サイドナビにチーム管理セクション追加

### API
- `GET /api/teams/:id/members`
- `GET /api/teams/:id/opponents`

### Cron ジョブ
- `POST /api/cron/process-deadlines` — 締切到来の出欠自動処理
- `POST /api/cron/send-reminders` — リマインド通知キュー
- `POST /api/cron/check-fulfillment` — 助っ人充足判定

## Test plan
- [x] `make check` (lint + typecheck + 107テスト) 全パス
- [ ] 各ページの表示確認
- [ ] Cron エンドポイントの動作確認

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added Expenses & Settlement management interface for completed games
  - Added Team detail pages displaying members, helpers, and opponents
  - Implemented automated reminder notifications for RSVP deadlines
  - Automatic game status confirmation when minimum player count is met

* **Improvements**
  - Updated team-scoped navigation in manager section for better organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->