### PR TITLE
feat: グラウンド監視スクレイパー基盤 + Cron API

### DIFF
--- a/packages/core/src/__tests__/ground-scraper.test.ts
+++ b/packages/core/src/__tests__/ground-scraper.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "bun:test";
+import { detectNewAvailability } from "../lib/ground-monitor";
+import {
+  type ScrapedSlot,
+  ayaseAdapter,
+  fujisawaAdapter,
+  generateMockSlots,
+  getAdapter,
+  getSupportedMunicipalities,
+  hiratsukAdapter,
+  kamakuraAdapter,
+  kanagawaAdapter,
+  scrapeGround,
+  yokohamaAdapter,
+} from "../lib/ground-scraper";
+
+// --- テストヘルパー ---
+
+function createPreviousSlot(
+  date: string,
+  timeSlot: "MORNING" | "AFTERNOON" | "EVENING",
+  status: "AVAILABLE" | "RESERVED" | "UNAVAILABLE",
+) {
+  return { date, time_slot: timeSlot, status };
+}
+
+// ============================================================
+// グラウンドスクレイパー
+// ============================================================
+
+describe("GroundScraperAdapter", () => {
+  describe("アダプターレジストリ", () => {
+    it("対応する自治体のアダプターを返す", () => {
+      const adapter = getAdapter("横浜市");
+      expect(adapter).toBeDefined();
+      expect(adapter!.municipality).toBe("横浜市");
+    });
+
+    it("未対応の自治体では undefined を返す", () => {
+      const adapter = getAdapter("札幌市");
+      expect(adapter).toBeUndefined();
+    });
+
+    it("6つの自治体に対応している", () => {
+      const municipalities = getSupportedMunicipalities();
+      expect(municipalities).toHaveLength(6);
+      expect(municipalities).toContain("横浜市");
+      expect(municipalities).toContain("藤沢市");
+      expect(municipalities).toContain("平塚市");
+      expect(municipalities).toContain("鎌倉市");
+      expect(municipalities).toContain("神奈川県");
+      expect(municipalities).toContain("綾瀬市");
+    });
+  });
+
+  describe("各アダプターのscrapeメソッド", () => {
+    const adapters = [
+      yokohamaAdapter,
+      fujisawaAdapter,
+      hiratsukAdapter,
+      kamakuraAdapter,
+      kanagawaAdapter,
+      ayaseAdapter,
+    ];
+
+    for (const adapter of adapters) {
+      it(`${adapter.municipality}アダプターがスロットを返す`, async () => {
+        const slots = await adapter.scrape("テスト球場");
+
+        expect(slots.length).toBeGreaterThan(0);
+
+        for (const slot of slots) {
+          expect(slot.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+          expect(["MORNING", "AFTERNOON", "EVENING"]).toContain(slot.timeSlot);
+          expect(["AVAILABLE", "RESERVED", "UNAVAILABLE"]).toContain(
+            slot.status,
+          );
+        }
+      });
+    }
+  });
+
+  describe("scrapeGround関数", () => {
+    it("対応自治体のグラウンド情報を取得する", async () => {
+      const slots = await scrapeGround("横浜市", "三ツ沢球場");
+      expect(slots.length).toBeGreaterThan(0);
+    });
+
+    it("未対応自治体でエラーを投げる", async () => {
+      await expect(scrapeGround("札幌市", "円山球場")).rejects.toThrow(
+        "未対応の自治体です: 札幌市",
+      );
+    });
+  });
+
+  describe("generateMockSlots", () => {
+    it("2〜4週間先のスロットを生成する", () => {
+      const baseDate = new Date("2026-04-01");
+      const slots = generateMockSlots("test", baseDate);
+
+      // 14日後〜28日後 = 15日間 * 3スロット = 45スロット
+      expect(slots).toHaveLength(45);
+
+      // 日付が2〜4週間先であることを確認
+      const dates = slots.map((s) => s.date);
+      const minDate = "2026-04-15";
+      const maxDate = "2026-04-29";
+      for (const d of dates) {
+        expect(d >= minDate).toBe(true);
+        expect(d <= maxDate).toBe(true);
+      }
+    });
+
+    it("同じシードなら同じ結果を返す", () => {
+      const base = new Date("2026-04-01");
+      const a = generateMockSlots("seed-A", base);
+      const b = generateMockSlots("seed-A", base);
+      expect(a).toEqual(b);
+    });
+
+    it("異なるシードなら異なる結果を返す", () => {
+      const base = new Date("2026-04-01");
+      const a = generateMockSlots("seed-A", base);
+      const b = generateMockSlots("seed-B", base);
+      // ステータスの分布が異なるはず
+      const aStatuses = a.map((s) => s.status).join(",");
+      const bStatuses = b.map((s) => s.status).join(",");
+      expect(aStatuses).not.toBe(bStatuses);
+    });
+
+    it("AVAILABLE / RESERVED / UNAVAILABLE の3種類が含まれる", () => {
+      const slots = generateMockSlots("variety-test", new Date("2026-04-01"));
+      const statuses = new Set(slots.map((s) => s.status));
+      expect(statuses.has("AVAILABLE")).toBe(true);
+      expect(statuses.has("RESERVED")).toBe(true);
+      expect(statuses.has("UNAVAILABLE")).toBe(true);
+    });
+  });
+});
+
+// ============================================================
+// 空き検出ロジック
+// ============================================================
+
+describe("detectNewAvailability", () => {
+  describe("前回データがないとき", () => {
+    it("AVAILABLEなスロットをすべて新規検出する", () => {
+      const current: ScrapedSlot[] = [
+        { date: "2026-04-20", timeSlot: "MORNING", status: "AVAILABLE" },
+        { date: "2026-04-20", timeSlot: "AFTERNOON", status: "RESERVED" },
+      ];
+
+      const result = detectNewAvailability([], current);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe("2026-04-20");
+      expect(result[0].timeSlot).toBe("MORNING");
+    });
+  });
+
+  describe("前回RESERVEDだったスロットがAVAILABLEになったとき", () => {
+    it("新規空きとして検出する", () => {
+      const previous = [
+        createPreviousSlot("2026-04-20", "MORNING", "RESERVED"),
+        createPreviousSlot("2026-04-20", "AFTERNOON", "AVAILABLE"),
+      ];
+      const current: ScrapedSlot[] = [
+        { date: "2026-04-20", timeSlot: "MORNING", status: "AVAILABLE" },
+        { date: "2026-04-20", timeSlot: "AFTERNOON", status: "AVAILABLE" },
+      ];
+
+      const result = detectNewAvailability(previous, current);
+
+      // MORNINGのみ新規 (AFTERNOONは前回もAVAILABLE)
+      expect(result).toHaveLength(1);
+      expect(result[0].timeSlot).toBe("MORNING");
+    });
+  });
+
+  describe("前回もAVAILABLEだったスロットのとき", () => {
+    it("新規検出しない", () => {
+      const previous = [
+        createPreviousSlot("2026-04-20", "MORNING", "AVAILABLE"),
+      ];
+      const current: ScrapedSlot[] = [
+        { date: "2026-04-20", timeSlot: "MORNING", status: "AVAILABLE" },
+      ];
+
+      const result = detectNewAvailability(previous, current);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("すべてRESERVEDのとき", () => {
+    it("空き検出しない", () => {
+      const current: ScrapedSlot[] = [
+        { date: "2026-04-20", timeSlot: "MORNING", status: "RESERVED" },
+        { date: "2026-04-20", timeSlot: "AFTERNOON", status: "RESERVED" },
+        { date: "2026-04-20", timeSlot: "EVENING", status: "UNAVAILABLE" },
+      ];
+
+      const result = detectNewAvailability([], current);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("複数日にまたがる新規空きのとき", () => {
+    it("すべての新規空きを検出する", () => {
+      const previous = [
+        createPreviousSlot("2026-04-20", "MORNING", "RESERVED"),
+        createPreviousSlot("2026-04-21", "AFTERNOON", "UNAVAILABLE"),
+      ];
+      const current: ScrapedSlot[] = [
+        { date: "2026-04-20", timeSlot: "MORNING", status: "AVAILABLE" },
+        { date: "2026-04-21", timeSlot: "AFTERNOON", status: "AVAILABLE" },
+        { date: "2026-04-22", timeSlot: "EVENING", status: "AVAILABLE" },
+      ];
+
+      const result = detectNewAvailability(previous, current);
+
+      expect(result).toHaveLength(3);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -242,6 +242,34 @@ export type {
   EmailSettlementRequestContext,
 } from "./lib/email-service";
 
+// Ground Scraper
+export {
+  scrapeGround,
+  getAdapter,
+  getSupportedMunicipalities,
+  generateMockSlots,
+  TIME_SLOTS,
+  SLOT_STATUSES,
+  scrapedSlotSchema,
+} from "./lib/ground-scraper";
+export type {
+  ScrapedSlot,
+  GroundScraperAdapter,
+  TimeSlot as ScraperTimeSlot,
+  SlotStatus as ScraperSlotStatus,
+} from "./lib/ground-scraper";
+
+// Ground Monitor
+export {
+  detectNewAvailability,
+  checkGrounds,
+} from "./lib/ground-monitor";
+export type {
+  NewAvailability,
+  GroundCheckResult,
+  CheckGroundsResult,
+} from "./lib/ground-monitor";
+
 // Notification Dispatcher
 export {
   dispatchNotifications,

--- a/packages/core/src/lib/ground-monitor.ts
+++ b/packages/core/src/lib/ground-monitor.ts
@@ -1,0 +1,199 @@
+// ============================================================
+// グラウンド監視サービス
+// watch_active なグラウンドを定期チェックし、
+// 新たに空きが見つかった場合に通知を発行する。
+// ============================================================
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Ground, GroundSlot } from "../types/domain";
+import type { ScrapedSlot } from "./ground-scraper";
+import { scrapeGround } from "./ground-scraper";
+
+// --- 空き検出 ---
+
+export interface NewAvailability {
+  groundId: string;
+  groundName: string;
+  date: string;
+  timeSlot: "MORNING" | "AFTERNOON" | "EVENING";
+}
+
+/**
+ * 前回と今回のスロットを比較し、新たに AVAILABLE になったスロットを検出する。
+ * 前回存在しなかったスロットが AVAILABLE の場合も新規検出とみなす。
+ */
+export function detectNewAvailability(
+  previousSlots: Pick<GroundSlot, "date" | "time_slot" | "status">[],
+  currentSlots: ScrapedSlot[],
+): ScrapedSlot[] {
+  const prevMap = new Map<string, string>();
+  for (const s of previousSlots) {
+    prevMap.set(`${s.date}:${s.time_slot}`, s.status);
+  }
+
+  return currentSlots.filter((s) => {
+    if (s.status !== "AVAILABLE") return false;
+    const prevStatus = prevMap.get(`${s.date}:${s.timeSlot}`);
+    // 前回 AVAILABLE でなかった or 前回記録がない → 新規空き
+    return prevStatus !== "AVAILABLE";
+  });
+}
+
+// --- チェック結果 ---
+
+export interface GroundCheckResult {
+  groundId: string;
+  groundName: string;
+  municipality: string;
+  slotsScraped: number;
+  newAvailabilities: NewAvailability[];
+  error?: string;
+}
+
+export interface CheckGroundsResult {
+  teamId: string;
+  checkedAt: string;
+  results: GroundCheckResult[];
+  totalNewAvailabilities: number;
+  notificationSent: boolean;
+}
+
+// --- メインサービス ---
+
+/**
+ * チームの watch_active なグラウンドをすべてチェックし、
+ * 新しい空きを検出して ground_slots テーブルを更新する。
+ */
+export async function checkGrounds(
+  supabase: SupabaseClient,
+  teamId: string,
+): Promise<CheckGroundsResult> {
+  // 1. watch_active なグラウンドを取得
+  const { data: grounds, error: groundsError } = await supabase
+    .from("grounds")
+    .select("*")
+    .eq("team_id", teamId)
+    .eq("watch_active", true);
+
+  if (groundsError) {
+    throw new Error(`グラウンド取得エラー: ${groundsError.message}`);
+  }
+
+  const results: GroundCheckResult[] = [];
+
+  for (const ground of (grounds ?? []) as Ground[]) {
+    try {
+      const result = await checkSingleGround(supabase, ground);
+      results.push(result);
+    } catch (e) {
+      results.push({
+        groundId: ground.id,
+        groundName: ground.name,
+        municipality: ground.municipality,
+        slotsScraped: 0,
+        newAvailabilities: [],
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  const totalNewAvailabilities = results.reduce(
+    (sum, r) => sum + r.newAvailabilities.length,
+    0,
+  );
+
+  // 3. 新しい空きがある場合に通知ログを挿入
+  let notificationSent = false;
+  if (totalNewAvailabilities > 0) {
+    const lines = results
+      .flatMap((r) =>
+        r.newAvailabilities.map(
+          (a) => `${r.groundName} ${a.date} ${a.timeSlot}`,
+        ),
+      )
+      .slice(0, 10); // 最大10件
+
+    const content = `グラウンド空き検出:\n${lines.join("\n")}`;
+
+    const { error: notifError } = await supabase
+      .from("notification_logs")
+      .insert({
+        team_id: teamId,
+        game_id: null,
+        recipient_type: "MEMBER",
+        notification_type: "GROUND_ALERT",
+        content,
+      });
+
+    notificationSent = !notifError;
+    if (notifError) {
+      console.error("通知ログ挿入エラー:", notifError);
+    }
+  }
+
+  return {
+    teamId,
+    checkedAt: new Date().toISOString(),
+    results,
+    totalNewAvailabilities,
+    notificationSent,
+  };
+}
+
+/**
+ * 単一グラウンドの空き状況をチェックし、ground_slots を更新する。
+ */
+async function checkSingleGround(
+  supabase: SupabaseClient,
+  ground: Ground,
+): Promise<GroundCheckResult> {
+  // スクレイピング実行
+  const scrapedSlots = await scrapeGround(ground.municipality, ground.name);
+
+  // 既存スロットを取得
+  const { data: existingSlots, error: slotsError } = await supabase
+    .from("ground_slots")
+    .select("date, time_slot, status")
+    .eq("ground_id", ground.id);
+
+  if (slotsError) {
+    throw new Error(`スロット取得エラー: ${slotsError.message}`);
+  }
+
+  // 新しい空きを検出
+  const newSlots = detectNewAvailability(existingSlots ?? [], scrapedSlots);
+
+  // ground_slots をアップサート (全スクレイピング結果)
+  const upsertRows = scrapedSlots.map((s) => ({
+    ground_id: ground.id,
+    date: s.date,
+    time_slot: s.timeSlot,
+    status: s.status,
+    detected_at: new Date().toISOString(),
+  }));
+
+  if (upsertRows.length > 0) {
+    const { error: upsertError } = await supabase
+      .from("ground_slots")
+      .upsert(upsertRows, {
+        onConflict: "ground_id,date,time_slot",
+      });
+
+    if (upsertError) {
+      console.error("スロットupsertエラー:", upsertError);
+    }
+  }
+
+  return {
+    groundId: ground.id,
+    groundName: ground.name,
+    municipality: ground.municipality,
+    slotsScraped: scrapedSlots.length,
+    newAvailabilities: newSlots.map((s) => ({
+      groundId: ground.id,
+      groundName: ground.name,
+      date: s.date,
+      timeSlot: s.timeSlot,
+    })),
+  };
+}

--- a/packages/core/src/lib/ground-scraper.ts
+++ b/packages/core/src/lib/ground-scraper.ts
@@ -1,0 +1,146 @@
+// ============================================================
+// グラウンド空き状況スクレイパー — アダプターパターン
+// 各自治体の予約システムをスクレイピングして空き状況を取得する。
+// 現時点ではモックデータを返すスタブ実装。
+// ============================================================
+
+import { z } from "zod/v4";
+
+// --- スクレイパー結果型 ---
+
+export const TIME_SLOTS = ["MORNING", "AFTERNOON", "EVENING"] as const;
+export type TimeSlot = (typeof TIME_SLOTS)[number];
+
+export const SLOT_STATUSES = ["AVAILABLE", "RESERVED", "UNAVAILABLE"] as const;
+export type SlotStatus = (typeof SLOT_STATUSES)[number];
+
+export const scrapedSlotSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  timeSlot: z.enum(TIME_SLOTS),
+  status: z.enum(SLOT_STATUSES),
+});
+
+export type ScrapedSlot = z.infer<typeof scrapedSlotSchema>;
+
+// --- アダプターインターフェース ---
+
+export interface GroundScraperAdapter {
+  /** 対応する自治体名 */
+  readonly municipality: string;
+  /** 指定グラウンド名の空き状況を取得する */
+  scrape(groundName: string): Promise<ScrapedSlot[]>;
+}
+
+// --- モックデータ生成ヘルパー ---
+
+/**
+ * 2〜4週間先のリアルなモックスロットを生成する。
+ * 土日はRESERVEDが多く、平日はAVAILABLEが多い傾向。
+ */
+export function generateMockSlots(
+  seed: string,
+  baseDate: Date = new Date(),
+): ScrapedSlot[] {
+  const slots: ScrapedSlot[] = [];
+  // 簡易ハッシュでシード値を数値化
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) & 0x7fffffff;
+  }
+
+  for (let dayOffset = 14; dayOffset <= 28; dayOffset++) {
+    const d = new Date(baseDate);
+    d.setDate(d.getDate() + dayOffset);
+    const dateStr = d.toISOString().slice(0, 10);
+    const dayOfWeek = d.getDay(); // 0=日, 6=土
+    const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
+    for (const timeSlot of TIME_SLOTS) {
+      hash = (hash * 1103515245 + 12345) & 0x7fffffff;
+      const roll = hash % 100;
+
+      let status: SlotStatus;
+      if (isWeekend) {
+        // 週末: 70% RESERVED, 20% UNAVAILABLE, 10% AVAILABLE
+        status =
+          roll < 10 ? "AVAILABLE" : roll < 30 ? "UNAVAILABLE" : "RESERVED";
+      } else {
+        // 平日: 50% AVAILABLE, 30% RESERVED, 20% UNAVAILABLE
+        status =
+          roll < 50 ? "AVAILABLE" : roll < 80 ? "RESERVED" : "UNAVAILABLE";
+      }
+
+      slots.push({ date: dateStr, timeSlot, status });
+    }
+  }
+
+  return slots;
+}
+
+// --- 自治体別スタブアダプター ---
+
+function createStubAdapter(municipality: string): GroundScraperAdapter {
+  return {
+    municipality,
+    async scrape(groundName: string): Promise<ScrapedSlot[]> {
+      return generateMockSlots(`${municipality}:${groundName}`);
+    },
+  };
+}
+
+export const yokohamaAdapter: GroundScraperAdapter =
+  createStubAdapter("横浜市");
+export const fujisawaAdapter: GroundScraperAdapter =
+  createStubAdapter("藤沢市");
+export const hiratsukAdapter: GroundScraperAdapter =
+  createStubAdapter("平塚市");
+export const kamakuraAdapter: GroundScraperAdapter =
+  createStubAdapter("鎌倉市");
+export const kanagawaAdapter: GroundScraperAdapter =
+  createStubAdapter("神奈川県");
+export const ayaseAdapter: GroundScraperAdapter = createStubAdapter("綾瀬市");
+
+// --- アダプターレジストリ ---
+
+const ADAPTERS: ReadonlyMap<string, GroundScraperAdapter> = new Map([
+  ["横浜市", yokohamaAdapter],
+  ["藤沢市", fujisawaAdapter],
+  ["平塚市", hiratsukAdapter],
+  ["鎌倉市", kamakuraAdapter],
+  ["神奈川県", kanagawaAdapter],
+  ["綾瀬市", ayaseAdapter],
+]);
+
+/**
+ * 自治体名からアダプターを取得する。
+ * 未対応の自治体の場合は undefined を返す。
+ */
+export function getAdapter(
+  municipality: string,
+): GroundScraperAdapter | undefined {
+  return ADAPTERS.get(municipality);
+}
+
+/**
+ * 対応自治体の一覧を返す。
+ */
+export function getSupportedMunicipalities(): string[] {
+  return [...ADAPTERS.keys()];
+}
+
+/**
+ * 指定グラウンドの空き状況をスクレイピングする。
+ * 未対応自治体の場合はエラーを投げる。
+ */
+export async function scrapeGround(
+  municipality: string,
+  groundName: string,
+): Promise<ScrapedSlot[]> {
+  const adapter = getAdapter(municipality);
+  if (!adapter) {
+    throw new Error(`未対応の自治体です: ${municipality}`);
+  }
+  const slots = await adapter.scrape(groundName);
+  // バリデーション
+  return slots.map((s) => scrapedSlotSchema.parse(s));
+}

--- a/packages/web/src/app/api/cron/grounds/route.ts
+++ b/packages/web/src/app/api/cron/grounds/route.ts
@@ -1,0 +1,61 @@
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, checkGrounds } from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/cron/grounds — グラウンド空き状況チェック (Vercel Cron 等から呼び出し)
+ *
+ * watch_active なグラウンドを持つ全チームをチェックし、
+ * 新しい空きが見つかった場合に通知を発行する。
+ */
+export async function GET(request: Request) {
+  // Cron シークレットの検証
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json(apiError("UNAUTHORIZED", "Invalid CRON_SECRET"), {
+      status: 401,
+    });
+  }
+
+  const supabase = await createClient();
+
+  // watch_active なグラウンドを持つチームIDを取得
+  const { data: activeGrounds, error: queryError } = await supabase
+    .from("grounds")
+    .select("team_id")
+    .eq("watch_active", true);
+
+  if (queryError) {
+    return NextResponse.json(apiError("DATABASE_ERROR", queryError.message), {
+      status: 500,
+    });
+  }
+
+  // ユニークなチームIDを抽出
+  const teamIds = [...new Set((activeGrounds ?? []).map((g) => g.team_id))];
+
+  const results = [];
+  let totalNewAvailabilities = 0;
+
+  for (const teamId of teamIds) {
+    try {
+      const result = await checkGrounds(supabase, teamId);
+      results.push(result);
+      totalNewAvailabilities += result.totalNewAvailabilities;
+    } catch (e) {
+      console.error(`チーム ${teamId} のグラウンドチェック失敗:`, e);
+      results.push({
+        teamId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return NextResponse.json(
+    apiSuccess({
+      teamsChecked: teamIds.length,
+      totalNewAvailabilities,
+      results,
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- 6自治体対応のスクレイパーアダプター基盤 (横浜市/藤沢市/平塚市/鎌倉市/神奈川県/綾瀬市)
- グラウンドモニターサービス (空き検知 → ground_slots upsert → LINE通知)
- Cron API エンドポイント (`GET /api/cron/grounds`)
- BDD テスト20件追加 (計207テスト合格)

現在はモックデータですが、アダプターを差し替えるだけで実サイト対応可能。

Closes #67

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n