### PR TITLE
feat: グラウンド空き監視の統合

### DIFF
--- a/packages/web/src/app/(manager)/layout.tsx
+++ b/packages/web/src/app/(manager)/layout.tsx
@@ -69,6 +69,11 @@ export default function ManagerLayout({
                   },
                   {
                     type: "link",
+                    text: "グラウンド",
+                    href: `/teams/${DEFAULT_TEAM_ID}/grounds`,
+                  },
+                  {
+                    type: "link",
                     text: "成績・統計",
                     href: `/teams/${DEFAULT_TEAM_ID}/stats`,
                   },

--- a/packages/web/src/app/(manager)/teams/[id]/grounds/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/grounds/page.tsx
@@ -1,0 +1,135 @@
+import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import Cards from "@cloudscape-design/components/cards";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+
+const TIME_SLOT_LABELS: Record<string, string> = {
+  MORNING: "午前",
+  AFTERNOON: "午後",
+  EVENING: "夜間",
+};
+
+export default async function GroundsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: team } = await supabase
+    .from("teams")
+    .select("name")
+    .eq("id", id)
+    .single();
+
+  const { data: grounds } = await supabase
+    .from("grounds")
+    .select("*")
+    .eq("team_id", id)
+    .order("name");
+
+  // 各グラウンドの直近の空き状況を取得
+  const today = new Date().toISOString().split("T")[0];
+  const groundsWithSlots = [];
+  for (const ground of grounds ?? []) {
+    const { data: slots } = await supabase
+      .from("ground_slots")
+      .select("*")
+      .eq("ground_id", ground.id)
+      .gte("date", today)
+      .eq("status", "AVAILABLE")
+      .order("date")
+      .limit(5);
+
+    groundsWithSlots.push({
+      ...ground,
+      available_slots: slots ?? [],
+    });
+  }
+
+  return (
+    <ContentLayout
+      header={
+        <Header
+          variant="h1"
+          description={team?.name ?? ""}
+          actions={<Link href={`/teams/${id}`}>チームに戻る</Link>}
+        >
+          グラウンド管理
+        </Header>
+      }
+    >
+      <Cards
+        header={
+          <Header counter={`(${groundsWithSlots.length})`}>
+            グラウンド一覧
+          </Header>
+        }
+        cardDefinition={{
+          header: (item) => item.name,
+          sections: [
+            {
+              id: "municipality",
+              header: "自治体",
+              content: (item) => item.municipality,
+            },
+            {
+              id: "cost",
+              header: "料金",
+              content: (item) =>
+                item.cost_per_slot
+                  ? `¥${item.cost_per_slot.toLocaleString()}/枠`
+                  : "—",
+            },
+            {
+              id: "features",
+              header: "設備",
+              content: (item) => {
+                const features = [];
+                if (item.is_hardball_ok) features.push("硬式可");
+                if (item.has_night_lights) features.push("照明あり");
+                return features.length > 0 ? features.join(", ") : "—";
+              },
+            },
+            {
+              id: "watch",
+              header: "監視",
+              content: (item) => (
+                <StatusIndicator
+                  type={item.watch_active ? "success" : "stopped"}
+                >
+                  {item.watch_active ? "監視中" : "停止中"}
+                </StatusIndicator>
+              ),
+            },
+            {
+              id: "available",
+              header: "直近の空き",
+              content: (item) => {
+                if (item.available_slots.length === 0) {
+                  return "空きなし";
+                }
+                return item.available_slots
+                  .map(
+                    (s: { date: string; time_slot: string }) =>
+                      `${s.date} ${TIME_SLOT_LABELS[s.time_slot] ?? s.time_slot}`,
+                  )
+                  .join(", ");
+              },
+            },
+          ],
+        }}
+        items={groundsWithSlots}
+        empty={
+          <Box textAlign="center" color="text-body-secondary" padding="xxl">
+            グラウンドが登録されていません
+          </Box>
+        }
+      />
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/api/grounds/[id]/slots/route.ts
+++ b/packages/web/src/app/api/grounds/[id]/slots/route.ts
@@ -1,0 +1,43 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/grounds/:id/slots — グラウンド空き状況 */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const from = searchParams.get("from");
+  const to = searchParams.get("to");
+
+  let query = supabase
+    .from("ground_slots")
+    .select("*")
+    .eq("ground_id", id)
+    .order("date", { ascending: true })
+    .order("time_slot", { ascending: true });
+
+  if (from) query = query.gte("date", from);
+  if (to) query = query.lte("date", to);
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  const slots = data ?? [];
+  const summary = {
+    available: slots.filter((s) => s.status === "AVAILABLE").length,
+    reserved: slots.filter((s) => s.status === "RESERVED").length,
+    unavailable: slots.filter((s) => s.status === "UNAVAILABLE").length,
+    total: slots.length,
+  };
+
+  return NextResponse.json(apiSuccess(slots, [], { summary }));
+}

--- a/packages/web/src/app/api/grounds/webhook/route.ts
+++ b/packages/web/src/app/api/grounds/webhook/route.ts
@@ -1,0 +1,103 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * POST /api/grounds/webhook — 外部グラウンド監視ツールからの空き情報インポート
+ *
+ * Body: {
+ *   secret: string,
+ *   ground_id: string,
+ *   slots: Array<{ date: string, time_slot: "MORNING"|"AFTERNOON"|"EVENING", status: "AVAILABLE"|"UNAVAILABLE" }>
+ * }
+ */
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  // Webhook シークレット検証
+  if (body.secret !== process.env.GROUND_WEBHOOK_SECRET) {
+    return NextResponse.json(apiError("UNAUTHORIZED", "無効なシークレット"), {
+      status: 401,
+    });
+  }
+
+  const supabase = await createClient();
+  const { ground_id, slots } = body;
+
+  if (!ground_id || !slots || !Array.isArray(slots)) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "ground_id と slots が必要です"),
+      { status: 400 },
+    );
+  }
+
+  // グラウンド存在確認
+  const { data: ground, error: groundError } = await supabase
+    .from("grounds")
+    .select("id, team_id, name")
+    .eq("id", ground_id)
+    .single();
+
+  if (groundError) {
+    return NextResponse.json(
+      apiError("NOT_FOUND", "グラウンドが見つかりません"),
+      { status: 404 },
+    );
+  }
+
+  // スロットを upsert
+  const rows = slots.map(
+    (s: { date: string; time_slot: string; status: string }) => ({
+      ground_id,
+      date: s.date,
+      time_slot: s.time_slot,
+      status: s.status,
+      detected_at: new Date().toISOString(),
+    }),
+  );
+
+  const { data, error } = await supabase
+    .from("ground_slots")
+    .upsert(rows, { onConflict: "ground_id,date,time_slot" })
+    .select();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  const newlyAvailable =
+    data?.filter((s) => s.status === "AVAILABLE").length ?? 0;
+
+  await writeAuditLog(supabase, {
+    actor_type: "SYSTEM",
+    actor_id: "GROUND_MONITOR",
+    action: "IMPORT_GROUND_SLOTS",
+    target_type: "ground",
+    target_id: ground_id,
+    after_json: {
+      imported: data?.length ?? 0,
+      newly_available: newlyAvailable,
+    },
+  });
+
+  return NextResponse.json(
+    apiSuccess(
+      {
+        imported: data?.length ?? 0,
+        newly_available: newlyAvailable,
+        ground_name: ground.name,
+      },
+      newlyAvailable > 0
+        ? [
+            {
+              action: "create_game",
+              reason: `${ground.name}に${newlyAvailable}件の空きが見つかりました`,
+              priority: "high" as const,
+            },
+          ]
+        : [],
+    ),
+  );
+}


### PR DESCRIPTION
closes #45

## Summary
- `GET /api/grounds/:id/slots` — グラウンド空き状況照会 (日付フィルタ対応)
- `POST /api/grounds/webhook` — 外部監視ツールからの空き情報インポート (Webhook認証 + upsert)
- `/teams/[id]/grounds` — グラウンド管理画面 (Cloudscape Cards: 監視状態・料金・設備・直近空き)
- サイドナビにグラウンドリンク追加

## Test plan
- [x] `make check` 全パス
- [ ] Webhook でスロットデータ投入後の表示確認

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n