### PR TITLE
feat: Cloudscape デザインシステム拡充 (Wizard・Breadcrumb・エラーページ)

### DIFF
--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { TransitionButtons } from "@/components/TransitionButtons";
 import { createClient } from "@/lib/supabase/server";
 import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
@@ -84,6 +85,14 @@ export default async function GameDetailPage({
 
   return (
     <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/" },
+            { text: game.title, href: `/games/${id}` },
+          ]}
+        />
+      }
       header={
         <Header
           variant="h1"

--- a/packages/web/src/app/(manager)/games/new/page.tsx
+++ b/packages/web/src/app/(manager)/games/new/page.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import Button from "@cloudscape-design/components/button";
+import Box from "@cloudscape-design/components/box";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import DateInput from "@cloudscape-design/components/date-input";
 import Flashbar from "@cloudscape-design/components/flashbar";
-import Form from "@cloudscape-design/components/form";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import Select from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Textarea from "@cloudscape-design/components/textarea";
 import TimeInput from "@cloudscape-design/components/time-input";
+import Wizard from "@cloudscape-design/components/wizard";
 import type { GameType } from "@match-engine/core";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -26,6 +28,7 @@ const GAME_TYPE_OPTIONS = [
 
 export default function NewGamePage() {
   const router = useRouter();
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
   const [title, setTitle] = useState("");
   const [gameType, setGameType] = useState<GameType>("FRIENDLY");
   const [gameDate, setGameDate] = useState("");
@@ -70,6 +73,9 @@ export default function NewGamePage() {
     }
   };
 
+  const gameTypeLabel =
+    GAME_TYPE_OPTIONS.find((o) => o.value === gameType)?.label ?? gameType;
+
   return (
     <ContentLayout header={<Header variant="h1">試合作成</Header>}>
       {error && (
@@ -85,97 +91,156 @@ export default function NewGamePage() {
           ]}
         />
       )}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleSubmit();
+      <Wizard
+        i18nStrings={{
+          stepNumberLabel: (stepNumber) => `ステップ ${stepNumber}`,
+          collapsedStepsLabel: (stepNumber, stepsCount) =>
+            `ステップ ${stepNumber}/${stepsCount}`,
+          cancelButton: "キャンセル",
+          previousButton: "前へ",
+          nextButton: "次へ",
+          submitButton: "試合を作成",
+          optional: "任意",
         }}
-      >
-        <Form
-          actions={
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button variant="link" onClick={() => router.push("/")}>
-                キャンセル
-              </Button>
-              <Button
-                variant="primary"
-                formAction="submit"
-                loading={submitting}
+        onCancel={() => router.push("/")}
+        onNavigate={({ detail }) =>
+          setActiveStepIndex(detail.requestedStepIndex)
+        }
+        onSubmit={handleSubmit}
+        activeStepIndex={activeStepIndex}
+        isLoadingNextStep={submitting}
+        steps={[
+          {
+            title: "基本情報",
+            description: "試合のタイトル・種別・日時を入力します",
+            content: (
+              <Container header={<Header variant="h2">基本情報</Header>}>
+                <SpaceBetween size="l">
+                  <FormField label="タイトル">
+                    <Input
+                      value={title}
+                      onChange={({ detail }) => setTitle(detail.value)}
+                      placeholder="例: 4/5 vs ○○さん"
+                    />
+                  </FormField>
+                  <FormField label="種別">
+                    <Select
+                      selectedOption={
+                        GAME_TYPE_OPTIONS.find((o) => o.value === gameType) ??
+                        null
+                      }
+                      onChange={({ detail }) =>
+                        setGameType(
+                          (detail.selectedOption.value as GameType) ??
+                            "FRIENDLY",
+                        )
+                      }
+                      options={GAME_TYPE_OPTIONS}
+                    />
+                  </FormField>
+                  <FormField label="試合日">
+                    <DateInput
+                      value={gameDate}
+                      onChange={({ detail }) => setGameDate(detail.value)}
+                      placeholder="YYYY/MM/DD"
+                    />
+                  </FormField>
+                  <FormField label="開始時刻">
+                    <TimeInput
+                      value={startTime}
+                      onChange={({ detail }) => setStartTime(detail.value)}
+                      format="hh:mm"
+                      placeholder="HH:mm"
+                    />
+                  </FormField>
+                </SpaceBetween>
+              </Container>
+            ),
+          },
+          {
+            title: "グラウンド・相手",
+            description: "グラウンドと人数の設定を行います",
+            content: (
+              <Container
+                header={<Header variant="h2">グラウンド・相手</Header>}
               >
-                試合を作成
-              </Button>
-            </SpaceBetween>
-          }
-        >
-          <Container header={<Header variant="h2">試合情報</Header>}>
-            <SpaceBetween size="l">
-              <FormField label="タイトル">
-                <Input
-                  value={title}
-                  onChange={({ detail }) => setTitle(detail.value)}
-                  placeholder="例: 4/5 vs ○○さん"
-                />
-              </FormField>
-
-              <FormField label="種別">
-                <Select
-                  selectedOption={
-                    GAME_TYPE_OPTIONS.find((o) => o.value === gameType) ?? null
-                  }
-                  onChange={({ detail }) =>
-                    setGameType(
-                      (detail.selectedOption.value as GameType) ?? "FRIENDLY",
-                    )
-                  }
-                  options={GAME_TYPE_OPTIONS}
-                />
-              </FormField>
-
-              <FormField label="試合日">
-                <DateInput
-                  value={gameDate}
-                  onChange={({ detail }) => setGameDate(detail.value)}
-                  placeholder="YYYY/MM/DD"
-                />
-              </FormField>
-
-              <FormField label="開始時刻">
-                <TimeInput
-                  value={startTime}
-                  onChange={({ detail }) => setStartTime(detail.value)}
-                  format="hh:mm"
-                  placeholder="HH:mm"
-                />
-              </FormField>
-
-              <FormField label="グラウンド">
-                <Input
-                  value={groundName}
-                  onChange={({ detail }) => setGroundName(detail.value)}
-                  placeholder="例: 八部公園野球場"
-                />
-              </FormField>
-
-              <FormField label="最低人数">
-                <Input
-                  type="number"
-                  value={minPlayers}
-                  onChange={({ detail }) => setMinPlayers(detail.value)}
-                  inputMode="numeric"
-                />
-              </FormField>
-
-              <FormField label="メモ">
-                <Textarea
-                  value={note}
-                  onChange={({ detail }) => setNote(detail.value)}
-                  rows={3}
-                />
-              </FormField>
-            </SpaceBetween>
-          </Container>
-        </Form>
-      </form>
+                <SpaceBetween size="l">
+                  <FormField label="グラウンド">
+                    <Input
+                      value={groundName}
+                      onChange={({ detail }) => setGroundName(detail.value)}
+                      placeholder="例: 八部公園野球場"
+                    />
+                  </FormField>
+                  <FormField label="最低人数">
+                    <Input
+                      type="number"
+                      value={minPlayers}
+                      onChange={({ detail }) => setMinPlayers(detail.value)}
+                      inputMode="numeric"
+                    />
+                  </FormField>
+                </SpaceBetween>
+              </Container>
+            ),
+          },
+          {
+            title: "確認",
+            description: "入力内容を確認して試合を作成します",
+            content: (
+              <SpaceBetween size="l">
+                <Container header={<Header variant="h2">入力内容</Header>}>
+                  <ColumnLayout columns={2} variant="text-grid">
+                    <KeyValuePairs
+                      items={[
+                        {
+                          label: "タイトル",
+                          value: title || "未入力",
+                        },
+                        { label: "種別", value: gameTypeLabel },
+                        {
+                          label: "試合日",
+                          value: gameDate || "未定",
+                        },
+                        {
+                          label: "開始時刻",
+                          value: startTime || "未定",
+                        },
+                      ]}
+                    />
+                    <KeyValuePairs
+                      items={[
+                        {
+                          label: "グラウンド",
+                          value: groundName || "未定",
+                        },
+                        {
+                          label: "最低人数",
+                          value: `${minPlayers}人`,
+                        },
+                      ]}
+                    />
+                  </ColumnLayout>
+                </Container>
+                <Container header={<Header variant="h2">メモ</Header>}>
+                  <FormField label="メモ">
+                    <Textarea
+                      value={note}
+                      onChange={({ detail }) => setNote(detail.value)}
+                      rows={3}
+                    />
+                  </FormField>
+                </Container>
+                {submitting && (
+                  <Box textAlign="center" color="text-body-secondary">
+                    作成中...
+                  </Box>
+                )}
+              </SpaceBetween>
+            ),
+          },
+        ]}
+      />
     </ContentLayout>
   );
 }

--- a/packages/web/src/app/(manager)/teams/[id]/helpers/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/helpers/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import Cards from "@cloudscape-design/components/cards";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
@@ -28,6 +29,15 @@ export default async function HelpersPage({
 
   return (
     <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/" },
+            { text: team?.name ?? "チーム", href: `/teams/${id}` },
+            { text: "助っ人管理", href: `/teams/${id}/helpers` },
+          ]}
+        />
+      }
       header={
         <Header
           variant="h1"

--- a/packages/web/src/app/(manager)/teams/[id]/opponents/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/opponents/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
@@ -27,6 +28,15 @@ export default async function OpponentsPage({
 
   return (
     <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/" },
+            { text: team?.name ?? "チーム", href: `/teams/${id}` },
+            { text: "対戦相手", href: `/teams/${id}/opponents` },
+          ]}
+        />
+      }
       header={
         <Header
           variant="h1"

--- a/packages/web/src/app/(manager)/teams/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import Cards from "@cloudscape-design/components/cards";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
@@ -59,6 +60,14 @@ export default async function TeamDetailPage({
 
   return (
     <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/" },
+            { text: team.name, href: `/teams/${id}` },
+          ]}
+        />
+      }
       header={
         <Header
           variant="h1"

--- a/packages/web/src/app/(manager)/teams/[id]/stats/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/stats/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
@@ -61,6 +62,15 @@ export default async function StatsPage({
 
   return (
     <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/" },
+            { text: team?.name ?? "チーム", href: `/teams/${id}` },
+            { text: "成績", href: `/teams/${id}/stats` },
+          ]}
+        />
+      }
       header={
         <Header
           variant="h1"

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { createClient } from "@/lib/supabase/client";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 
@@ -19,26 +25,37 @@ function LoginContent() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm space-y-6 rounded-lg border bg-white p-8 shadow-sm">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900">試合成立エンジン</h1>
-          <p className="mt-2 text-sm text-gray-500">
-            ログインして試合を管理しましょう
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={handleLogin}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#06C755] px-4 py-3 text-sm font-medium text-white hover:bg-[#05b04d] transition-colors"
-        >
-          LINEでログイン
-        </button>
-        <p className="text-center text-xs text-gray-400">
-          LINE アカウントで認証します
-        </p>
-      </div>
-    </div>
+    <Box padding="xxxl">
+      <ContentLayout
+        header={
+          <Header variant="h1">
+            <Box textAlign="center">試合成立エンジン</Box>
+          </Header>
+        }
+      >
+        <Box margin={{ left: "xxxl", right: "xxxl" }}>
+          <Container header={<Header variant="h2">ログイン</Header>}>
+            <SpaceBetween size="l">
+              <Box variant="p" textAlign="center">
+                ログインして試合を管理しましょう
+              </Box>
+              <Box textAlign="center">
+                <Button variant="primary" onClick={handleLogin}>
+                  LINE でログイン
+                </Button>
+              </Box>
+              <Box
+                textAlign="center"
+                color="text-body-secondary"
+                fontSize="body-s"
+              >
+                LINE アカウントで認証します
+              </Box>
+            </SpaceBetween>
+          </Container>
+        </Box>
+      </ContentLayout>
+    </Box>
   );
 }
 

--- a/packages/web/src/app/not-found.tsx
+++ b/packages/web/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Box from "@cloudscape-design/components/box";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function NotFound() {
+  return (
+    <Box padding="xxxl" textAlign="center">
+      <SpaceBetween size="l">
+        <Header variant="h1">ページが見つかりません</Header>
+        <Box variant="p" color="text-body-secondary">
+          お探しのページは存在しないか、移動された可能性があります。
+        </Box>
+        <Link href="/">ダッシュボードに戻る</Link>
+      </SpaceBetween>
+    </Box>
+  );
+}


### PR DESCRIPTION
closes #58

## Summary
### Wizard で試合作成フロー
- Step 1 (基本情報): タイトル・種別・日程・開始時刻
- Step 2 (グラウンド・相手): グラウンド名・最低人数
- Step 3 (確認): KeyValuePairs でレビュー + メモ入力 + 作成

### BreadcrumbGroup (5ページ)
- `/teams/[id]` — ダッシュボード > チーム名
- `/games/[id]` — ダッシュボード > 試合名
- `/teams/[id]/helpers` — ダッシュボード > チーム名 > 助っ人管理
- `/teams/[id]/opponents` — ダッシュボード > チーム名 > 対戦相手
- `/teams/[id]/stats` — ダッシュボード > チーム名 > 成績

### エラーページ
- `not-found.tsx` — Cloudscape の 404 ページ

### ログインページ
- Cloudscape コンポーネントで統一 (Container + Header + Button)

## Test plan
- [x] `make check` (139テスト) 全パス
- [ ] Wizard の3ステップフロー確認
- [ ] Breadcrumb ナビゲーション動作確認

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n