### PR TITLE
feat: 精算・PayPay 連携

### DIFF
--- a/packages/core/src/__tests__/paypay.test.ts
+++ b/packages/core/src/__tests__/paypay.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { generatePayPayLink } from "../lib/paypay";
+
+describe("generatePayPayLink", () => {
+  describe("有効な金額と説明を渡したとき", () => {
+    it("有効なURLを返す", () => {
+      const link = generatePayPayLink(1500, "グラウンド代");
+
+      expect(() => new URL(link)).not.toThrow();
+      expect(link).toContain("https://pay.paypay.ne.jp/request");
+    });
+
+    it("金額がクエリパラメータに含まれる", () => {
+      const link = generatePayPayLink(2000, "精算");
+      const url = new URL(link);
+
+      expect(url.searchParams.get("amount")).toBe("2000");
+    });
+
+    it("説明文がエンコードされてクエリパラメータに含まれる", () => {
+      const link = generatePayPayLink(1000, "4/3 練習試合 精算");
+      const url = new URL(link);
+
+      expect(url.searchParams.get("description")).toBe("4/3 練習試合 精算");
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,9 @@ export {
 } from "./lib/stats";
 export type { BattingStats, PitchingStats, TeamStats } from "./lib/stats";
 
+// PayPay
+export { generatePayPayLink } from "./lib/paypay";
+
 // Validators
 export {
   createGameSchema,

--- a/packages/core/src/lib/paypay.ts
+++ b/packages/core/src/lib/paypay.ts
@@ -1,0 +1,25 @@
+/**
+ * PayPay 決済リンク生成
+ *
+ * PayPay には公式の公開APIがないため、
+ * プレースホルダーURLを生成する。
+ * 将来的に PayPay API が利用可能になった場合はこのモジュールを差し替える。
+ */
+
+const PAYPAY_BASE_URL = "https://pay.paypay.ne.jp/request";
+
+/**
+ * PayPay 支払いリクエストURLを生成する
+ * @param amount - 支払い金額（円）
+ * @param description - 支払い説明文
+ * @returns PayPay ディープリンクURL
+ */
+export function generatePayPayLink(
+  amount: number,
+  description: string,
+): string {
+  const url = new URL(PAYPAY_BASE_URL);
+  url.searchParams.set("amount", String(amount));
+  url.searchParams.set("description", description);
+  return url.toString();
+}

--- a/packages/web/src/app/(manager)/games/[id]/expenses/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/expenses/page.tsx
@@ -8,7 +8,9 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table from "@cloudscape-design/components/table";
 
+import { SettlementActions } from "@/components/SettlementActions";
 import { createClient } from "@/lib/supabase/server";
+import { generatePayPayLink } from "@match-engine/core";
 
 const CATEGORY_LABELS: Record<string, string> = {
   GROUND: "グラウンド",
@@ -131,43 +133,73 @@ export default async function ExpensesPage({
 
         {settlement ? (
           <Container header={<Header variant="h2">精算サマリ</Header>}>
-            <KeyValuePairs
-              items={[
-                {
-                  label: "合計費用",
-                  value: `¥${Number(settlement.total_cost).toLocaleString()}`,
-                },
-                {
-                  label: "対戦相手負担",
-                  value: `¥${Number(settlement.opponent_share).toLocaleString()}`,
-                },
-                {
-                  label: "チーム負担",
-                  value: `¥${Number(settlement.team_cost).toLocaleString()}`,
-                },
-                {
-                  label: "一人あたり",
-                  value: `¥${Number(settlement.per_member).toLocaleString()}`,
-                },
-                {
-                  label: "参加人数",
-                  value: `${settlement.member_count}人`,
-                },
-                {
-                  label: "ステータス",
-                  value: (
-                    <StatusIndicator
-                      type={
-                        SETTLEMENT_STATUS_TYPE[settlement.status] ?? "pending"
-                      }
-                    >
-                      {SETTLEMENT_STATUS_LABELS[settlement.status] ??
-                        settlement.status}
-                    </StatusIndicator>
-                  ),
-                },
-              ]}
-            />
+            <SpaceBetween size="l">
+              <KeyValuePairs
+                items={[
+                  {
+                    label: "合計費用",
+                    value: `¥${Number(settlement.total_cost).toLocaleString()}`,
+                  },
+                  {
+                    label: "対戦相手負担",
+                    value: `¥${Number(settlement.opponent_share).toLocaleString()}`,
+                  },
+                  {
+                    label: "チーム負担",
+                    value: `¥${Number(settlement.team_cost).toLocaleString()}`,
+                  },
+                  {
+                    label: "一人あたり",
+                    value: `¥${Number(settlement.per_member).toLocaleString()}`,
+                  },
+                  {
+                    label: "参加人数",
+                    value: `${settlement.member_count}人`,
+                  },
+                  {
+                    label: "ステータス",
+                    value: (
+                      <StatusIndicator
+                        type={
+                          SETTLEMENT_STATUS_TYPE[settlement.status] ?? "pending"
+                        }
+                      >
+                        {SETTLEMENT_STATUS_LABELS[settlement.status] ??
+                          settlement.status}
+                      </StatusIndicator>
+                    ),
+                  },
+                  ...((settlement.status === "NOTIFIED" ||
+                    settlement.status === "SETTLED") &&
+                  game.title
+                    ? [
+                        {
+                          label: "PayPay リンク",
+                          value: (
+                            <Link
+                              href={generatePayPayLink(
+                                settlement.per_member,
+                                `${game.title} 精算`,
+                              )}
+                              external
+                            >
+                              PayPay で ¥
+                              {Number(settlement.per_member).toLocaleString()}{" "}
+                              を支払う
+                            </Link>
+                          ),
+                        },
+                      ]
+                    : []),
+                ]}
+              />
+
+              <SettlementActions
+                gameId={id}
+                settlementStatus={settlement.status}
+                perMember={settlement.per_member}
+              />
+            </SpaceBetween>
           </Container>
         ) : (
           <Container header={<Header variant="h2">精算サマリ</Header>}>

--- a/packages/web/src/app/api/games/[id]/settlement/complete/route.ts
+++ b/packages/web/src/app/api/games/[id]/settlement/complete/route.ts
@@ -1,0 +1,67 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** POST /api/games/:id/settlement/complete — 精算完了 */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // 精算情報を取得
+  const { data: settlement, error: settlementError } = await supabase
+    .from("settlements")
+    .select("*")
+    .eq("game_id", id)
+    .single();
+
+  if (settlementError || !settlement) {
+    return NextResponse.json(
+      apiError("NOT_FOUND", "精算情報が見つかりません"),
+      { status: 404 },
+    );
+  }
+
+  if (settlement.status === "SETTLED") {
+    return NextResponse.json(apiError("INVALID_STATUS", "既に精算済みです"), {
+      status: 422,
+    });
+  }
+
+  // ステータスを SETTLED に更新
+  const { data, error: updateError } = await supabase
+    .from("settlements")
+    .update({
+      status: "SETTLED",
+      settled_at: new Date().toISOString(),
+    })
+    .eq("id", settlement.id)
+    .select()
+    .single();
+
+  if (updateError) {
+    return NextResponse.json(apiError("DATABASE_ERROR", updateError.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "COMPLETE_SETTLEMENT",
+    target_type: "settlement",
+    target_id: settlement.id,
+    before_json: { status: settlement.status },
+    after_json: { status: "SETTLED", settled_at: data.settled_at },
+  });
+
+  return NextResponse.json(apiSuccess(data));
+}

--- a/packages/web/src/app/api/games/[id]/settlement/notify/route.ts
+++ b/packages/web/src/app/api/games/[id]/settlement/notify/route.ts
@@ -1,0 +1,134 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  generatePayPayLink,
+  writeAuditLog,
+} from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** POST /api/games/:id/settlement/notify — 精算通知送信 */
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // 精算情報を取得
+  const { data: settlement, error: settlementError } = await supabase
+    .from("settlements")
+    .select("*")
+    .eq("game_id", id)
+    .single();
+
+  if (settlementError || !settlement) {
+    return NextResponse.json(
+      apiError("NOT_FOUND", "精算情報が見つかりません"),
+      { status: 404 },
+    );
+  }
+
+  if (settlement.status !== "DRAFT") {
+    return NextResponse.json(
+      apiError(
+        "INVALID_STATUS",
+        `精算ステータスが DRAFT ではありません (現在: ${settlement.status})`,
+      ),
+      { status: 422 },
+    );
+  }
+
+  // 試合情報を取得（通知内容に使用）
+  const { data: game } = await supabase
+    .from("games")
+    .select("title, team_id")
+    .eq("id", id)
+    .single();
+
+  if (!game) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  // PayPay リンク生成
+  const paypayLink = generatePayPayLink(
+    settlement.per_member,
+    `${game.title} 精算`,
+  );
+
+  // 参加メンバーを取得（出席者 or AVAILABLE メンバー）
+  const { data: attendances } = await supabase
+    .from("attendances")
+    .select("member_id")
+    .eq("game_id", id);
+
+  let recipientIds: string[] = [];
+
+  if (attendances && attendances.length > 0) {
+    recipientIds = attendances.map((a) => a.member_id);
+  } else {
+    const { data: rsvps } = await supabase
+      .from("rsvps")
+      .select("member_id")
+      .eq("game_id", id)
+      .eq("response", "AVAILABLE");
+
+    recipientIds = rsvps?.map((r) => r.member_id) ?? [];
+  }
+
+  // 通知ログを挿入
+  if (recipientIds.length > 0) {
+    const notificationLogs = recipientIds.map((memberId) => ({
+      team_id: game.team_id,
+      game_id: id,
+      recipient_type: "MEMBER" as const,
+      recipient_id: memberId,
+      channel: "LINE" as const,
+      notification_type: "SETTLEMENT" as const,
+      content: `精算金額: ¥${settlement.per_member.toLocaleString()} PayPay: ${paypayLink}`,
+    }));
+
+    await supabase.from("notification_logs").insert(notificationLogs);
+  }
+
+  // ステータスを NOTIFIED に更新
+  const { error: updateError } = await supabase
+    .from("settlements")
+    .update({ status: "NOTIFIED" })
+    .eq("id", settlement.id);
+
+  if (updateError) {
+    return NextResponse.json(apiError("DATABASE_ERROR", updateError.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "NOTIFY_SETTLEMENT",
+    target_type: "settlement",
+    target_id: settlement.id,
+    before_json: { status: "DRAFT" },
+    after_json: {
+      status: "NOTIFIED",
+      paypay_link: paypayLink,
+      notification_count: recipientIds.length,
+    },
+  });
+
+  return NextResponse.json(
+    apiSuccess({
+      paypay_link: paypayLink,
+      notification_count: recipientIds.length,
+    }),
+  );
+}

--- a/packages/web/src/components/SettlementActions.tsx
+++ b/packages/web/src/components/SettlementActions.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface SettlementActionsProps {
+  gameId: string;
+  settlementStatus: string;
+  perMember: number;
+}
+
+export function SettlementActions({
+  gameId,
+  settlementStatus,
+  perMember,
+}: SettlementActionsProps) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paypayLink, setPaypayLink] = useState<string | null>(null);
+
+  const handleNotify = async () => {
+    setPending(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/games/${gameId}/settlement/notify`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "精算通知の送信に失敗しました");
+        return;
+      }
+
+      const data = await res.json();
+      setPaypayLink(data.data.paypay_link);
+      router.refresh();
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleComplete = async () => {
+    setPending(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/games/${gameId}/settlement/complete`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "精算完了に失敗しました");
+        return;
+      }
+
+      router.refresh();
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <SpaceBetween size="s">
+      {error && (
+        <Flashbar
+          items={[
+            {
+              type: "error",
+              content: error,
+              dismissible: true,
+              onDismiss: () => setError(null),
+              id: "settlement-error",
+            },
+          ]}
+        />
+      )}
+
+      {settlementStatus === "DRAFT" && (
+        <Button variant="primary" loading={pending} onClick={handleNotify}>
+          精算通知を送信
+        </Button>
+      )}
+
+      {(settlementStatus === "NOTIFIED" || settlementStatus === "SETTLED") &&
+        paypayLink && (
+          <Box>
+            <Link href={paypayLink} external>
+              PayPay で ¥{perMember.toLocaleString()} を支払う
+            </Link>
+          </Box>
+        )}
+
+      {settlementStatus === "NOTIFIED" && (
+        <Button variant="primary" loading={pending} onClick={handleComplete}>
+          精算完了
+        </Button>
+      )}
+    </SpaceBetween>
+  );
+}


### PR DESCRIPTION
closes #47

## Summary
- Core: `generatePayPayLink(amount, description)` — PayPay 支払いリンク生成 (スタブ) + テスト3件
- API: `POST /api/games/:id/settlement/notify` — 精算通知送信 (DRAFT→NOTIFIED, PayPayリンク生成, notification_logs記録)
- API: `POST /api/games/:id/settlement/complete` — 精算完了 (NOTIFIED→SETTLED)
- UI: `SettlementActions` コンポーネント (精算通知ボタン + 精算完了ボタン)
- UI: expenses ページに PayPay リンク表示 + 精算アクション統合

## Test plan
- [x] `make check` (117テスト) 全パス
- [ ] 精算通知→PayPayリンク表示→精算完了フロー確認

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n