### PR TITLE
feat: API ドキュメント・AI エージェント説明・開発者リファレンス

### DIFF
--- a/packages/web/src/app/(public)/docs/ai/page.tsx
+++ b/packages/web/src/app/(public)/docs/ai/page.tsx
@@ -1,0 +1,473 @@
+import type { Metadata } from "next";
+import styles from "../docs.module.css";
+
+export const metadata: Metadata = {
+  title: "AI エージェント | mound",
+  description:
+    "mound の AI エージェント機能。MCP サーバー連携、出欠予測、助っ人推薦、メッセージ生成。",
+};
+
+export default function AiDocsPage() {
+  return (
+    <>
+      <h1 className={styles.pageTitle}>AI エージェント</h1>
+      <p className={styles.pageDescription}>
+        mound は AI エージェントをシステムの一級市民として設計しています。代表は
+        Claude Code や Cursor
+        から自然言語で操作でき、将来はチーム同士のエージェントが自動で対戦交渉を行います。
+      </p>
+
+      {/* Philosophy */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>
+          設計哲学: AI は提案する (Planner)
+        </h2>
+        <div className={styles.info}>
+          <strong>
+            AI は提案する。システムは状態を持つ。人が最後に決める。
+          </strong>
+        </div>
+        <p className={styles.paragraph}>
+          mound の AI は自律的に判断や実行を行いません。あくまで「提案者
+          (Planner)」として振る舞います。
+        </p>
+        <ul className={styles.list}>
+          <li>
+            <strong>AI が行うこと:</strong>{" "}
+            出欠予測、助っ人の推薦、交渉メッセージの生成、次のアクションの提案
+          </li>
+          <li>
+            <strong>AI が行わないこと:</strong>{" "}
+            試合の確定、精算の実行、メンバーの除外など不可逆な操作
+          </li>
+          <li>
+            <strong>Governor (ルールエンジン):</strong>{" "}
+            成立条件を満たさない遷移をブロックし、AI の暴走を防止
+          </li>
+          <li>
+            <strong>人間の役割:</strong> 最終的な承認 (CONFIRMED 遷移)
+            は必ず人間が行う
+          </li>
+        </ul>
+        <p className={styles.paragraph}>
+          全ての API レスポンスには{" "}
+          <code className={styles.codeInline}>next_actions</code>{" "}
+          フィールドが含まれ、AI
+          エージェントが「次に何をすべきか」を自律的に判断できる構造になっています。
+        </p>
+      </div>
+
+      {/* AI Features */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>AI 機能</h2>
+
+        <div className={styles.featureCard}>
+          <h3 className={styles.featureCardTitle}>出欠予測</h3>
+          <p className={styles.featureCardDesc}>
+            メンバーごとの出席率、曜日・時間帯の傾向、天候予報、過去のドタキャン率を基に、各メンバーの参加確率を予測します。「全員の回答を待たずに人数の見通しが立つ」ため、早期に助っ人打診の判断ができます。
+          </p>
+          <div className={styles.codeBlock}>
+            {`POST /api/ai/predict-attendance
+{ "game_id": "uuid" }
+
+→ 予測結果:
+  田中: 85% (高い出席率 + 土曜午前は参加傾向)
+  佐藤: 40% (最近の出席率低下 + 午後の試合は欠席傾向)
+  予想参加人数: 11人`}
+          </div>
+        </div>
+
+        <div className={styles.featureCard}>
+          <h3 className={styles.featureCardTitle}>助っ人推薦</h3>
+          <p className={styles.featureCardDesc}>
+            不足人数に応じて、信頼度スコア・過去の参加実績・ポジション適性・直近の打診状況を考慮して、最適な助っ人候補を推薦します。「誰に声をかければいいか」の判断を支援します。
+          </p>
+          <div className={styles.codeBlock}>
+            {`POST /api/ai/recommend-helpers
+{ "game_id": "uuid" }
+
+→ 推薦結果:
+  1. 山田 (スコア: 0.95) - 信頼度高 + キャッチャー経験
+  2. 高橋 (スコア: 0.82) - 内野手 + 最近3回連続参加
+  必要人数: 2人`}
+          </div>
+        </div>
+
+        <div className={styles.featureCard}>
+          <h3 className={styles.featureCardTitle}>交渉メッセージ生成</h3>
+          <p className={styles.featureCardDesc}>
+            対戦相手チームへの交渉メッセージを AI
+            が生成します。相手チームの情報、候補日、過去の対戦履歴を考慮した丁寧なメッセージを作成します。
+          </p>
+          <div className={styles.codeBlock}>
+            {`POST /api/ai/generate-message
+{
+  "game_id": "uuid",
+  "opponent_team_id": "uuid"
+}
+
+→ 生成メッセージ:
+  "○○チーム ご担当者様
+
+  いつもお世話になっております。△△チームの□□です。
+  4月に練習試合をお願いできればと思いご連絡いたしました。
+  候補日は以下の通りです:
+  - 4/12 (土) 9:00-12:00
+  - 4/19 (土) 9:00-12:00
+  ご検討のほどよろしくお願いいたします。"`}
+          </div>
+        </div>
+
+        <div className={styles.featureCard}>
+          <h3 className={styles.featureCardTitle}>週次レポート</h3>
+          <p className={styles.featureCardDesc}>
+            今週の試合予定、出欠状況、未完了タスク、次週の予定をまとめたレポートを自動生成します。代表が毎週の状況を一目で把握できるダイジェストです。
+          </p>
+          <div className={styles.codeBlock}>
+            {`POST /api/ai/weekly-report
+{ "team_id": "uuid" }
+
+→ レポート:
+  ## 今週のサマリー
+  - 4/12 vs 横国さん: 出欠回収中 (7/15)
+  - 4/14 練習: 確定済み (12人参加)
+
+  ## 要対応
+  - 4/12の試合: あと2人必要 → 助っ人打診を推奨
+  - 4/19のグラウンド: 未確保 → 八部公園に空きあり`}
+          </div>
+        </div>
+      </div>
+
+      {/* MCP Server */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>MCP サーバー連携</h2>
+        <p className={styles.paragraph}>
+          mound は <strong>Model Context Protocol (MCP)</strong>{" "}
+          サーバーを提供しています。Claude Desktop、Cursor、Claude Code などの
+          AI ツールから、mound
+          のすべての機能をネイティブなツールとして利用できます。
+        </p>
+        <div className={styles.info}>
+          代表は「試合を組んで」と言うだけで、エージェントが MCP
+          ツールを呼び出して試合作成から出欠収集まで自動で進めます。
+        </div>
+
+        <h3 className={styles.subsectionTitle}>セットアップ</h3>
+        <p className={styles.paragraph}>
+          Claude Desktop または Cursor の MCP
+          設定ファイルに以下を追加してください。
+        </p>
+        <div className={styles.codeBlock}>
+          {`// claude_desktop_config.json または .cursor/mcp.json
+{
+  "mcpServers": {
+    "mound": {
+      "command": "bun",
+      "args": ["run", "/path/to/mound/packages/mcp/src/index.ts"],
+      "env": {
+        "MOUND_API_BASE_URL": "http://localhost:3000",
+        "MOUND_API_KEY": "<your-api-key>"
+      }
+    }
+  }
+}`}
+        </div>
+
+        <h3 className={styles.subsectionTitle}>利用例</h3>
+        <div className={styles.codeBlock}>
+          {`# Claude Desktop / Cursor での操作例
+
+ユーザー: "来週の土曜に練習試合を組みたい"
+
+AI エージェント:
+  1. create_game → DRAFT で試合作成
+  2. transition_game → COLLECTING に遷移
+  3. request_rsvps → 全メンバーに出欠依頼送信
+  4. "試合を作成し、メンバーに出欠確認を送信しました"
+
+ユーザー: "出欠状況を教えて"
+
+AI エージェント:
+  1. get_rsvps → 出欠一覧取得
+  2. "参加7人、不参加3人、未回答5人です。
+      あと2人必要です。助っ人に声をかけますか？"
+
+ユーザー: "おすすめの助っ人に依頼して"
+
+AI エージェント:
+  1. recommend_helpers → AI が推薦
+  2. create_helper_requests → 上位2名に打診
+  3. "山田さんと高橋さんに依頼を送りました"`}
+        </div>
+      </div>
+
+      {/* MCP Tools */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>MCP ツール一覧</h2>
+        <p className={styles.paragraph}>
+          エージェントが呼び出せる全ツールです。試合成立ループに必要な操作を網羅しています。
+        </p>
+
+        <h3 className={styles.subsectionTitle}>
+          試合ライフサイクル (5 ツール)
+        </h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ツール名</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>create_game</code>
+              </td>
+              <td>試合を新規作成する。DRAFT 状態で作成される</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>get_game</code>
+              </td>
+              <td>
+                試合の詳細を取得する。ステータス・出欠集計・次のアクション候補を含む
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>list_games</code>
+              </td>
+              <td>チームの試合一覧を取得する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>transition_game</code>
+              </td>
+              <td>
+                試合のステータスを遷移させる。CONFIRMED
+                への遷移はガバナー条件が必要
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>validate_game</code>
+              </td>
+              <td>試合が確定条件を満たしているか検証する</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className={styles.subsectionTitle}>出欠管理 (3 ツール)</h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ツール名</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>request_rsvps</code>
+              </td>
+              <td>全メンバーに出欠確認を送信する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>get_rsvps</code>
+              </td>
+              <td>出欠回答一覧と集計を取得する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>respond_rsvp</code>
+              </td>
+              <td>出欠回答を登録する (AVAILABLE / UNAVAILABLE / MAYBE)</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className={styles.subsectionTitle}>助っ人管理 (2 ツール)</h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ツール名</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>list_helpers</code>
+              </td>
+              <td>チームに登録されている助っ人一覧を取得する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>
+                  create_helper_requests
+                </code>
+              </td>
+              <td>助っ人に参加依頼を一括送信する</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className={styles.subsectionTitle}>対戦交渉 (3 ツール)</h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ツール名</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>create_negotiation</code>
+              </td>
+              <td>相手チームとの対戦交渉を開始する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>update_negotiation</code>
+              </td>
+              <td>交渉ステータスを更新する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>list_negotiations</code>
+              </td>
+              <td>試合に関連する交渉一覧を取得する</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className={styles.subsectionTitle}>精算 (3 ツール)</h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ツール名</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>add_expense</code>
+              </td>
+              <td>試合の費用を登録する</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>calculate_settlement</code>
+              </td>
+              <td>精算を計算する (参加者ごとの支払い額を算出)</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>list_expenses</code>
+              </td>
+              <td>登録済み費用一覧を取得する</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Agent-to-Agent */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>エージェント間交渉 (将来構想)</h2>
+        <p className={styles.paragraph}>
+          将来的に、チームAのエージェントとチームBのエージェントが自動で対戦交渉を行う仕組みを実現します。
+        </p>
+
+        <div className={styles.codeBlock}>
+          {`現在 (Phase 1):
+  代表 → Claude Code → MCP → システム → DB
+
+Phase 4 (半自動交渉):
+  代表 → Claude Code → MCP → システム → 相手チームのMCP → 相手のエージェント
+
+Phase 5 (完全自動交渉):
+  エージェントA → MCP → システム → MCP → エージェントB
+  (人間は承認のみ)`}
+        </div>
+
+        <h3 className={styles.subsectionTitle}>交渉ポリシー</h3>
+        <p className={styles.paragraph}>
+          各チームが交渉ポリシーを設定し、エージェントがポリシーに基づいて自動判断します。
+        </p>
+        <div className={styles.codeBlock}>
+          {`{
+  "auto_accept": true,
+  "preferred_days": ["SATURDAY", "SUNDAY"],
+  "preferred_time_slots": ["MORNING"],
+  "max_travel_minutes": 30,
+  "cost_split": "HALF",
+  "min_notice_days": 14,
+  "blackout_dates": ["2026-05-03", "2026-05-04", "2026-05-05"],
+  "auto_decline_reasons": ["HOLIDAY", "CONSECUTIVE"]
+}`}
+        </div>
+
+        <h3 className={styles.subsectionTitle}>自動交渉フロー</h3>
+        <div className={styles.codeBlock}>
+          {`1. チームA エージェント: list_available_opponents
+   → ポリシーがマッチするチーム一覧を取得
+
+2. チームA エージェント: propose_match
+   → チームBに「4/12 9:00-12:00 八部公園」を提案
+
+3. システム: チームBのポリシーと照合
+   - preferred_days に SATURDAY を含む ... OK
+   - preferred_time_slots に MORNING を含む ... OK
+   - max_travel_minutes: 八部公園はチームBから20分 ... OK
+   - min_notice_days: 14日以上先 ... OK
+   → 自動承諾
+
+4. チームA エージェント: 承諾通知を受信 → confirm_match で確定
+
+5. チームB エージェント: 確定通知を受信 → 自チームの出欠収集を開始`}
+        </div>
+      </div>
+
+      {/* Roadmap */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>ロードマップ</h2>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Phase</th>
+              <th>内容</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>Phase 1 (現在)</strong>
+              </td>
+              <td>代表が Claude Code で手動操作。MCP ツール経由で試合管理</td>
+            </tr>
+            <tr>
+              <td>Phase 2</td>
+              <td>代表が交渉ポリシーを設定。システムが候補チームを提示</td>
+            </tr>
+            <tr>
+              <td>Phase 3</td>
+              <td>相手チームに招待リンク送付。相手もシステムに登録</td>
+            </tr>
+            <tr>
+              <td>Phase 4</td>
+              <td>半自動交渉。ポリシーマッチ → 提案自動生成 → 人間承認</td>
+            </tr>
+            <tr>
+              <td>Phase 5</td>
+              <td>完全自動交渉。auto_accept=true のチーム同士は即成立</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/app/(public)/docs/api/page.tsx
+++ b/packages/web/src/app/(public)/docs/api/page.tsx
@@ -1,0 +1,718 @@
+import type { Metadata } from "next";
+import styles from "../docs.module.css";
+
+export const metadata: Metadata = {
+  title: "API リファレンス | mound",
+  description:
+    "mound REST API のエンドポイント一覧、リクエスト・レスポンス仕様",
+};
+
+function Endpoint({
+  method,
+  path,
+  description,
+  children,
+}: {
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  path: string;
+  description: string;
+  children?: React.ReactNode;
+}) {
+  const methodClass =
+    method === "GET"
+      ? styles.methodGet
+      : method === "POST"
+        ? styles.methodPost
+        : method === "PATCH"
+          ? styles.methodPatch
+          : styles.methodDelete;
+
+  return (
+    <div className={styles.endpointCard}>
+      <div className={styles.endpointHeader}>
+        <span className={`${styles.methodBadge} ${methodClass}`}>{method}</span>
+        <span className={styles.endpointPath}>{path}</span>
+      </div>
+      <div className={styles.endpointBody}>
+        <p className={styles.endpointDesc}>{description}</p>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default function ApiDocsPage() {
+  return (
+    <>
+      <h1 className={styles.pageTitle}>API リファレンス</h1>
+      <p className={styles.pageDescription}>
+        mound の REST API エンドポイント一覧です。全てのエンドポイントは JSON
+        形式でリクエスト・レスポンスを扱います。
+      </p>
+
+      {/* Authentication */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>認証</h2>
+        <p className={styles.paragraph}>
+          API へのアクセスには Supabase Auth による JWT
+          トークンが必要です。リクエストヘッダーに{" "}
+          <code className={styles.codeInline}>Authorization</code>{" "}
+          を含めてください。
+        </p>
+        <div className={styles.codeBlock}>
+          {"Authorization: Bearer <supabase-jwt-token>"}
+        </div>
+        <p className={styles.paragraph}>
+          LIFF エンドポイント（
+          <code className={styles.codeInline}>/api/liff/*</code>）は LINE
+          のアクセストークンで認証します。Cron エンドポイント（
+          <code className={styles.codeInline}>/api/cron/*</code>）は{" "}
+          <code className={styles.codeInline}>CRON_SECRET</code>{" "}
+          ヘッダーで認証します。
+        </p>
+      </div>
+
+      {/* Response format */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>レスポンス形式</h2>
+        <p className={styles.paragraph}>
+          全エンドポイントは統一された JSON
+          構造を返します。エージェントが次のアクションを自律的に判断できるよう、
+          <code className={styles.codeInline}>next_actions</code>{" "}
+          フィールドが含まれます。
+        </p>
+        <div className={styles.codeBlock}>
+          {`// 成功レスポンス
+{
+  "data": { ... },
+  "meta": {
+    "status": "COLLECTING",
+    "available_count": 7,
+    "min_players": 9
+  },
+  "next_actions": [
+    {
+      "action": "check_rsvps",
+      "reason": "2人の未回答メンバーがいます",
+      "priority": "high"
+    }
+  ]
+}
+
+// エラーレスポンス
+{
+  "error": "状態遷移が不正です: DRAFT → CONFIRMED",
+  "error_code": "INVALID_TRANSITION",
+  "next_actions": [
+    {
+      "action": "transition_game",
+      "reason": "まず COLLECTING に遷移してください",
+      "suggested_params": { "new_status": "COLLECTING" }
+    }
+  ]
+}`}
+        </div>
+      </div>
+
+      {/* Rate limiting */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>レート制限</h2>
+        <div className={styles.note}>
+          API にはレート制限が適用されます。1分あたり 60
+          リクエストを超えた場合、HTTP 429 が返されます。レスポンスヘッダーの{" "}
+          <code className={styles.codeInline}>X-RateLimit-Remaining</code>{" "}
+          で残りリクエスト数を確認できます。
+        </div>
+      </div>
+
+      {/* Games endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>試合 (Games)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/games"
+          description="新しい試合を作成します。DRAFT ステータスで作成されます。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "team_id": "uuid",
+  "title": "4/12 vs 横国さん",
+  "game_type": "FRIENDLY",       // PRACTICE | FRIENDLY | LEAGUE | TOURNAMENT
+  "game_date": "2026-04-12",     // optional
+  "start_time": "09:00",         // optional
+  "end_time": "12:00",           // optional
+  "ground_name": "八部公園野球場", // optional
+  "min_players": 9,              // default: 9
+  "rsvp_deadline": "2026-03-29T23:59:59+09:00", // optional
+  "note": "集合は8:30"           // optional
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="GET"
+          path="/api/games?team_id={id}"
+          description="チームの試合一覧を取得します。ステータスや日付でフィルタリングできます。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/games/{id}"
+          description="試合の詳細情報を取得します。出欠集計・次のアクション候補を含みます。"
+        >
+          <div className={styles.codeBlock}>
+            {`// レスポンス
+{
+  "data": {
+    "id": "uuid",
+    "title": "4/12 vs 横国さん",
+    "status": "COLLECTING",
+    "game_date": "2026-04-12",
+    "rsvp_summary": {
+      "available": 7,
+      "unavailable": 3,
+      "maybe": 2,
+      "no_response": 3
+    }
+  },
+  "next_actions": [
+    {
+      "action": "create_helper_requests",
+      "reason": "現在7人。最低9人必要。助っ人2人の打診を推奨",
+      "priority": "medium"
+    }
+  ]
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="PATCH"
+          path="/api/games/{id}"
+          description="試合情報を更新します。DRAFT ステータスの試合のみ編集可能です。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/transition"
+          description="試合のステータスを遷移させます。CONFIRMED への遷移はガバナー条件の充足が必要です。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "status": "COLLECTING",  // 遷移先ステータス
+  "version": 1,            // 楽観ロック用 (optional)
+  "actor_id": "user-uuid"
+}
+
+// 許可される遷移:
+// DRAFT → COLLECTING | CONFIRMED | CANCELLED
+// COLLECTING → CONFIRMED | CANCELLED
+// CONFIRMED → COMPLETED | CANCELLED
+// COMPLETED → SETTLED`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/validate"
+          description="試合が確定 (CONFIRMED) 条件を満たしているか検証します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// レスポンス
+{
+  "data": {
+    "can_confirm": false,
+    "checks": {
+      "min_players_met": false,
+      "has_ground": true,
+      "has_opponent": true,
+      "has_game_date": true
+    },
+    "available_count": 7,
+    "min_players": 9
+  },
+  "next_actions": [
+    {
+      "action": "create_helper_requests",
+      "reason": "あと2人必要です",
+      "priority": "high"
+    }
+  ]
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* RSVP endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>出欠 (RSVPs)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/rsvps"
+          description="全メンバーに出欠確認を送信します。各メンバーに RSVP レコードが作成されます。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/games/{id}/rsvps"
+          description="出欠回答の一覧と集計を取得します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// レスポンス
+{
+  "data": [
+    {
+      "id": "uuid",
+      "member_id": "uuid",
+      "member_name": "田中",
+      "response": "AVAILABLE",
+      "responded_at": "2026-03-20T10:00:00+09:00",
+      "response_channel": "LINE"
+    }
+  ],
+  "meta": {
+    "available": 7,
+    "unavailable": 3,
+    "maybe": 2,
+    "no_response": 3,
+    "total": 15
+  }
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="PATCH"
+          path="/api/rsvps/{id}"
+          description="出欠回答を登録・更新します。AVAILABLE / UNAVAILABLE / MAYBE のいずれか。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "response": "AVAILABLE",          // AVAILABLE | UNAVAILABLE | MAYBE
+  "channel": "LINE"                 // APP | LINE | EMAIL | WEB
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* Helper endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>助っ人 (Helpers)</h2>
+
+        <Endpoint
+          method="GET"
+          path="/api/helpers?team_id={id}"
+          description="チームに登録されている助っ人候補の一覧を取得します。信頼度順でソートされます。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/helper-requests"
+          description="助っ人に参加依頼を送信します。複数の助っ人を一括で依頼できます。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "helper_ids": ["uuid-1", "uuid-2"],
+  "message": "4/12の試合、助っ人お願いできますか？",  // optional
+  "actor_id": "user-uuid"
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="PATCH"
+          path="/api/helper-requests/{id}"
+          description="助っ人打診の回答を更新します。充足時は未回答の打診を自動キャンセルします。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "status": "ACCEPTED"  // ACCEPTED | DECLINED | CANCELLED
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* Negotiation endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>対戦交渉 (Negotiations)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/negotiations"
+          description="相手チームとの対戦交渉を開始します。候補日を提示して交渉を作成します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "opponent_team_id": "uuid",
+  "proposed_dates": ["2026-04-12", "2026-04-19"],
+  "message": "4月に練習試合をお願いできますか？",  // optional
+  "actor_id": "user-uuid"
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="GET"
+          path="/api/games/{id}/negotiations"
+          description="試合に関連する対戦交渉の一覧を取得します。"
+        />
+
+        <Endpoint
+          method="PATCH"
+          path="/api/negotiations/{id}"
+          description="交渉のステータスを更新します。SENT → REPLIED → ACCEPTED / DECLINED の順に進みます。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "status": "ACCEPTED",           // SENT | REPLIED | ACCEPTED | DECLINED | CANCELLED
+  "reply_message": "4/12で承りました",  // optional
+  "cancel_reason": null           // optional
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* Settlement endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>精算 (Settlement)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/expenses"
+          description="試合の費用を登録します。グラウンド代・審判代・ボール代などを追加します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "category": "GROUND",           // GROUND | UMPIRE | BALL | DRINK | TOURNAMENT_FEE | OTHER
+  "amount": 5000,                 // 金額 (円)
+  "paid_by": "member-uuid",       // 立替者 (optional)
+  "split_with_opponent": true,    // 相手チームと折半 (default: false)
+  "note": "グラウンド使用料"       // optional
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="GET"
+          path="/api/games/{id}/expenses"
+          description="試合に登録されている費用の一覧を取得します。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/settlement"
+          description="精算を計算します。参加者ごとの支払い額を算出します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// レスポンス
+{
+  "data": {
+    "total_cost": 10000,
+    "opponent_share": 2500,
+    "team_cost": 7500,
+    "member_count": 10,
+    "per_member": 750,
+    "status": "DRAFT"
+  }
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/settlement/notify"
+          description="精算結果をメンバーに通知します。PayPay 送金リンクを含みます。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/settlement/complete"
+          description="精算を完了としてマークします。"
+        />
+      </div>
+
+      {/* Results endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>試合結果 (Results)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/games/{id}/results"
+          description="試合結果を記録します。スコア、打撃成績、投手成績を登録します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "our_score": 5,
+  "opponent_score": 3,
+  "innings": 7,
+  "note": "好ゲーム"
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* Team endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>チーム (Teams)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/teams"
+          description="新しいチームを作成します。作成者が自動的にオーナーになります。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/teams"
+          description="ログインユーザーが所属するチームの一覧を取得します。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/teams/{id}/members"
+          description="チームメンバーの一覧を取得します。出席率付き。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/teams/{id}/opponents"
+          description="登録済みの対戦相手チーム一覧を取得します。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/teams/{id}/stats"
+          description="チームの成績統計を取得します。勝敗数、個人打率ランキングなど。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/teams/{id}/calendar"
+          description="チームの試合カレンダーを取得します。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/teams/{id}/policy"
+          description="チームの交渉ポリシーを取得します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// レスポンス
+{
+  "data": {
+    "auto_accept": false,
+    "preferred_days": ["SATURDAY", "SUNDAY"],
+    "preferred_time_slots": ["MORNING"],
+    "max_travel_minutes": 30,
+    "min_notice_days": 14,
+    "blackout_dates": ["2026-05-03", "2026-05-04"]
+  }
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* Notification endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>通知 (Notifications)</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/notifications/send"
+          description="通知を送信します。LINE Push / メール / プッシュ通知のチャネルを指定できます。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/notifications/remind"
+          description="未回答メンバーにリマインド通知を送信します。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/notifications/history"
+          description="通知履歴を取得します。"
+        />
+      </div>
+
+      {/* AI endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>AI 機能</h2>
+
+        <Endpoint
+          method="POST"
+          path="/api/ai/predict-attendance"
+          description="メンバーの出欠を予測します。過去の出席率・曜日・天候などを考慮します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{ "game_id": "uuid" }
+
+// レスポンス
+{
+  "data": {
+    "predictions": [
+      {
+        "member_id": "uuid",
+        "name": "田中",
+        "probability": 0.85,
+        "factors": ["高い出席率", "土曜午前は参加傾向"]
+      }
+    ],
+    "expected_count": 11
+  }
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="POST"
+          path="/api/ai/recommend-helpers"
+          description="試合に適した助っ人を推薦します。信頼度・過去実績・ポジション適性を考慮します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{ "game_id": "uuid" }
+
+// レスポンス
+{
+  "data": {
+    "recommendations": [
+      {
+        "helper_id": "uuid",
+        "name": "佐藤",
+        "score": 0.92,
+        "reasons": ["信頼度が高い", "キャッチャー経験あり"]
+      }
+    ],
+    "needed_count": 2
+  }
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="POST"
+          path="/api/ai/generate-message"
+          description="対戦交渉用のメッセージを AI が生成します。相手チーム情報・候補日を考慮します。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{
+  "game_id": "uuid",
+  "opponent_team_id": "uuid"
+}
+
+// レスポンス
+{
+  "data": {
+    "message": "○○チーム ご担当者様\\n\\n4月に練習試合をお願いできればと..."
+  }
+}`}
+          </div>
+        </Endpoint>
+
+        <Endpoint
+          method="POST"
+          path="/api/ai/weekly-report"
+          description="チームの週次レポートを生成します。今週の試合予定・出欠状況・ToDo をまとめます。"
+        >
+          <div className={styles.codeBlock}>
+            {`// リクエスト
+{ "team_id": "uuid" }
+
+// レスポンス
+{
+  "data": {
+    "report": "## 今週のサマリー\\n- 4/12 vs 横国さん: 出欠回収中 (7/15)..."
+  }
+}`}
+          </div>
+        </Endpoint>
+      </div>
+
+      {/* LIFF endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>LIFF (LINE連携)</h2>
+        <p className={styles.paragraph}>
+          LINE LIFF アプリ向けのエンドポイントです。LINE
+          のアクセストークンで認証します。
+        </p>
+
+        <Endpoint
+          method="POST"
+          path="/api/liff/verify"
+          description="LIFF トークンを検証し、ユーザー情報を返します。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/liff/register"
+          description="LINE ユーザーをシステムに登録します。"
+        />
+
+        <Endpoint
+          method="GET"
+          path="/api/liff/games/{id}/my-rsvp"
+          description="LINE ユーザーの出欠回答状況を取得します。"
+        />
+      </div>
+
+      {/* Cron endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>Cron ジョブ</h2>
+        <p className={styles.paragraph}>
+          定期実行されるバックグラウンド処理です。
+          <code className={styles.codeInline}>CRON_SECRET</code>{" "}
+          ヘッダーによる認証が必要です。
+        </p>
+
+        <Endpoint
+          method="POST"
+          path="/api/cron/process-deadlines"
+          description="出欠締切が到来した試合を処理します。未回答を NO_RESPONSE に確定し、状態を遷移させます。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/cron/send-reminders"
+          description="出欠未回答のメンバーにリマインド通知を送信します。締切の 72h/48h/24h 前に段階的に送信します。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/cron/check-fulfillment"
+          description="助っ人の充足状況をチェックします。人数が揃った場合、未回答の打診を自動キャンセルします。"
+        />
+      </div>
+
+      {/* Grounds endpoints */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>グラウンド (Grounds)</h2>
+
+        <Endpoint
+          method="GET"
+          path="/api/grounds/{id}/slots"
+          description="グラウンドの空き状況を取得します。スロット単位 (MORNING / AFTERNOON / EVENING) で返します。"
+        />
+
+        <Endpoint
+          method="POST"
+          path="/api/grounds/webhook"
+          description="グラウンド予約サイトからのウェブフック。空き状況の変更を受信します。"
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/app/(public)/docs/docs.module.css
+++ b/packages/web/src/app/(public)/docs/docs.module.css
@@ -1,0 +1,331 @@
+.pageTitle {
+  font-size: 28px;
+  font-weight: 700;
+  color: #16191f;
+  margin: 0 0 8px;
+}
+
+.pageDescription {
+  font-size: 15px;
+  color: #5f6b7a;
+  margin: 0 0 40px;
+  line-height: 1.6;
+}
+
+.section {
+  margin-bottom: 40px;
+}
+
+.sectionTitle {
+  font-size: 20px;
+  font-weight: 700;
+  color: #16191f;
+  margin: 0 0 16px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e9ebed;
+}
+
+.subsectionTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #16191f;
+  margin: 24px 0 12px;
+}
+
+.paragraph {
+  font-size: 14px;
+  line-height: 1.8;
+  color: #414750;
+  margin: 0 0 12px;
+}
+
+.codeBlock {
+  background: #1a1a2e;
+  color: #e0e0e0;
+  border-radius: 8px;
+  padding: 16px 20px;
+  overflow-x: auto;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 12px 0 16px;
+}
+
+.codeInline {
+  background: #f0f2f4;
+  color: #d63384;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 12px;
+}
+
+.codeComment {
+  color: #6a9955;
+}
+
+.codeKeyword {
+  color: #569cd6;
+}
+
+.codeString {
+  color: #ce9178;
+}
+
+.codeNumber {
+  color: #b5cea8;
+}
+
+.endpointCard {
+  border: 1px solid #d5dbdb;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.endpointHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #fafafa;
+  border-bottom: 1px solid #e9ebed;
+}
+
+.methodBadge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  min-width: 52px;
+  text-align: center;
+}
+
+.methodGet {
+  background: #e6f4ea;
+  color: #137333;
+}
+
+.methodPost {
+  background: #e3f0fd;
+  color: #0972d3;
+}
+
+.methodPatch {
+  background: #fef3e0;
+  color: #b06000;
+}
+
+.methodDelete {
+  background: #fce8e6;
+  color: #c5221f;
+}
+
+.endpointPath {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 14px;
+  color: #16191f;
+  font-weight: 500;
+}
+
+.endpointBody {
+  padding: 16px;
+}
+
+.endpointDesc {
+  font-size: 14px;
+  color: #414750;
+  margin: 0 0 8px;
+  line-height: 1.6;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 12px 0 16px;
+  font-size: 13px;
+}
+
+.table th {
+  text-align: left;
+  padding: 8px 12px;
+  background: #fafafa;
+  border: 1px solid #e9ebed;
+  font-weight: 600;
+  color: #16191f;
+}
+
+.table td {
+  padding: 8px 12px;
+  border: 1px solid #e9ebed;
+  color: #414750;
+  line-height: 1.5;
+}
+
+.featureCard {
+  border: 1px solid #d5dbdb;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 16px;
+  transition: box-shadow 0.15s;
+}
+
+.featureCard:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.featureCardTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #16191f;
+  margin: 0 0 8px;
+}
+
+.featureCardDesc {
+  font-size: 14px;
+  color: #414750;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.linkCard {
+  display: block;
+  border: 1px solid #d5dbdb;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.linkCard:hover {
+  border-color: #0972d3;
+  box-shadow: 0 2px 8px rgba(9, 114, 211, 0.1);
+}
+
+.linkCardTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #0972d3;
+  margin: 0 0 4px;
+}
+
+.linkCardDesc {
+  font-size: 14px;
+  color: #5f6b7a;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 8px;
+}
+
+.badgeRequired {
+  background: #fce8e6;
+  color: #c5221f;
+}
+
+.badgeOptional {
+  background: #e9ebed;
+  color: #5f6b7a;
+}
+
+.list {
+  padding-left: 24px;
+  margin: 8px 0 16px;
+}
+
+.list li {
+  font-size: 14px;
+  line-height: 2;
+  color: #414750;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.statusFlow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 12px 0 16px;
+}
+
+.statusNode {
+  background: #e3f0fd;
+  color: #0972d3;
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.statusArrow {
+  color: #8d9daa;
+  font-size: 16px;
+}
+
+.note {
+  background: #fef3e0;
+  border-left: 4px solid #f89c24;
+  padding: 12px 16px;
+  border-radius: 0 8px 8px 0;
+  margin: 12px 0 16px;
+  font-size: 14px;
+  color: #414750;
+  line-height: 1.6;
+}
+
+.info {
+  background: #e3f0fd;
+  border-left: 4px solid #0972d3;
+  padding: 12px 16px;
+  border-radius: 0 8px 8px 0;
+  margin: 12px 0 16px;
+  font-size: 14px;
+  color: #414750;
+  line-height: 1.6;
+}
+
+.techStack {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.techItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  background: #fafafa;
+  border-radius: 8px;
+  border: 1px solid #e9ebed;
+}
+
+.techLabel {
+  font-size: 13px;
+  color: #5f6b7a;
+}
+
+.techValue {
+  font-size: 14px;
+  font-weight: 600;
+  color: #16191f;
+}

--- a/packages/web/src/app/(public)/docs/layout.module.css
+++ b/packages/web/src/app/(public)/docs/layout.module.css
@@ -1,0 +1,113 @@
+.docsLayout {
+  display: flex;
+  min-height: calc(100vh - 56px);
+}
+
+.sidebar {
+  width: 260px;
+  flex-shrink: 0;
+  background: #fafafa;
+  border-right: 1px solid #d5dbdb;
+  padding: 24px 0;
+  position: sticky;
+  top: 56px;
+  height: calc(100vh - 56px);
+  overflow-y: auto;
+}
+
+.sidebarTitle {
+  font-size: 12px;
+  font-weight: 700;
+  color: #5f6b7a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0 20px;
+  margin: 0 0 8px;
+}
+
+.sidebarSection {
+  margin-bottom: 24px;
+}
+
+.sidebarLink {
+  display: block;
+  padding: 8px 20px;
+  font-size: 14px;
+  color: #414750;
+  text-decoration: none;
+  line-height: 1.4;
+  transition: background 0.15s, color 0.15s;
+}
+
+.sidebarLink:hover {
+  background: #e9ebed;
+  color: #0972d3;
+}
+
+.sidebarLinkActive {
+  display: block;
+  padding: 8px 20px;
+  font-size: 14px;
+  text-decoration: none;
+  line-height: 1.4;
+  background: #e3f0fd;
+  color: #0972d3;
+  font-weight: 600;
+  border-right: 3px solid #0972d3;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  padding: 40px 48px;
+  max-width: 960px;
+}
+
+.mobileNav {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .docsLayout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .mobileNav {
+    display: block;
+    background: #fafafa;
+    border-bottom: 1px solid #d5dbdb;
+    padding: 12px 16px;
+  }
+
+  .mobileNavToggle {
+    background: none;
+    border: 1px solid #d5dbdb;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 14px;
+    color: #414750;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+  }
+
+  .mobileNavLinks {
+    margin-top: 8px;
+  }
+
+  .mobileNavLinks a {
+    display: block;
+    padding: 8px 0;
+    font-size: 14px;
+    color: #414750;
+    text-decoration: none;
+  }
+
+  .content {
+    padding: 24px 16px;
+  }
+}

--- a/packages/web/src/app/(public)/docs/layout.tsx
+++ b/packages/web/src/app/(public)/docs/layout.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import styles from "./layout.module.css";
+
+const NAV_SECTIONS = [
+  {
+    title: "ドキュメント",
+    links: [
+      { href: "/docs", label: "概要" },
+      { href: "/docs/api", label: "API リファレンス" },
+      { href: "/docs/ai", label: "AI エージェント" },
+    ],
+  },
+];
+
+export default function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className={styles.docsLayout}>
+      {/* Desktop sidebar */}
+      <nav className={styles.sidebar}>
+        {NAV_SECTIONS.map((section) => (
+          <div key={section.title} className={styles.sidebarSection}>
+            <div className={styles.sidebarTitle}>{section.title}</div>
+            {section.links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={
+                  pathname === link.href
+                    ? styles.sidebarLinkActive
+                    : styles.sidebarLink
+                }
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        ))}
+      </nav>
+
+      {/* Mobile nav */}
+      <div className={styles.mobileNav}>
+        <button
+          type="button"
+          className={styles.mobileNavToggle}
+          onClick={() => setMobileOpen(!mobileOpen)}
+        >
+          {mobileOpen ? "メニューを閉じる" : "ドキュメントメニュー"}
+        </button>
+        {mobileOpen && (
+          <div className={styles.mobileNavLinks}>
+            {NAV_SECTIONS.flatMap((section) =>
+              section.links.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => setMobileOpen(false)}
+                >
+                  {link.label}
+                </Link>
+              )),
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Main content */}
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+}

--- a/packages/web/src/app/(public)/docs/page.tsx
+++ b/packages/web/src/app/(public)/docs/page.tsx
@@ -1,0 +1,408 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import styles from "./docs.module.css";
+
+export const metadata: Metadata = {
+  title: "開発者ドキュメント | mound",
+  description:
+    "mound の開発者向けドキュメント。アーキテクチャ、データモデル、API リファレンス、AI エージェント連携について。",
+};
+
+export default function DocsPage() {
+  return (
+    <>
+      <h1 className={styles.pageTitle}>開発者ドキュメント</h1>
+      <p className={styles.pageDescription}>
+        mound は草野球チーム向けの試合成立エンジン SaaS
+        です。このドキュメントでは、システムの技術的な構成と開発に必要な情報を提供します。
+      </p>
+
+      {/* Quick links */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>ドキュメント</h2>
+        <div className={styles.grid}>
+          <Link href="/docs/api" className={styles.linkCard}>
+            <div className={styles.linkCardTitle}>API リファレンス</div>
+            <p className={styles.linkCardDesc}>
+              REST API
+              エンドポイントの一覧、リクエスト・レスポンス仕様、認証方法について。
+            </p>
+          </Link>
+          <Link href="/docs/ai" className={styles.linkCard}>
+            <div className={styles.linkCardTitle}>AI エージェント</div>
+            <p className={styles.linkCardDesc}>
+              MCP サーバー連携、AI
+              機能（出欠予測・助っ人推薦・メッセージ生成）の解説。
+            </p>
+          </Link>
+        </div>
+      </div>
+
+      {/* Architecture */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>アーキテクチャ</h2>
+        <p className={styles.paragraph}>
+          mound
+          は「試合を組む」という業務ループをシステム化したものです。代表は試合を作成するだけで、出欠通知、段階的リマインド、人数判定、助っ人打診、精算計算までシステムが自動で回します。
+        </p>
+        <div className={styles.info}>
+          <strong>設計原則:</strong> AI は提案する (Planner) /
+          システムは状態を持つ (State Machine) / ルールエンジンが暴走を防ぐ
+          (Governor) / 人が最後に承認する
+        </div>
+
+        <h3 className={styles.subsectionTitle}>状態遷移</h3>
+        <p className={styles.paragraph}>
+          試合は以下のステータスを順に遷移します。CONFIRMED
+          への遷移はガバナー条件を満たす必要があります。
+        </p>
+        <div className={styles.statusFlow}>
+          <span className={styles.statusNode}>DRAFT</span>
+          <span className={styles.statusArrow}>&rarr;</span>
+          <span className={styles.statusNode}>COLLECTING</span>
+          <span className={styles.statusArrow}>&rarr;</span>
+          <span className={styles.statusNode}>CONFIRMED</span>
+          <span className={styles.statusArrow}>&rarr;</span>
+          <span className={styles.statusNode}>COMPLETED</span>
+          <span className={styles.statusArrow}>&rarr;</span>
+          <span className={styles.statusNode}>SETTLED</span>
+        </div>
+        <p className={styles.paragraph}>
+          どの段階からも <code className={styles.codeInline}>CANCELLED</code>{" "}
+          への遷移が可能です（COMPLETED / SETTLED を除く）。
+        </p>
+
+        <h3 className={styles.subsectionTitle}>システム構成</h3>
+        <div className={styles.codeBlock}>
+          {`packages/
+  core/         # ドメインロジック (state-machine, governor, ai-service)
+  web/          # Next.js App Router (API Routes + フロントエンド)
+  mcp/          # MCP サーバー (Claude Desktop 連携)
+
+代表 → Claude Code / Web UI → API Routes → Core ロジック → Supabase DB
+                                  ↕
+                            MCP Server → Claude Desktop / Cursor`}
+        </div>
+      </div>
+
+      {/* Data model */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>データモデル</h2>
+        <p className={styles.paragraph}>
+          主要なテーブルとリレーションの概要です。
+        </p>
+        <div className={styles.codeBlock}>
+          {`teams
+  ├──< members          チーム → メンバー
+  ├──< helpers           チーム → 助っ人候補
+  ├──< opponent_teams    チーム → 対戦相手
+  ├──< grounds           チーム → グラウンド
+  └──< games             チーム → 試合
+
+games
+  ├──< rsvps             試合 → 出欠回答
+  ├──< helper_requests   試合 → 助っ人打診
+  ├──< negotiations      試合 → 対戦交渉
+  ├──< expenses          試合 → 費用
+  └──  settlements       試合 → 精算サマリー`}
+        </div>
+
+        <h3 className={styles.subsectionTitle}>主要テーブル</h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>テーブル</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>teams</code>
+              </td>
+              <td>チーム情報。代表が管理し、設定情報を保持</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>members</code>
+              </td>
+              <td>チームの正規メンバー。出席率・ドタキャン率を自動計算</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>games</code>
+              </td>
+              <td>試合/練習イベント。状態遷移エンジンで管理</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>rsvps</code>
+              </td>
+              <td>出欠回答。メンバーごとに AVAILABLE / UNAVAILABLE / MAYBE</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>helpers</code>
+              </td>
+              <td>助っ人候補。信頼度スコア付き</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>helper_requests</code>
+              </td>
+              <td>助っ人への打診。充足時に未回答分を自動キャンセル</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>negotiations</code>
+              </td>
+              <td>対戦交渉。提案日 → 回答 → 承諾/辞退の追跡</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>expenses</code> /{" "}
+                <code className={styles.codeInline}>settlements</code>
+              </td>
+              <td>費用記録と精算計算。PayPay 連携による送金</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>grounds</code> /{" "}
+                <code className={styles.codeInline}>ground_slots</code>
+              </td>
+              <td>グラウンド情報と空き状況の監視</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>at_bats</code> /{" "}
+                <code className={styles.codeInline}>pitching_stats</code>
+              </td>
+              <td>個人打撃・投手成績の記録と自動集計</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Tech stack */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>技術スタック</h2>
+        <div className={styles.techStack}>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>フレームワーク</div>
+              <div className={styles.techValue}>Next.js (App Router)</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>言語</div>
+              <div className={styles.techValue}>TypeScript (strict)</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>データベース</div>
+              <div className={styles.techValue}>Supabase (PostgreSQL)</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>認証</div>
+              <div className={styles.techValue}>Supabase Auth</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>ランタイム</div>
+              <div className={styles.techValue}>Bun</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>UI</div>
+              <div className={styles.techValue}>Cloudscape Design System</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>バリデーション</div>
+              <div className={styles.techValue}>Zod</div>
+            </div>
+          </div>
+          <div className={styles.techItem}>
+            <div>
+              <div className={styles.techLabel}>デプロイ</div>
+              <div className={styles.techValue}>Vercel + Supabase</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Getting started */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>開発環境のセットアップ</h2>
+
+        <h3 className={styles.subsectionTitle}>前提条件</h3>
+        <ul className={styles.list}>
+          <li>Bun (v1.0 以上)</li>
+          <li>Node.js (v18 以上)</li>
+          <li>Supabase CLI (ローカル開発用)</li>
+        </ul>
+
+        <h3 className={styles.subsectionTitle}>セットアップ手順</h3>
+        <div className={styles.codeBlock}>
+          {`# リポジトリをクローン
+git clone https://github.com/your-org/mound.git
+cd mound
+
+# 依存関係のインストール
+bun install
+
+# 環境変数を設定
+cp .env.example .env.local
+
+# 開発サーバーを起動
+make start
+
+# lint + 型チェック + テスト
+make check`}
+        </div>
+
+        <h3 className={styles.subsectionTitle}>環境変数</h3>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>変数名</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>
+                  NEXT_PUBLIC_SUPABASE_URL
+                </code>
+              </td>
+              <td>Supabase プロジェクト URL</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>
+                  NEXT_PUBLIC_SUPABASE_ANON_KEY
+                </code>
+              </td>
+              <td>Supabase 匿名キー</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>
+                  SUPABASE_SERVICE_ROLE_KEY
+                </code>
+              </td>
+              <td>Supabase サービスロールキー (サーバーサイド用)</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>NEXT_PUBLIC_LIFF_ID</code>
+              </td>
+              <td>LINE LIFF アプリケーション ID</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>
+                  LINE_CHANNEL_ACCESS_TOKEN
+                </code>
+              </td>
+              <td>LINE Messaging API アクセストークン</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>CRON_SECRET</code>
+              </td>
+              <td>Cron エンドポイントの認証シークレット</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3 className={styles.subsectionTitle}>利用可能なコマンド</h3>
+        <div className={styles.codeBlock}>
+          {`make check          # lint + 型チェック + テスト (変更後に必ず実行)
+make lint-fix       # lint の自動修正
+make test           # テスト実行
+make start          # 開発サーバー起動
+make help           # 全コマンド一覧`}
+        </div>
+      </div>
+
+      {/* Core modules */}
+      <div className={styles.section}>
+        <h2 className={styles.sectionTitle}>コアモジュール</h2>
+        <p className={styles.paragraph}>
+          ビジネスロジックは{" "}
+          <code className={styles.codeInline}>packages/core/src/lib/</code>{" "}
+          に集約されています。
+        </p>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>モジュール</th>
+              <th>説明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>state-machine.ts</code>
+              </td>
+              <td>
+                試合・交渉・助っ人打診のステートマシン。許可される遷移を定義
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>governor.ts</code>
+              </td>
+              <td>
+                成立条件の判定エンジン。CONFIRMED 遷移時のガード条件をチェック
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>ai-service.ts</code>
+              </td>
+              <td>
+                AI 機能 (出欠予測、助っ人推薦、メッセージ生成、週次レポート)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>negotiation-policy.ts</code>
+              </td>
+              <td>対戦交渉ポリシーの評価。自動承諾/辞退の判定</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>
+                  notification-dispatcher.ts
+                </code>
+              </td>
+              <td>通知配信。LINE Push / メール / プッシュ通知のチャネル制御</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>stats.ts</code>
+              </td>
+              <td>個人成績の計算。打率・防御率・OPS 等の自動集計</td>
+            </tr>
+            <tr>
+              <td>
+                <code className={styles.codeInline}>paypay.ts</code>
+              </td>
+              <td>PayPay 連携。精算時の送金リンク生成</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- `/docs` — 開発者リファレンス (アーキテクチャ、状態マシン、環境構築手順)
- `/docs/api` — API リファレンス (35+ エンドポイント、リクエスト/レスポンス例)
- `/docs/ai` — AI エージェント機能説明 (MCP ツール16個、エージェントプロトコル)
- サイドバーナビ付きドキュメントレイアウト

Closes #78

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n