### PR TITLE
feat: Modal + Gemma AI対応 & LPコピーをペイン訴求にリライト

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -198,6 +198,14 @@ export type {
   NegotiationMessageContext,
 } from "./lib/ai-service";
 
+// Modal AI Service
+export {
+  predictAttendanceModal,
+  recommendHelpersModal,
+  generateNegotiationMessageModal,
+  generateWeeklyReportModal,
+} from "./lib/modal-ai-service";
+
 // LINE Messaging
 export {
   pushMessage,

--- a/packages/core/src/lib/ai-service.ts
+++ b/packages/core/src/lib/ai-service.ts
@@ -1,8 +1,20 @@
 // ============================================================
 // AI サービス — Claude API を利用した各種 AI 機能
+// AI_PROVIDER=modal の場合は Modal (Gemma 4) に委譲
 // ============================================================
 
+import {
+  generateNegotiationMessageModal,
+  generateWeeklyReportModal,
+  predictAttendanceModal,
+  recommendHelpersModal,
+} from "./modal-ai-service";
+
 const MODEL = "claude-sonnet-4-20250514";
+
+function useModal(): boolean {
+  return process.env.AI_PROVIDER === "modal";
+}
 
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import for optional dependency
 function createAnthropicClient(): any | null {
@@ -73,6 +85,8 @@ export async function predictAttendance(
   member: PredictAttendanceInput,
   game: PredictAttendanceGameInput,
 ): Promise<AttendancePrediction> {
+  if (useModal()) return predictAttendanceModal(member, game);
+
   const fallback: AttendancePrediction = {
     probability: member.attendance_rate,
     reasoning:
@@ -122,6 +136,8 @@ export async function recommendHelpers(
   helpers: RecommendHelpersInput[],
   needed: number,
 ): Promise<HelperRecommendation[]> {
+  if (useModal()) return recommendHelpersModal(helpers, needed);
+
   const fallback: HelperRecommendation[] = helpers
     .sort((a, b) => b.reliability_score - a.reliability_score)
     .slice(0, needed)
@@ -174,6 +190,8 @@ JSON配列で回答してください（他のテキストは不要）:
 export async function generateNegotiationMessage(
   context: NegotiationMessageContext,
 ): Promise<string> {
+  if (useModal()) return generateNegotiationMessageModal(context);
+
   const fallback = `${context.opponent_name} 御中\n\nいつもお世話になっております。${context.team_name}です。\n下記の日程で試合をお願いできませんでしょうか。\n\n候補日:\n${context.proposed_dates.map((d) => `・${d}`).join("\n")}${context.ground_name ? `\n\n会場: ${context.ground_name}` : ""}\n\nご検討のほどよろしくお願いいたします。`;
 
   const client = createAnthropicClient();
@@ -212,6 +230,8 @@ ${context.ground_name ? `会場: ${context.ground_name}` : "会場: 未定"}
 export async function generateWeeklyReport(
   games: WeeklyReportGameInput[],
 ): Promise<string> {
+  if (useModal()) return generateWeeklyReportModal(games);
+
   if (games.length === 0) {
     return "今週の試合予定はありません。";
   }

--- a/packages/core/src/lib/modal-ai-service.ts
+++ b/packages/core/src/lib/modal-ai-service.ts
@@ -1,0 +1,209 @@
+// ============================================================
+// Modal AI サービス — Gemma 4 モデルを Modal 上で実行
+// OpenAI-compatible API を使用
+// ============================================================
+
+import type {
+  AttendancePrediction,
+  HelperRecommendation,
+  NegotiationMessageContext,
+  PredictAttendanceGameInput,
+  PredictAttendanceInput,
+  RecommendHelpersInput,
+  WeeklyReportGameInput,
+} from "./ai-service";
+
+const MODAL_MODEL = "gemma-4";
+
+interface ModalConfig {
+  apiUrl: string;
+  apiKey: string;
+}
+
+function getModalConfig(): ModalConfig | null {
+  const apiUrl = process.env.MODAL_API_URL;
+  if (!apiUrl) return null;
+  const apiKey = process.env.MODAL_API_KEY;
+  return { apiUrl, apiKey: apiKey ?? "" };
+}
+
+async function callModal(
+  prompt: string,
+  systemPrompt?: string,
+): Promise<string | null> {
+  const config = getModalConfig();
+  if (!config) return null;
+
+  const res = await fetch(`${config.apiUrl}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      model: MODAL_MODEL,
+      messages: [
+        ...(systemPrompt
+          ? [{ role: "system" as const, content: systemPrompt }]
+          : []),
+        { role: "user" as const, content: prompt },
+      ],
+      temperature: 0.7,
+      max_tokens: 1024,
+    }),
+  });
+
+  if (!res.ok) return null;
+  const data = (await res.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  return data.choices?.[0]?.message?.content ?? null;
+}
+
+// --- 公開関数 ---
+
+/**
+ * メンバーの出欠予測を行う (Modal / Gemma 4)
+ */
+export async function predictAttendanceModal(
+  member: PredictAttendanceInput,
+  game: PredictAttendanceGameInput,
+): Promise<AttendancePrediction> {
+  const fallback: AttendancePrediction = {
+    probability: member.attendance_rate,
+    reasoning:
+      "AI分析が利用できないため、過去の出席率をそのまま使用しています。",
+  };
+
+  const prompt = `あなたは草野球チームの出欠予測AIです。以下の情報から、このメンバーが試合に参加する確率を予測してください。
+
+メンバー: ${member.name}
+過去の出席率: ${(member.attendance_rate * 100).toFixed(1)}%
+無断欠席率: ${(member.no_show_rate * 100).toFixed(1)}%
+試合日: ${game.game_date ?? "未定"}
+試合種別: ${game.game_type}
+
+JSON形式で回答してください（他のテキストは不要）:
+{"probability": 0.0〜1.0の数値, "reasoning": "理由の説明"}`;
+
+  try {
+    const text = await callModal(prompt);
+    if (!text) return fallback;
+
+    const parsed = JSON.parse(text) as AttendancePrediction;
+    return {
+      probability: Math.max(0, Math.min(1, parsed.probability)),
+      reasoning: parsed.reasoning,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * 助っ人の推薦を行う (Modal / Gemma 4)
+ */
+export async function recommendHelpersModal(
+  helpers: RecommendHelpersInput[],
+  needed: number,
+): Promise<HelperRecommendation[]> {
+  const fallback: HelperRecommendation[] = helpers
+    .sort((a, b) => b.reliability_score - a.reliability_score)
+    .slice(0, needed)
+    .map((h) => ({
+      helper_id: h.id,
+      reason: `信頼度スコア: ${h.reliability_score}、過去の助っ人回数: ${h.times_helped}回`,
+    }));
+
+  const helperList = helpers
+    .map(
+      (h) =>
+        `- ID: ${h.id}, 名前: ${h.name}, 信頼度: ${h.reliability_score}, 助っ人回数: ${h.times_helped}回`,
+    )
+    .join("\n");
+
+  const prompt = `あなたは草野球チームの助っ人推薦AIです。以下の助っ人候補から、${needed}人を推薦してください。
+信頼度スコアと過去の貢献回数を考慮してください。
+
+助っ人候補:
+${helperList}
+
+JSON配列で回答してください（他のテキストは不要）:
+[{"helper_id": "ID", "reason": "推薦理由"}]`;
+
+  try {
+    const text = await callModal(prompt);
+    if (!text) return fallback;
+
+    const parsed = JSON.parse(text) as HelperRecommendation[];
+    return parsed.slice(0, needed);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * 対戦交渉メッセージを生成する (Modal / Gemma 4)
+ */
+export async function generateNegotiationMessageModal(
+  context: NegotiationMessageContext,
+): Promise<string> {
+  const fallback = `${context.opponent_name} 御中\n\nいつもお世話になっております。${context.team_name}です。\n下記の日程で試合をお願いできませんでしょうか。\n\n候補日:\n${context.proposed_dates.map((d) => `・${d}`).join("\n")}${context.ground_name ? `\n\n会場: ${context.ground_name}` : ""}\n\nご検討のほどよろしくお願いいたします。`;
+
+  const prompt = `あなたは草野球チームの連絡担当AIです。対戦相手に送る丁寧な交渉メッセージを日本語で作成してください。
+
+自チーム名: ${context.team_name}
+相手チーム名: ${context.opponent_name}
+候補日程: ${context.proposed_dates.join(", ")}
+${context.ground_name ? `会場: ${context.ground_name}` : "会場: 未定"}
+
+メッセージ本文のみを返してください（JSON不要）。丁寧で簡潔な文章にしてください。`;
+
+  try {
+    const text = await callModal(prompt);
+    if (!text) return fallback;
+    return text.trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * 週次レポートを生成する (Modal / Gemma 4)
+ */
+export async function generateWeeklyReportModal(
+  games: WeeklyReportGameInput[],
+): Promise<string> {
+  if (games.length === 0) {
+    return "今週の試合予定はありません。";
+  }
+
+  const fallback = games
+    .map(
+      (g) =>
+        `・${g.title}（${g.game_date ?? "日程未定"}）: ${g.status} — 参加${g.available_count}/${g.min_players}人`,
+    )
+    .join("\n");
+
+  const gameList = games
+    .map(
+      (g) =>
+        `- ${g.title}: 日程=${g.game_date ?? "未定"}, 状態=${g.status}, 参加可能=${g.available_count}人, 最低人数=${g.min_players}人`,
+    )
+    .join("\n");
+
+  const prompt = `あなたは草野球チームのマネージャーAIです。以下の試合情報をもとに、チームメンバー向けの週次サマリーレポートを日本語で作成してください。
+
+試合一覧:
+${gameList}
+
+簡潔でわかりやすいレポートを本文のみで返してください（JSON不要）。人数が不足している試合があれば注意喚起してください。`;
+
+  try {
+    const text = await callModal(prompt);
+    if (!text) return fallback;
+    return text.trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/web/src/app/(public)/page.tsx
+++ b/packages/web/src/app/(public)/page.tsx
@@ -3,62 +3,62 @@ import Link from "next/link";
 import styles from "./page.module.css";
 
 export const metadata: Metadata = {
-  title: "mound - 草野球チームの試合運営を、もっとスマートに",
+  title: "mound - 金曜の夜、LINEの出欠まだ5人しか返事がない",
   description:
-    "出欠管理・グラウンド監視・対戦相手マッチング・精算まで。草野球チームの試合成立をAIがサポートする運営エンジン。",
+    "出欠回収・グラウンド確保・対戦相手探し・集金まで。草野球チームの試合成立をAIがサポートする運営エンジン。",
   openGraph: {
-    title: "mound - 草野球チームの試合運営を、もっとスマートに",
+    title: "mound - 金曜の夜、LINEの出欠まだ5人しか返事がない",
     description:
-      "出欠管理・グラウンド監視・対戦相手マッチング・精算まで。草野球チームの試合成立をAIがサポートする運営エンジン。",
+      "出欠回収・グラウンド確保・対戦相手探し・集金まで。草野球チームの試合成立をAIがサポートする運営エンジン。",
     type: "website",
     locale: "ja_JP",
   },
   twitter: {
     card: "summary_large_image",
-    title: "mound - 草野球チームの試合運営を、もっとスマートに",
+    title: "mound - 金曜の夜、LINEの出欠まだ5人しか返事がない",
     description:
-      "出欠管理・グラウンド監視・対戦相手マッチング・精算まで。草野球チームの試合成立をAIがサポートする運営エンジン。",
+      "出欠回収・グラウンド確保・対戦相手探し・集金まで。草野球チームの試合成立をAIがサポートする運営エンジン。",
   },
 };
 
 const FEATURES = [
   {
     abbr: "出欠",
-    title: "出欠管理",
-    desc: "LINEで出欠を回収。リマインド自動送信で未回答者を減らし、試合成立の見通しをリアルタイムに把握できます。",
+    title: "未読スルーされない出欠回収",
+    desc: "LINEで個別にリマインド自動送信。金曜夜に「あと3人！」がわかる。日曜朝の「やっぱ無理」も即反映。",
   },
   {
     abbr: "球場",
-    title: "グラウンド監視",
-    desc: "空きグラウンド情報を自動取得。抽選日程や空き状況をチームに通知し、確保のチャンスを逃しません。",
+    title: "グラウンド確保、もう抽選日を忘れない",
+    desc: "横浜市・藤沢市など6自治体の空き状況を毎日チェック。空きが出たらすぐ通知。",
   },
   {
     abbr: "対戦",
-    title: "対戦相手マッチング",
-    desc: "日程・地域・レベルが合うチームを自動で提案。対戦相手探しの手間を大幅に削減します。",
+    title: "対戦相手、探さなくていい",
+    desc: "日程と地域が合うチームを自動提案。メッセージ作成もAIがサポート。",
   },
   {
     abbr: "精算",
-    title: "精算・PayPay連携",
-    desc: "参加費の自動計算とPayPayリンク送信。集金の手間とトラブルをゼロにします。",
+    title: "集金のストレスをゼロに",
+    desc: "参加費を自動計算してPayPayリンクを送信。「誰が払った？」を管理画面で一目瞭然。",
   },
 ] as const;
 
 const STEPS = [
   {
     number: 1,
-    title: "チーム登録",
-    desc: "LINEグループと連携するだけ。メンバー情報は自動で取り込まれます。",
+    title: "LINEグループと連携",
+    desc: "チームのLINEグループを登録するだけ。メンバー一覧が自動で作成されます。",
   },
   {
     number: 2,
-    title: "試合作成",
-    desc: "日程と場所を入力するだけで、出欠回収から対戦相手探しまで自動で開始します。",
+    title: "試合を立てる",
+    desc: "日付と場所を入れたら、出欠回収が自動スタート。リマインドも全自動。",
   },
   {
     number: 3,
-    title: "自動運営",
-    desc: "AIが試合成立までの段取りを提案。あなたは最終確認するだけです。",
+    title: "試合成立",
+    desc: "人数OK・グラウンドOK・相手OK。確定ボタンひとつで全員に通知。",
   },
 ] as const;
 
@@ -69,14 +69,14 @@ export default function LandingPage() {
       <section className={styles.hero}>
         <div className={styles.heroInner}>
           <h1 className={styles.heroTitle}>
-            草野球チームの試合運営を、
+            金曜の夜。LINEの出欠、
             <br />
-            もっとスマートに
+            まだ5人しか返事がない。
           </h1>
           <p className={styles.heroSub}>
-            出欠管理・グラウンド確保・対戦相手探し・精算まで。
+            「9人集まるのか」「グラウンドどうする」「相手チームは」——
             <br />
-            試合成立に必要なすべてを、AIがサポートします。
+            全部、mound が解決します。
           </p>
           <Link href="/login" className={styles.ctaButton}>
             無料ではじめる


### PR DESCRIPTION
## Summary
- Modal + Gemma 4 の AI サービス実装 (`modal-ai-service.ts`)
- `AI_PROVIDER=modal` 環境変数で Anthropic/Modal を切替可能に
- LP コピーを草野球監督のリアルなペインに刺さる内容にリライト
  - ヒーロー: 「金曜の夜。LINEの出欠、まだ5人しか返事がない。」
  - 機能: ペイン→解決のストーリー形式に

Closes #77 Closes #79

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n