### PR TITLE
feat: API エンドポイント完成 + 認証・レートリミットミドルウェア

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -164,6 +164,8 @@ export {
   updateNegotiationSchema,
   createExpenseSchema,
   createTeamSchema,
+  createGroundSchema,
+  updateGroundWatchSchema,
   sendNotificationSchema,
   zodToValidationError,
 } from "./lib/validators";
@@ -178,6 +180,8 @@ export type {
   UpdateNegotiationInput,
   CreateExpenseInput,
   CreateTeamInput,
+  CreateGroundInput,
+  UpdateGroundWatchInput,
   SendNotificationInput,
 } from "./lib/validators";
 

--- a/packages/core/src/lib/validators.ts
+++ b/packages/core/src/lib/validators.ts
@@ -128,6 +128,26 @@ export const createTeamSchema = z.object({
 });
 export type CreateTeamInput = z.infer<typeof createTeamSchema>;
 
+// --- Ground ---
+
+export const createGroundSchema = z.object({
+  team_id: uuidSchema,
+  name: z.string().min(1, "グラウンド名は必須です").max(200),
+  municipality: z.string().min(1, "市区町村は必須です").max(200),
+  source_url: z.string().url().nullable().default(null),
+  cost_per_slot: z.number().int().min(0).nullable().default(null),
+  is_hardball_ok: z.boolean().default(false),
+  has_night_lights: z.boolean().default(false),
+  note: z.string().max(500).nullable().default(null),
+});
+export type CreateGroundInput = z.infer<typeof createGroundSchema>;
+
+export const updateGroundWatchSchema = z.object({
+  watch_active: z.boolean(),
+  conditions_json: z.record(z.string(), z.unknown()).nullable().default(null),
+});
+export type UpdateGroundWatchInput = z.infer<typeof updateGroundWatchSchema>;
+
 // --- Notification ---
 
 export const sendNotificationSchema = z.object({

--- a/packages/web/src/app/api/expenses/route.ts
+++ b/packages/web/src/app/api/expenses/route.ts
@@ -1,0 +1,124 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  createExpenseSchema,
+  writeAuditLog,
+  zodToValidationError,
+} from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/expenses?game_id=xxx */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const gameId = searchParams.get("game_id");
+
+  if (!gameId) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "game_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("expenses")
+    .select("*, members:paid_by(name)")
+    .eq("game_id", gameId);
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  const expenses = data ?? [];
+  const totalAmount = expenses.reduce((sum, e) => sum + e.amount, 0);
+
+  return NextResponse.json(
+    apiSuccess(expenses, [], { total_amount: totalAmount }),
+  );
+}
+
+/** POST /api/expenses — 支出登録 (game_id をボディで指定) */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const supabase = await createClient();
+  const body = await request.json();
+
+  const gameId = body.game_id;
+  if (!gameId || typeof gameId !== "string") {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "game_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  const parsed = createExpenseSchema.safeParse(body);
+  if (!parsed.success) {
+    const ve = zodToValidationError(parsed.error);
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", ve.issues.map((i) => i.message).join("; ")),
+      { status: 400 },
+    );
+  }
+
+  const input = parsed.data;
+
+  const { error: gameError } = await supabase
+    .from("games")
+    .select("id")
+    .eq("id", gameId)
+    .single();
+
+  if (gameError) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  const { data, error } = await supabase
+    .from("expenses")
+    .insert({
+      game_id: gameId,
+      category: input.category,
+      amount: input.amount,
+      paid_by: input.paid_by,
+      split_with_opponent: input.split_with_opponent,
+      note: input.note,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: input.actor_id,
+    action: "ADD_EXPENSE",
+    target_type: "expense",
+    target_id: data.id,
+    after_json: data,
+  });
+
+  return NextResponse.json(
+    apiSuccess(data, [
+      {
+        action: "calculate_settlement",
+        reason: "支出が登録されました。精算を計算できます",
+        priority: "medium",
+        suggested_params: { game_id: gameId },
+      },
+    ]),
+    { status: 201 },
+  );
+}

--- a/packages/web/src/app/api/grounds/route.ts
+++ b/packages/web/src/app/api/grounds/route.ts
@@ -1,0 +1,148 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  createGroundSchema,
+  updateGroundWatchSchema,
+  writeAuditLog,
+  zodToValidationError,
+} from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/grounds?team_id=xxx&watch_active=true */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const teamId = searchParams.get("team_id");
+  const watchActive = searchParams.get("watch_active");
+
+  let query = supabase
+    .from("grounds")
+    .select("*")
+    .order("name", { ascending: true });
+
+  if (teamId) query = query.eq("team_id", teamId);
+  if (watchActive !== null && watchActive !== undefined) {
+    query = query.eq("watch_active", watchActive === "true");
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data ?? [], []));
+}
+
+/** POST /api/grounds — グラウンド登録 / 監視設定更新 */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const supabase = await createClient();
+  const body = await request.json();
+
+  // ground_id が指定されていれば監視設定の更新
+  if (body.ground_id) {
+    const parsed = updateGroundWatchSchema.safeParse(body);
+    if (!parsed.success) {
+      const ve = zodToValidationError(parsed.error);
+      return NextResponse.json(
+        apiError(
+          "VALIDATION_ERROR",
+          ve.issues.map((i) => i.message).join("; "),
+        ),
+        { status: 400 },
+      );
+    }
+
+    const input = parsed.data;
+    const { data, error } = await supabase
+      .from("grounds")
+      .update({
+        watch_active: input.watch_active,
+        conditions_json: input.conditions_json,
+      })
+      .eq("id", body.ground_id)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+        status: 400,
+      });
+    }
+
+    await writeAuditLog(supabase, {
+      actor_type: "USER",
+      actor_id: authResult.id,
+      action: "UPDATE_GROUND_WATCH",
+      target_type: "ground",
+      target_id: body.ground_id,
+      after_json: { watch_active: input.watch_active },
+    });
+
+    return NextResponse.json(apiSuccess(data, []));
+  }
+
+  // 新規グラウンド登録
+  const parsed = createGroundSchema.safeParse(body);
+  if (!parsed.success) {
+    const ve = zodToValidationError(parsed.error);
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", ve.issues.map((i) => i.message).join("; ")),
+      { status: 400 },
+    );
+  }
+
+  const input = parsed.data;
+  const { data, error } = await supabase
+    .from("grounds")
+    .insert({
+      team_id: input.team_id,
+      name: input.name,
+      municipality: input.municipality,
+      source_url: input.source_url,
+      cost_per_slot: input.cost_per_slot,
+      is_hardball_ok: input.is_hardball_ok,
+      has_night_lights: input.has_night_lights,
+      note: input.note,
+      watch_active: false,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "CREATE_GROUND",
+    target_type: "ground",
+    target_id: data.id,
+    after_json: data,
+  });
+
+  return NextResponse.json(
+    apiSuccess(data, [
+      {
+        action: "update_ground_watch",
+        reason:
+          "グラウンドが登録されました。空き監視を有効にするには watch_active を設定してください",
+        priority: "low",
+        suggested_params: { ground_id: data.id },
+      },
+    ]),
+    { status: 201 },
+  );
+}

--- a/packages/web/src/app/api/helper-requests/route.ts
+++ b/packages/web/src/app/api/helper-requests/route.ts
@@ -1,0 +1,137 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  createHelperRequestsSchema,
+  writeAuditLog,
+  zodToValidationError,
+} from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/helper-requests?game_id=xxx&status=xxx */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const gameId = searchParams.get("game_id");
+  const status = searchParams.get("status");
+  const limit = Math.min(Number(searchParams.get("limit") ?? 50), 100);
+  const cursor = searchParams.get("cursor");
+
+  let query = supabase
+    .from("helper_requests")
+    .select("*, helpers(name, note, reliability_score)")
+    .order("created_at", { ascending: false })
+    .limit(limit + 1);
+
+  if (gameId) query = query.eq("game_id", gameId);
+  if (status) query = query.eq("status", status);
+  if (cursor) query = query.lt("created_at", cursor);
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  const hasMore = data && data.length > limit;
+  const items = hasMore ? data.slice(0, limit) : (data ?? []);
+  const nextCursor = hasMore ? items[items.length - 1]?.created_at : null;
+
+  const summary = {
+    pending: items.filter((r) => r.status === "PENDING").length,
+    accepted: items.filter((r) => r.status === "ACCEPTED").length,
+    declined: items.filter((r) => r.status === "DECLINED").length,
+    cancelled: items.filter((r) => r.status === "CANCELLED").length,
+    total: items.length,
+  };
+
+  return NextResponse.json(
+    apiSuccess(items, [], { summary, next_cursor: nextCursor }),
+  );
+}
+
+/** POST /api/helper-requests — 助っ人打診作成 (game_id をボディで指定) */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const supabase = await createClient();
+  const body = await request.json();
+
+  const gameId = body.game_id;
+  if (!gameId || typeof gameId !== "string") {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "game_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  const parsed = createHelperRequestsSchema.safeParse(body);
+  if (!parsed.success) {
+    const ve = zodToValidationError(parsed.error);
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", ve.issues.map((i) => i.message).join("; ")),
+      { status: 400 },
+    );
+  }
+
+  const input = parsed.data;
+
+  // 試合の存在確認
+  const { error: gameError } = await supabase
+    .from("games")
+    .select("id, team_id, status")
+    .eq("id", gameId)
+    .single();
+
+  if (gameError) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  const rows = input.helper_ids.map((helperId) => ({
+    game_id: gameId,
+    helper_id: helperId,
+    status: "PENDING",
+    message: input.message,
+    sent_at: new Date().toISOString(),
+  }));
+
+  const { data, error } = await supabase
+    .from("helper_requests")
+    .insert(rows)
+    .select();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: input.actor_id,
+    action: "CREATE_HELPER_REQUESTS",
+    target_type: "game",
+    target_id: gameId,
+    after_json: { helper_ids: input.helper_ids, count: data?.length ?? 0 },
+  });
+
+  return NextResponse.json(
+    apiSuccess(data ?? [], [
+      {
+        action: "check_fulfillment",
+        reason: "助っ人の回答を待って充足状況を確認してください",
+        priority: "medium",
+        suggested_params: { game_id: gameId },
+      },
+    ]),
+    { status: 201 },
+  );
+}

--- a/packages/web/src/app/api/middleware.ts
+++ b/packages/web/src/app/api/middleware.ts
@@ -1,0 +1,106 @@
+// ============================================================
+// API ルート共通ミドルウェアヘルパー
+// 認証チェック + レート制限
+// ============================================================
+import { requireAuth, requireRole } from "@/lib/auth";
+import type { AuthenticatedMember } from "@/lib/auth";
+import { apiError } from "@match-engine/core";
+import type { MemberRole } from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+// --- 認証・認可ラッパー ---
+
+export type AuthSuccess = { member: AuthenticatedMember };
+export type AuthFailure = { response: NextResponse };
+export type AuthResult = AuthSuccess | AuthFailure;
+
+/** 認証チェック — 成功なら member、失敗なら NextResponse を返す */
+export async function checkAuth(
+  requiredRole?: MemberRole,
+): Promise<AuthResult> {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) {
+    return { response: authResult };
+  }
+  if (requiredRole) {
+    const roleCheck = requireRole(authResult, requiredRole);
+    if (roleCheck) {
+      return { response: roleCheck };
+    }
+  }
+  return { member: authResult };
+}
+
+export function isAuthFailure(result: AuthResult): result is AuthFailure {
+  return "response" in result;
+}
+
+// --- レート制限 (インメモリ簡易実装) ---
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const rateLimitStore = new Map<string, RateLimitEntry>();
+
+const DEFAULT_WINDOW_MS = 60_000; // 1分
+const DEFAULT_MAX_REQUESTS = 60; // 1分あたり60リクエスト
+
+interface RateLimitOptions {
+  windowMs?: number;
+  maxRequests?: number;
+}
+
+/**
+ * 簡易レート制限チェック
+ * @returns null: OK / NextResponse: 制限超過
+ */
+export function checkRateLimit(
+  key: string,
+  options?: RateLimitOptions,
+): NextResponse | null {
+  const windowMs = options?.windowMs ?? DEFAULT_WINDOW_MS;
+  const maxRequests = options?.maxRequests ?? DEFAULT_MAX_REQUESTS;
+  const now = Date.now();
+
+  const entry = rateLimitStore.get(key);
+
+  if (!entry || now >= entry.resetAt) {
+    rateLimitStore.set(key, { count: 1, resetAt: now + windowMs });
+    return null;
+  }
+
+  entry.count++;
+  if (entry.count > maxRequests) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    return NextResponse.json(
+      apiError("RATE_LIMITED", "リクエスト数が制限を超えました", [
+        {
+          action: "retry",
+          reason: `${retryAfter}秒後に再試行してください`,
+          priority: "low",
+        },
+      ]),
+      {
+        status: 429,
+        headers: { "Retry-After": String(retryAfter) },
+      },
+    );
+  }
+
+  return null;
+}
+
+// 定期クリーンアップ (期限切れエントリの除去)
+if (typeof globalThis !== "undefined") {
+  const CLEANUP_INTERVAL = 5 * 60_000; // 5分ごと
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of rateLimitStore) {
+      if (now >= entry.resetAt) {
+        rateLimitStore.delete(key);
+      }
+    }
+  }, CLEANUP_INTERVAL).unref?.();
+}

--- a/packages/web/src/app/api/negotiations/[id]/route.ts
+++ b/packages/web/src/app/api/negotiations/[id]/route.ts
@@ -11,6 +11,29 @@ import {
 import type { NegotiationStatus } from "@match-engine/core";
 import { type NextRequest, NextResponse } from "next/server";
 
+/** GET /api/negotiations/:id — 交渉詳細取得 */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("negotiations")
+    .select("*, opponent_teams(name, area, contact_name)")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("NOT_FOUND", "交渉が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data, []));
+}
+
 /** PATCH /api/negotiations/:id — 交渉状態遷移 */
 export async function PATCH(
   request: NextRequest,

--- a/packages/web/src/app/api/negotiations/route.ts
+++ b/packages/web/src/app/api/negotiations/route.ts
@@ -1,0 +1,153 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  createNegotiationSchema,
+  writeAuditLog,
+  zodToValidationError,
+} from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/negotiations?game_id=xxx&team_id=xxx&status=xxx */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const gameId = searchParams.get("game_id");
+  const teamId = searchParams.get("team_id");
+  const status = searchParams.get("status");
+  const limit = Math.min(Number(searchParams.get("limit") ?? 50), 100);
+  const cursor = searchParams.get("cursor");
+
+  let query = supabase
+    .from("negotiations")
+    .select("*, opponent_teams(name, area, contact_name)")
+    .order("created_at", { ascending: false })
+    .limit(limit + 1);
+
+  if (gameId) query = query.eq("game_id", gameId);
+  if (status) query = query.eq("status", status);
+  if (cursor) query = query.lt("created_at", cursor);
+
+  // team_id フィルタは games テーブル経由で行う
+  if (teamId) {
+    const { data: gameIds } = await supabase
+      .from("games")
+      .select("id")
+      .eq("team_id", teamId);
+
+    if (gameIds && gameIds.length > 0) {
+      query = supabase
+        .from("negotiations")
+        .select("*, opponent_teams(name, area, contact_name)")
+        .in(
+          "game_id",
+          gameIds.map((g) => g.id),
+        )
+        .order("created_at", { ascending: false })
+        .limit(limit + 1);
+
+      if (status) query = query.eq("status", status);
+      if (cursor) query = query.lt("created_at", cursor);
+    } else {
+      return NextResponse.json(apiSuccess([], [], { next_cursor: null }));
+    }
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  const hasMore = data && data.length > limit;
+  const items = hasMore ? data.slice(0, limit) : (data ?? []);
+  const nextCursor = hasMore ? items[items.length - 1]?.created_at : null;
+
+  return NextResponse.json(apiSuccess(items, [], { next_cursor: nextCursor }));
+}
+
+/** POST /api/negotiations — 交渉作成 (game_id をボディで指定) */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const supabase = await createClient();
+  const body = await request.json();
+
+  // game_id はボディから取得
+  const gameId = body.game_id;
+  if (!gameId || typeof gameId !== "string") {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "game_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  const parsed = createNegotiationSchema.safeParse(body);
+  if (!parsed.success) {
+    const ve = zodToValidationError(parsed.error);
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", ve.issues.map((i) => i.message).join("; ")),
+      { status: 400 },
+    );
+  }
+
+  const input = parsed.data;
+
+  // 試合の存在確認
+  const { error: gameError } = await supabase
+    .from("games")
+    .select("id")
+    .eq("id", gameId)
+    .single();
+
+  if (gameError) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  const { data, error } = await supabase
+    .from("negotiations")
+    .insert({
+      game_id: gameId,
+      opponent_team_id: input.opponent_team_id,
+      status: "DRAFT",
+      proposed_dates_json: JSON.stringify(input.proposed_dates),
+      message_sent: input.message,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: input.actor_type,
+    actor_id: input.actor_id,
+    action: "CREATE_NEGOTIATION",
+    target_type: "negotiation",
+    target_id: data.id,
+    after_json: data,
+  });
+
+  return NextResponse.json(
+    apiSuccess(data, [
+      {
+        action: "update_negotiation",
+        reason: "交渉を送信してください (DRAFT → SENT)",
+        priority: "high",
+        suggested_params: { negotiation_id: data.id, status: "SENT" },
+      },
+    ]),
+    { status: 201 },
+  );
+}

--- a/packages/web/src/app/api/stats/route.ts
+++ b/packages/web/src/app/api/stats/route.ts
@@ -1,0 +1,84 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  calculateBattingStats,
+  calculatePitchingStats,
+  calculateTeamStats,
+} from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** GET /api/stats?team_id=xxx&member_id=xxx */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const teamId = searchParams.get("team_id");
+  const memberId = searchParams.get("member_id");
+
+  if (!teamId) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "team_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  // チーム戦績
+  const { data: gameResults } = await supabase
+    .from("game_results")
+    .select("result, our_score, opponent_score, games!inner(team_id)")
+    .eq("games.team_id", teamId);
+
+  const teamStats = calculateTeamStats(gameResults ?? []);
+
+  // メンバー個別指定の場合
+  if (memberId) {
+    const [atBatsRes, pitchingRes, gamesRes] = await Promise.all([
+      supabase.from("at_bats").select("*").eq("member_id", memberId),
+      supabase.from("pitching_stats").select("*").eq("member_id", memberId),
+      supabase
+        .from("attendances")
+        .select("id")
+        .eq("person_id", memberId)
+        .eq("status", "ATTENDED"),
+    ]);
+
+    const gamesPlayed = gamesRes.data?.length ?? 0;
+    const batting = calculateBattingStats(atBatsRes.data ?? [], gamesPlayed);
+    const pitching = calculatePitchingStats(pitchingRes.data ?? []);
+
+    return NextResponse.json(
+      apiSuccess({ teamStats, batting, pitching, gamesPlayed }, []),
+    );
+  }
+
+  // チーム全体のメンバー別打撃サマリー
+  const { data: members } = await supabase
+    .from("members")
+    .select("id, name")
+    .eq("team_id", teamId)
+    .eq("status", "ACTIVE");
+
+  const memberStats = [];
+  for (const member of members ?? []) {
+    const { data: atBats } = await supabase
+      .from("at_bats")
+      .select("result, rbi, runs_scored, stolen_base")
+      .eq("member_id", member.id);
+
+    const { data: attended } = await supabase
+      .from("attendances")
+      .select("id")
+      .eq("person_id", member.id)
+      .eq("status", "ATTENDED");
+
+    if (atBats && atBats.length > 0) {
+      const stats = calculateBattingStats(atBats, attended?.length ?? 0);
+      memberStats.push({ member_id: member.id, name: member.name, ...stats });
+    }
+  }
+
+  // 打率順ソート
+  memberStats.sort((a, b) => b.avg - a.avg);
+
+  return NextResponse.json(apiSuccess({ teamStats, memberStats }, []));
+}


### PR DESCRIPTION
## Summary
- 新規6 API Route: negotiations, helper-requests, expenses, stats, grounds + 個別GET
- 認証チェック + レートリミットミドルウェア (`api/middleware.ts`)
- Zod バリデーションスキーマ追加 (createGroundSchema, updateGroundWatchSchema)
- カーソルベースページネーション対応

Closes #70

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n