### PR TITLE
feat: 精算・PayPay連携の本番化

### DIFF
--- a/packages/core/src/__tests__/settlement.test.ts
+++ b/packages/core/src/__tests__/settlement.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "bun:test";
+import { generatePayPayLink } from "../lib/paypay";
+import { calculateSettlement } from "../lib/settlement";
+import type { SettlementCalculationInput } from "../lib/settlement";
+
+// --- テストヘルパー ---
+
+function createExpense(
+  overrides: Partial<{ amount: number; split_with_opponent: boolean }> = {},
+) {
+  return {
+    amount: overrides.amount ?? 1000,
+    split_with_opponent: overrides.split_with_opponent ?? false,
+  };
+}
+
+function createInput(
+  overrides: Partial<SettlementCalculationInput> = {},
+): SettlementCalculationInput {
+  return {
+    expenses: overrides.expenses ?? [createExpense()],
+    memberCount: overrides.memberCount ?? 10,
+  };
+}
+
+// --- テスト ---
+
+describe("calculateSettlement", () => {
+  describe("経費が1件で折半なしのとき", () => {
+    it("合計費用がそのまま計算される", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [createExpense({ amount: 5000 })],
+          memberCount: 10,
+        }),
+      );
+
+      expect(result.totalCost).toBe(5000);
+      expect(result.opponentShare).toBe(0);
+      expect(result.teamCost).toBe(5000);
+      expect(result.perMember).toBe(500);
+      expect(result.memberCount).toBe(10);
+    });
+  });
+
+  describe("複数の経費があるとき", () => {
+    it("合計費用が全経費の合算になる", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [
+            createExpense({ amount: 3000 }),
+            createExpense({ amount: 2000 }),
+            createExpense({ amount: 500 }),
+          ],
+          memberCount: 10,
+        }),
+      );
+
+      expect(result.totalCost).toBe(5500);
+      expect(result.teamCost).toBe(5500);
+      expect(result.perMember).toBe(550);
+    });
+  });
+
+  describe("対戦相手と折半する経費があるとき", () => {
+    it("折半分が対戦相手負担として差し引かれる", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [
+            createExpense({ amount: 6000, split_with_opponent: true }),
+            createExpense({ amount: 1000, split_with_opponent: false }),
+          ],
+          memberCount: 5,
+        }),
+      );
+
+      expect(result.totalCost).toBe(7000);
+      expect(result.opponentShare).toBe(3000); // 6000 / 2
+      expect(result.teamCost).toBe(4000); // 7000 - 3000
+      expect(result.perMember).toBe(800); // 4000 / 5
+    });
+  });
+
+  describe("折半で端数が出るとき", () => {
+    it("対戦相手負担は切り捨て、一人あたりは切り上げになる", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [
+            createExpense({ amount: 5001, split_with_opponent: true }),
+          ],
+          memberCount: 3,
+        }),
+      );
+
+      // 5001 / 2 = 2500.5 → floor → 2500
+      expect(result.opponentShare).toBe(2500);
+      // 5001 - 2500 = 2501
+      expect(result.teamCost).toBe(2501);
+      // 2501 / 3 = 833.67 → ceil → 834
+      expect(result.perMember).toBe(834);
+    });
+  });
+
+  describe("全経費が折半のとき", () => {
+    it("全額の半分が対戦相手負担になる", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [
+            createExpense({ amount: 4000, split_with_opponent: true }),
+            createExpense({ amount: 2000, split_with_opponent: true }),
+          ],
+          memberCount: 4,
+        }),
+      );
+
+      expect(result.totalCost).toBe(6000);
+      expect(result.opponentShare).toBe(3000); // 2000 + 1000
+      expect(result.teamCost).toBe(3000);
+      expect(result.perMember).toBe(750);
+    });
+  });
+
+  describe("参加人数が1人のとき", () => {
+    it("チーム負担全額が一人あたりになる", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [createExpense({ amount: 3000 })],
+          memberCount: 1,
+        }),
+      );
+
+      expect(result.perMember).toBe(3000);
+    });
+  });
+
+  describe("経費が空のとき", () => {
+    it("エラーをスローする", () => {
+      expect(() => calculateSettlement(createInput({ expenses: [] }))).toThrow(
+        "経費が登録されていません",
+      );
+    });
+  });
+
+  describe("参加人数が0のとき", () => {
+    it("エラーをスローする", () => {
+      expect(() =>
+        calculateSettlement(createInput({ memberCount: 0 })),
+      ).toThrow("参加人数は1以上である必要があります");
+    });
+  });
+
+  describe("参加人数が負の数のとき", () => {
+    it("エラーをスローする", () => {
+      expect(() =>
+        calculateSettlement(createInput({ memberCount: -1 })),
+      ).toThrow("参加人数は1以上である必要があります");
+    });
+  });
+});
+
+describe("generatePayPayLink — 精算連携", () => {
+  describe("精算結果の一人あたり金額を渡したとき", () => {
+    it("金額がURLに含まれる", () => {
+      const result = calculateSettlement(
+        createInput({
+          expenses: [
+            createExpense({ amount: 6000, split_with_opponent: true }),
+            createExpense({ amount: 1000 }),
+          ],
+          memberCount: 5,
+        }),
+      );
+
+      const link = generatePayPayLink(result.perMember, "4/3 練習試合 精算");
+      const url = new URL(link);
+
+      expect(url.searchParams.get("amount")).toBe(String(result.perMember));
+    });
+
+    it("説明文がURLに含まれる", () => {
+      const link = generatePayPayLink(800, "春季リーグ第1節 精算");
+      const url = new URL(link);
+
+      expect(url.searchParams.get("description")).toBe("春季リーグ第1節 精算");
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,6 +152,13 @@ export { generateICalFeed, generateVEvent } from "./lib/ical";
 // PayPay
 export { generatePayPayLink } from "./lib/paypay";
 
+// Settlement
+export { calculateSettlement } from "./lib/settlement";
+export type {
+  SettlementCalculationInput,
+  SettlementCalculationResult,
+} from "./lib/settlement";
+
 // Validators
 export {
   createGameSchema,

--- a/packages/core/src/lib/settlement.ts
+++ b/packages/core/src/lib/settlement.ts
@@ -1,0 +1,71 @@
+/**
+ * 精算計算ロジック
+ *
+ * 経費一覧から精算金額を計算する純粋関数群。
+ * API ルートや UI から利用される。
+ */
+
+import type { Expense } from "../types/domain";
+
+/** 精算計算の入力 */
+export interface SettlementCalculationInput {
+  /** 経費一覧 */
+  expenses: Pick<Expense, "amount" | "split_with_opponent">[];
+  /** 参加人数 */
+  memberCount: number;
+}
+
+/** 精算計算の結果 */
+export interface SettlementCalculationResult {
+  /** 合計費用 */
+  totalCost: number;
+  /** 対戦相手負担額 */
+  opponentShare: number;
+  /** チーム負担額 */
+  teamCost: number;
+  /** 一人あたり金額（切り上げ） */
+  perMember: number;
+  /** 参加人数 */
+  memberCount: number;
+}
+
+/**
+ * 経費一覧から精算金額を計算する
+ *
+ * - totalCost: 全経費の合計
+ * - opponentShare: split_with_opponent が true の経費を半額にした合計
+ * - teamCost: totalCost - opponentShare
+ * - perMember: teamCost / memberCount（切り上げ）
+ *
+ * @throws {Error} expenses が空、または memberCount が 0 以下の場合
+ */
+export function calculateSettlement(
+  input: SettlementCalculationInput,
+): SettlementCalculationResult {
+  const { expenses, memberCount } = input;
+
+  if (expenses.length === 0) {
+    throw new Error("経費が登録されていません");
+  }
+
+  if (memberCount <= 0) {
+    throw new Error("参加人数は1以上である必要があります");
+  }
+
+  const totalCost = expenses.reduce((sum, e) => sum + e.amount, 0);
+
+  const opponentShare = expenses
+    .filter((e) => e.split_with_opponent)
+    .reduce((sum, e) => sum + Math.floor(e.amount / 2), 0);
+
+  const teamCost = totalCost - opponentShare;
+  const perMember = Math.ceil(teamCost / memberCount);
+
+  return {
+    totalCost,
+    opponentShare,
+    teamCost,
+    perMember,
+    memberCount,
+  };
+}

--- a/packages/web/src/app/(manager)/games/[id]/expenses/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/expenses/page.tsx
@@ -1,4 +1,6 @@
+import Badge from "@cloudscape-design/components/badge";
 import Box from "@cloudscape-design/components/box";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
@@ -8,9 +10,10 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
 import Table from "@cloudscape-design/components/table";
 
+import { PaymentStatusTable } from "@/components/PaymentStatusTable";
 import { SettlementActions } from "@/components/SettlementActions";
 import { createClient } from "@/lib/supabase/server";
-import { generatePayPayLink } from "@match-engine/core";
+import { calculateSettlement, generatePayPayLink } from "@match-engine/core";
 
 const CATEGORY_LABELS: Record<string, string> = {
   GROUND: "グラウンド",
@@ -19,6 +22,15 @@ const CATEGORY_LABELS: Record<string, string> = {
   DRINK: "飲料",
   TOURNAMENT_FEE: "大会費",
   OTHER: "その他",
+};
+
+const CATEGORY_COLORS: Record<string, "green" | "blue" | "grey"> = {
+  GROUND: "green",
+  UMPIRE: "blue",
+  BALL: "grey",
+  DRINK: "grey",
+  TOURNAMENT_FEE: "blue",
+  OTHER: "grey",
 };
 
 const SETTLEMENT_STATUS_TYPE: Record<
@@ -71,6 +83,79 @@ export default async function ExpensesPage({
     .eq("game_id", id)
     .single();
 
+  // 経費合計（ランニングトータル）
+  const totalAmount = (expenses ?? []).reduce(
+    (sum, e) => sum + Number(e.amount),
+    0,
+  );
+  const splitAmount = (expenses ?? [])
+    .filter((e) => e.split_with_opponent)
+    .reduce((sum, e) => sum + Number(e.amount), 0);
+
+  // 精算プレビュー計算（settlement 未作成でも表示用に計算）
+  const hasExpenses = expenses && expenses.length > 0;
+  const previewCalc =
+    hasExpenses && settlement?.member_count
+      ? calculateSettlement({
+          expenses: expenses.map((e) => ({
+            amount: Number(e.amount),
+            split_with_opponent: e.split_with_opponent,
+          })),
+          memberCount: settlement.member_count,
+        })
+      : null;
+
+  // PayPay リンク
+  const paypayLink =
+    settlement && game.title
+      ? generatePayPayLink(settlement.per_member, `${game.title} 精算`)
+      : null;
+
+  // 支払いステータス用のメンバー情報を取得
+  const { data: notifications } = await supabase
+    .from("notification_logs")
+    .select("recipient_id, created_at")
+    .eq("game_id", id)
+    .eq("notification_type", "SETTLEMENT");
+
+  const notifiedIds = new Set((notifications ?? []).map((n) => n.recipient_id));
+
+  // 参加メンバー一覧を取得
+  const { data: attendances } = await supabase
+    .from("attendances")
+    .select("member_id, members:member_id(id, name)")
+    .eq("game_id", id);
+
+  let paymentMembers: { id: string; name: string; notified: boolean }[] = [];
+
+  if (attendances && attendances.length > 0) {
+    paymentMembers = attendances.map((a) => {
+      const member = a.members as unknown as { id: string; name: string };
+      return {
+        id: member?.id ?? a.member_id,
+        name: member?.name ?? "不明",
+        notified: notifiedIds.has(a.member_id),
+      };
+    });
+  } else {
+    const { data: rsvps } = await supabase
+      .from("rsvps")
+      .select("member_id, members:member_id(id, name)")
+      .eq("game_id", id)
+      .eq("response", "AVAILABLE");
+
+    if (rsvps) {
+      paymentMembers = rsvps.map((r) => {
+        const member = r.members as unknown as { id: string; name: string };
+        return {
+          id: member?.id ?? r.member_id,
+          name: member?.name ?? "不明",
+          notified: notifiedIds.has(r.member_id),
+        };
+      });
+    }
+  }
+
   return (
     <ContentLayout
       header={
@@ -83,7 +168,8 @@ export default async function ExpensesPage({
       }
     >
       <SpaceBetween size="l">
-        {expenses && expenses.length > 0 ? (
+        {/* 経費一覧テーブル */}
+        {hasExpenses ? (
           <Table
             header={
               <Header variant="h2" counter={`(${expenses.length})`}>
@@ -94,7 +180,11 @@ export default async function ExpensesPage({
               {
                 id: "category",
                 header: "カテゴリ",
-                cell: (item) => CATEGORY_LABELS[item.category] ?? item.category,
+                cell: (item) => (
+                  <Badge color={CATEGORY_COLORS[item.category] ?? "grey"}>
+                    {CATEGORY_LABELS[item.category] ?? item.category}
+                  </Badge>
+                ),
               },
               {
                 id: "amount",
@@ -112,7 +202,12 @@ export default async function ExpensesPage({
               {
                 id: "split_with_opponent",
                 header: "対戦相手と折半",
-                cell: (item) => (item.split_with_opponent ? "はい" : "いいえ"),
+                cell: (item) =>
+                  item.split_with_opponent ? (
+                    <StatusIndicator type="success">はい</StatusIndicator>
+                  ) : (
+                    <StatusIndicator type="stopped">いいえ</StatusIndicator>
+                  ),
               },
               {
                 id: "note",
@@ -122,6 +217,21 @@ export default async function ExpensesPage({
             ]}
             items={expenses}
             variant="embedded"
+            footer={
+              <Box textAlign="right" fontWeight="bold" padding={{ right: "l" }}>
+                合計: ¥{totalAmount.toLocaleString()}
+                {splitAmount > 0 && (
+                  <Box
+                    variant="small"
+                    color="text-status-info"
+                    display="inline"
+                    padding={{ left: "s" }}
+                  >
+                    (うち折半対象: ¥{splitAmount.toLocaleString()})
+                  </Box>
+                )}
+              </Box>
+            }
           />
         ) : (
           <Container header={<Header variant="h2">経費一覧</Header>}>
@@ -131,6 +241,37 @@ export default async function ExpensesPage({
           </Container>
         )}
 
+        {/* ランニングトータル & 精算プレビュー */}
+        {hasExpenses && (
+          <Container header={<Header variant="h2">費用サマリ</Header>}>
+            <ColumnLayout columns={3} variant="text-grid">
+              <div>
+                <Box variant="awsui-key-label">合計費用</Box>
+                <Box variant="awsui-value-large">
+                  ¥{totalAmount.toLocaleString()}
+                </Box>
+              </div>
+              <div>
+                <Box variant="awsui-key-label">折半対象額</Box>
+                <Box variant="awsui-value-large">
+                  ¥{splitAmount.toLocaleString()}
+                </Box>
+              </div>
+              {previewCalc && (
+                <div>
+                  <Box variant="awsui-key-label">
+                    一人あたり（{previewCalc.memberCount}人）
+                  </Box>
+                  <Box variant="awsui-value-large">
+                    ¥{previewCalc.perMember.toLocaleString()}
+                  </Box>
+                </div>
+              )}
+            </ColumnLayout>
+          </Container>
+        )}
+
+        {/* 精算サマリ */}
         {settlement ? (
           <Container header={<Header variant="h2">精算サマリ</Header>}>
             <SpaceBetween size="l">
@@ -171,18 +312,12 @@ export default async function ExpensesPage({
                   },
                   ...((settlement.status === "NOTIFIED" ||
                     settlement.status === "SETTLED") &&
-                  game.title
+                  paypayLink
                     ? [
                         {
                           label: "PayPay リンク",
                           value: (
-                            <Link
-                              href={generatePayPayLink(
-                                settlement.per_member,
-                                `${game.title} 精算`,
-                              )}
-                              external
-                            >
+                            <Link href={paypayLink} external>
                               PayPay で ¥
                               {Number(settlement.per_member).toLocaleString()}{" "}
                               を支払う
@@ -208,6 +343,18 @@ export default async function ExpensesPage({
             </Box>
           </Container>
         )}
+
+        {/* 支払いステータス */}
+        {settlement &&
+          settlement.status !== "DRAFT" &&
+          paymentMembers.length > 0 && (
+            <PaymentStatusTable
+              members={paymentMembers}
+              perMember={settlement.per_member}
+              paypayLink={paypayLink}
+              settlementStatus={settlement.status}
+            />
+          )}
       </SpaceBetween>
     </ContentLayout>
   );

--- a/packages/web/src/app/api/games/[id]/settlement/route.ts
+++ b/packages/web/src/app/api/games/[id]/settlement/route.ts
@@ -1,6 +1,12 @@
 import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
-import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import {
+  apiError,
+  apiSuccess,
+  calculateSettlement,
+  generatePayPayLink,
+  writeAuditLog,
+} from "@match-engine/core";
 import { type NextRequest, NextResponse } from "next/server";
 
 /** POST /api/games/:id/settlement — 精算計算 */
@@ -17,13 +23,13 @@ export async function POST(
   const supabase = await createClient();
 
   // 試合の存在確認
-  const { error: gameError } = await supabase
+  const { data: game, error: gameError } = await supabase
     .from("games")
-    .select("id")
+    .select("id, title")
     .eq("id", id)
     .single();
 
-  if (gameError) {
+  if (gameError || !game) {
     return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
       status: 404,
     });
@@ -82,12 +88,14 @@ export async function POST(
     });
   }
 
-  const totalCost = expenses.reduce((sum, e) => sum + e.amount, 0);
-  const opponentShare = expenses
-    .filter((e) => e.split_with_opponent)
-    .reduce((sum, e) => sum + Math.floor(e.amount / 2), 0);
-  const teamCost = totalCost - opponentShare;
-  const perMember = Math.ceil(teamCost / memberCount);
+  // コアロジックで精算計算
+  const calc = calculateSettlement({ expenses, memberCount });
+
+  // PayPay リンク生成
+  const paypayLink = generatePayPayLink(
+    calc.perMember,
+    `${game.title ?? "試合"} 精算`,
+  );
 
   // upsert settlement
   const { data, error } = await supabase
@@ -95,11 +103,11 @@ export async function POST(
     .upsert(
       {
         game_id: id,
-        total_cost: totalCost,
-        opponent_share: opponentShare,
-        team_cost: teamCost,
-        member_count: memberCount,
-        per_member: perMember,
+        total_cost: calc.totalCost,
+        opponent_share: calc.opponentShare,
+        team_cost: calc.teamCost,
+        member_count: calc.memberCount,
+        per_member: calc.perMember,
         status: "DRAFT",
       },
       { onConflict: "game_id" },
@@ -123,18 +131,22 @@ export async function POST(
   });
 
   return NextResponse.json(
-    apiSuccess(data, [
-      {
-        action: "transition_game",
-        reason: "精算が完了したら SETTLED に遷移してください",
-        priority: "medium",
-        suggested_params: { game_id: id, new_status: "SETTLED" },
-      },
-    ]),
+    apiSuccess(
+      data,
+      [
+        {
+          action: "transition_game",
+          reason: "精算が完了したら SETTLED に遷移してください",
+          priority: "medium",
+          suggested_params: { game_id: id, new_status: "SETTLED" },
+        },
+      ],
+      { paypay_link: paypayLink },
+    ),
   );
 }
 
-/** GET /api/games/:id/settlement — 精算情報取得 */
+/** GET /api/games/:id/settlement — 精算情報取得（支払いステータス含む） */
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -142,13 +154,13 @@ export async function GET(
   const { id } = await params;
   const supabase = await createClient();
 
-  const { data, error } = await supabase
+  const { data: settlement, error } = await supabase
     .from("settlements")
     .select("*")
     .eq("game_id", id)
     .single();
 
-  if (error) {
+  if (error || !settlement) {
     return NextResponse.json(
       apiError("NOT_FOUND", "精算情報が見つかりません", [
         {
@@ -162,5 +174,149 @@ export async function GET(
     );
   }
 
-  return NextResponse.json(apiSuccess(data, []));
+  // 試合タイトルを取得して PayPay リンクを生成
+  const { data: game } = await supabase
+    .from("games")
+    .select("title")
+    .eq("id", id)
+    .single();
+
+  const paypayLink = generatePayPayLink(
+    settlement.per_member,
+    `${game?.title ?? "試合"} 精算`,
+  );
+
+  // 支払いステータスを取得（通知ログから SETTLEMENT タイプを参照）
+  const { data: notifications } = await supabase
+    .from("notification_logs")
+    .select("recipient_id, created_at")
+    .eq("game_id", id)
+    .eq("notification_type", "SETTLEMENT");
+
+  // 参加メンバー一覧を取得
+  const { data: attendances } = await supabase
+    .from("attendances")
+    .select("member_id, members:member_id(id, name)")
+    .eq("game_id", id);
+
+  let members: { id: string; name: string; notified: boolean }[] = [];
+
+  if (attendances && attendances.length > 0) {
+    const notifiedIds = new Set(
+      (notifications ?? []).map((n) => n.recipient_id),
+    );
+    members = attendances.map((a) => {
+      const member = a.members as unknown as { id: string; name: string };
+      return {
+        id: member?.id ?? a.member_id,
+        name: member?.name ?? "不明",
+        notified: notifiedIds.has(a.member_id),
+      };
+    });
+  } else {
+    // fallback: RSVP AVAILABLE members
+    const { data: rsvps } = await supabase
+      .from("rsvps")
+      .select("member_id, members:member_id(id, name)")
+      .eq("game_id", id)
+      .eq("response", "AVAILABLE");
+
+    if (rsvps) {
+      const notifiedIds = new Set(
+        (notifications ?? []).map((n) => n.recipient_id),
+      );
+      members = rsvps.map((r) => {
+        const member = r.members as unknown as { id: string; name: string };
+        return {
+          id: member?.id ?? r.member_id,
+          name: member?.name ?? "不明",
+          notified: notifiedIds.has(r.member_id),
+        };
+      });
+    }
+  }
+
+  return NextResponse.json(
+    apiSuccess(settlement, [], {
+      paypay_link: paypayLink,
+      members,
+    }),
+  );
+}
+
+/** PATCH /api/games/:id/settlement — 精算ステータス更新 */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const body = await request.json();
+
+  const { data: settlement, error: settlementError } = await supabase
+    .from("settlements")
+    .select("*")
+    .eq("game_id", id)
+    .single();
+
+  if (settlementError || !settlement) {
+    return NextResponse.json(
+      apiError("NOT_FOUND", "精算情報が見つかりません"),
+      { status: 404 },
+    );
+  }
+
+  // ステータス更新
+  const validStatuses = ["DRAFT", "NOTIFIED", "SETTLED"];
+  if (body.status && !validStatuses.includes(body.status)) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "無効なステータスです"),
+      { status: 400 },
+    );
+  }
+
+  const updateData: Record<string, unknown> = {};
+  if (body.status) {
+    updateData.status = body.status;
+    if (body.status === "SETTLED") {
+      updateData.settled_at = new Date().toISOString();
+    }
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "更新するフィールドがありません"),
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("settlements")
+    .update(updateData)
+    .eq("id", settlement.id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "UPDATE_SETTLEMENT",
+    target_type: "settlement",
+    target_id: settlement.id,
+    before_json: { status: settlement.status },
+    after_json: { status: data.status },
+  });
+
+  return NextResponse.json(apiSuccess(data));
 }

--- a/packages/web/src/components/PaymentStatusTable.tsx
+++ b/packages/web/src/components/PaymentStatusTable.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+
+interface PaymentMember {
+  id: string;
+  name: string;
+  notified: boolean;
+}
+
+interface PaymentStatusTableProps {
+  members: PaymentMember[];
+  perMember: number;
+  paypayLink: string | null;
+  settlementStatus: string;
+}
+
+export function PaymentStatusTable({
+  members,
+  perMember,
+  paypayLink,
+  settlementStatus,
+}: PaymentStatusTableProps) {
+  const notifiedCount = members.filter((m) => m.notified).length;
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          counter={`(${notifiedCount}/${members.length})`}
+          description="精算通知の送信状況"
+        >
+          支払いステータス
+        </Header>
+      }
+    >
+      <Table
+        columnDefinitions={[
+          {
+            id: "name",
+            header: "メンバー",
+            cell: (item) => item.name,
+          },
+          {
+            id: "amount",
+            header: "金額",
+            cell: () => `¥${perMember.toLocaleString()}`,
+          },
+          {
+            id: "status",
+            header: "通知ステータス",
+            cell: (item) =>
+              item.notified ? (
+                <StatusIndicator type="success">通知済み</StatusIndicator>
+              ) : (
+                <StatusIndicator type="pending">未通知</StatusIndicator>
+              ),
+          },
+          {
+            id: "paypay",
+            header: "PayPay",
+            cell: () =>
+              paypayLink ? (
+                <Link href={paypayLink} external>
+                  支払いリンク
+                </Link>
+              ) : (
+                <Box color="text-status-inactive">—</Box>
+              ),
+          },
+          {
+            id: "settled",
+            header: "精算状況",
+            cell: () =>
+              settlementStatus === "SETTLED" ? (
+                <StatusIndicator type="success">精算済み</StatusIndicator>
+              ) : (
+                <Button variant="inline-link" disabled>
+                  未精算
+                </Button>
+              ),
+          },
+        ]}
+        items={members}
+        variant="embedded"
+      />
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- 精算計算ロジック `calculateSettlement()` (折半・端数処理対応)
- 費用ページ UI 強化 (カテゴリバッジ、折半 StatusIndicator、合計サマリー)
- 支払状況テーブル `PaymentStatusTable` (PayPayリンク・通知状態表示)
- Settlement API: PATCH (状態更新) 追加、PayPayリンク返却
- BDD テスト9件追加 (計198テスト合格)

Closes #72

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n