### PR TITLE
feat: Onboardingウィザード統合 + テストカバレッジ強化 (221テスト)

### DIFF
--- a/packages/core/src/__tests__/email-service.test.ts
+++ b/packages/core/src/__tests__/email-service.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  buildGameConfirmedEmail,
+  buildRsvpReminderEmail,
+  buildSettlementRequestEmail,
+  createEmailSender,
+  sendEmail,
+} from "../lib/email-service";
+import type {
+  EmailGameConfirmedContext,
+  EmailRsvpReminderContext,
+  EmailSettlementRequestContext,
+} from "../lib/email-service";
+
+// --- テストヘルパー ---
+
+function createRsvpReminderContext(
+  overrides: Partial<EmailRsvpReminderContext> = {},
+): EmailRsvpReminderContext {
+  return {
+    teamName: "港北サンダース",
+    gameTitle: "練習試合 vs 横浜ベアーズ",
+    gameDate: "2026-05-01",
+    deadline: "2026-04-28",
+    rsvpUrl: "https://mound.app/rsvp/abc123",
+    ...overrides,
+  };
+}
+
+function createGameConfirmedContext(
+  overrides: Partial<EmailGameConfirmedContext> = {},
+): EmailGameConfirmedContext {
+  return {
+    teamName: "港北サンダース",
+    gameTitle: "練習試合 vs 横浜ベアーズ",
+    gameDate: "2026-05-01",
+    startTime: "10:00",
+    groundName: "新横浜公園グラウンドA",
+    detailUrl: "https://mound.app/games/abc123",
+    ...overrides,
+  };
+}
+
+function createSettlementContext(
+  overrides: Partial<EmailSettlementRequestContext> = {},
+): EmailSettlementRequestContext {
+  return {
+    teamName: "港北サンダース",
+    gameTitle: "練習試合 vs 横浜ベアーズ",
+    amount: 1500,
+    paypayLink: "https://paypay.ne.jp/abc",
+    detailUrl: "https://mound.app/games/abc123",
+    ...overrides,
+  };
+}
+
+// --- テスト ---
+
+describe("email-service", () => {
+  describe("buildRsvpReminderEmail", () => {
+    describe("すべての項目が設定されているとき", () => {
+      it("件名とHTMLにチーム名・試合名を含むメールを返す", () => {
+        const ctx = createRsvpReminderContext();
+
+        const result = buildRsvpReminderEmail(ctx);
+
+        expect(result.subject).toContain("港北サンダース");
+        expect(result.subject).toContain("出欠確認");
+        expect(result.html).toContain("練習試合 vs 横浜ベアーズ");
+        expect(result.html).toContain("https://mound.app/rsvp/abc123");
+      });
+    });
+
+    describe("日程が設定されているとき", () => {
+      it("HTML に日程を含む", () => {
+        const ctx = createRsvpReminderContext({ gameDate: "2026-05-01" });
+
+        const result = buildRsvpReminderEmail(ctx);
+
+        expect(result.html).toContain("2026-05-01");
+      });
+    });
+
+    describe("日程が未定のとき", () => {
+      it("HTML に日程を含まない", () => {
+        const ctx = createRsvpReminderContext({ gameDate: null });
+
+        const result = buildRsvpReminderEmail(ctx);
+
+        expect(result.html).not.toContain("日程:");
+      });
+    });
+
+    describe("締切が設定されているとき", () => {
+      it("HTML に締切を赤色で含む", () => {
+        const ctx = createRsvpReminderContext({ deadline: "2026-04-28" });
+
+        const result = buildRsvpReminderEmail(ctx);
+
+        expect(result.html).toContain("2026-04-28");
+        expect(result.html).toContain("color: red");
+      });
+    });
+
+    describe("締切が未設定のとき", () => {
+      it("HTML に締切を含まない", () => {
+        const ctx = createRsvpReminderContext({ deadline: null });
+
+        const result = buildRsvpReminderEmail(ctx);
+
+        expect(result.html).not.toContain("締切:");
+      });
+    });
+  });
+
+  describe("buildGameConfirmedEmail", () => {
+    describe("すべての項目が設定されているとき", () => {
+      it("確定通知メールを返す", () => {
+        const ctx = createGameConfirmedContext();
+
+        const result = buildGameConfirmedEmail(ctx);
+
+        expect(result.subject).toContain("試合確定");
+        expect(result.html).toContain("確定しました");
+        expect(result.html).toContain("2026-05-01");
+        expect(result.html).toContain("10:00");
+        expect(result.html).toContain("新横浜公園グラウンドA");
+      });
+    });
+
+    describe("会場が未定のとき", () => {
+      it("HTML に会場を含まない", () => {
+        const ctx = createGameConfirmedContext({ groundName: null });
+
+        const result = buildGameConfirmedEmail(ctx);
+
+        expect(result.html).not.toContain("会場:");
+      });
+    });
+
+    describe("開始時間が未定のとき", () => {
+      it("HTML に開始時間を含まない", () => {
+        const ctx = createGameConfirmedContext({ startTime: null });
+
+        const result = buildGameConfirmedEmail(ctx);
+
+        expect(result.html).not.toContain("開始:");
+      });
+    });
+  });
+
+  describe("buildSettlementRequestEmail", () => {
+    describe("PayPayリンクがあるとき", () => {
+      it("PayPayボタンを含む精算メールを返す", () => {
+        const ctx = createSettlementContext();
+
+        const result = buildSettlementRequestEmail(ctx);
+
+        expect(result.subject).toContain("精算");
+        expect(result.html).toContain("1,500");
+        expect(result.html).toContain("https://paypay.ne.jp/abc");
+        expect(result.html).toContain("PayPay");
+      });
+    });
+
+    describe("PayPayリンクがないとき", () => {
+      it("PayPayボタンを含まない精算メールを返す", () => {
+        const ctx = createSettlementContext({ paypayLink: null });
+
+        const result = buildSettlementRequestEmail(ctx);
+
+        expect(result.html).not.toContain("PayPay");
+      });
+    });
+
+    describe("金額が0のとき", () => {
+      it("金額0の精算メールを返す", () => {
+        const ctx = createSettlementContext({ amount: 0 });
+
+        const result = buildSettlementRequestEmail(ctx);
+
+        expect(result.html).toContain("0");
+      });
+    });
+  });
+
+  describe("sendEmail", () => {
+    const originalKey = process.env.RESEND_API_KEY;
+
+    beforeEach(() => {
+      process.env.RESEND_API_KEY = undefined;
+    });
+
+    afterEach(() => {
+      process.env.RESEND_API_KEY = originalKey;
+    });
+
+    describe("RESEND_API_KEY が未設定のとき", () => {
+      it("スタブとして成功を返す", async () => {
+        const result = await sendEmail({
+          to: "test@example.com",
+          subject: "テスト件名",
+          html: "<p>テスト本文</p>",
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.messageId).toBe("stub");
+      });
+    });
+  });
+
+  describe("createEmailSender", () => {
+    const originalKey = process.env.RESEND_API_KEY;
+
+    beforeEach(() => {
+      process.env.RESEND_API_KEY = undefined;
+    });
+
+    afterEach(() => {
+      process.env.RESEND_API_KEY = originalKey;
+    });
+
+    describe("スタブモードのとき", () => {
+      it("true を返す", async () => {
+        const sender = createEmailSender();
+
+        const result = await sender("test@example.com", "テスト内容");
+
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/core/src/__tests__/line-messaging.test.ts
+++ b/packages/core/src/__tests__/line-messaging.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  buildGameConfirmedMessage,
+  buildRsvpReminderFlex,
+  buildRsvpReminderMessage,
+  buildSettlementRequestMessage,
+  createLineSender,
+  pushMessage,
+} from "../lib/line-messaging";
+import type {
+  GameConfirmedContext,
+  RsvpReminderContext,
+  SettlementRequestContext,
+} from "../lib/line-messaging";
+
+// --- テストヘルパー ---
+
+function createRsvpReminderContext(
+  overrides: Partial<RsvpReminderContext> = {},
+): RsvpReminderContext {
+  return {
+    teamName: "港北サンダース",
+    gameTitle: "練習試合 vs 横浜ベアーズ",
+    gameDate: "2026-05-01",
+    deadline: "2026-04-28",
+    rsvpUrl: "https://mound.app/rsvp/abc123",
+    ...overrides,
+  };
+}
+
+function createGameConfirmedContext(
+  overrides: Partial<GameConfirmedContext> = {},
+): GameConfirmedContext {
+  return {
+    teamName: "港北サンダース",
+    gameTitle: "練習試合 vs 横浜ベアーズ",
+    gameDate: "2026-05-01",
+    startTime: "10:00",
+    groundName: "新横浜公園グラウンドA",
+    detailUrl: "https://mound.app/games/abc123",
+    ...overrides,
+  };
+}
+
+function createSettlementContext(
+  overrides: Partial<SettlementRequestContext> = {},
+): SettlementRequestContext {
+  return {
+    teamName: "港北サンダース",
+    gameTitle: "練習試合 vs 横浜ベアーズ",
+    amount: 1500,
+    paypayLink: "https://paypay.ne.jp/abc",
+    detailUrl: "https://mound.app/games/abc123",
+    ...overrides,
+  };
+}
+
+// --- テスト ---
+
+describe("line-messaging", () => {
+  describe("buildRsvpReminderMessage", () => {
+    describe("すべての項目が設定されているとき", () => {
+      it("チーム名・試合名・日程・締切・URLを含むメッセージを返す", () => {
+        const ctx = createRsvpReminderContext();
+
+        const result = buildRsvpReminderMessage(ctx);
+
+        expect(result.type).toBe("text");
+        expect(result.text).toContain("港北サンダース");
+        expect(result.text).toContain("練習試合 vs 横浜ベアーズ");
+        expect(result.text).toContain("2026-05-01");
+        expect(result.text).toContain("2026-04-28");
+        expect(result.text).toContain("https://mound.app/rsvp/abc123");
+      });
+    });
+
+    describe("日程が未定のとき", () => {
+      it("日程部分を含まないメッセージを返す", () => {
+        const ctx = createRsvpReminderContext({ gameDate: null });
+
+        const result = buildRsvpReminderMessage(ctx);
+
+        expect(result.text).not.toContain("日程:");
+      });
+    });
+
+    describe("締切が未設定のとき", () => {
+      it("締切部分を含まないメッセージを返す", () => {
+        const ctx = createRsvpReminderContext({ deadline: null });
+
+        const result = buildRsvpReminderMessage(ctx);
+
+        expect(result.text).not.toContain("締切:");
+      });
+    });
+  });
+
+  describe("buildRsvpReminderFlex", () => {
+    describe("すべての項目が設定されているとき", () => {
+      it("Flex メッセージを返す", () => {
+        const ctx = createRsvpReminderContext();
+
+        const result = buildRsvpReminderFlex(ctx);
+
+        expect(result.type).toBe("flex");
+        expect(result.altText).toContain("港北サンダース");
+        expect(result.contents.type).toBe("bubble");
+        expect(result.contents.footer).toBeDefined();
+      });
+    });
+
+    describe("日程が未定のとき", () => {
+      it("body に日程テキストを含まない", () => {
+        const ctx = createRsvpReminderContext({ gameDate: null });
+
+        const result = buildRsvpReminderFlex(ctx);
+
+        const bodyTexts = result.contents.body.contents
+          .filter((c) => c.type === "text")
+          .map((c) => ("text" in c ? c.text : ""));
+        const hasDateText = bodyTexts.some((t) => t.includes("日程:"));
+        expect(hasDateText).toBe(false);
+      });
+    });
+  });
+
+  describe("buildGameConfirmedMessage", () => {
+    describe("すべての項目が設定されているとき", () => {
+      it("確定通知メッセージを返す", () => {
+        const ctx = createGameConfirmedContext();
+
+        const result = buildGameConfirmedMessage(ctx);
+
+        expect(result.type).toBe("text");
+        expect(result.text).toContain("試合確定");
+        expect(result.text).toContain("2026-05-01");
+        expect(result.text).toContain("10:00");
+        expect(result.text).toContain("新横浜公園グラウンドA");
+      });
+    });
+
+    describe("会場が未定のとき", () => {
+      it("会場部分を含まないメッセージを返す", () => {
+        const ctx = createGameConfirmedContext({ groundName: null });
+
+        const result = buildGameConfirmedMessage(ctx);
+
+        expect(result.text).not.toContain("会場:");
+      });
+    });
+  });
+
+  describe("buildSettlementRequestMessage", () => {
+    describe("PayPayリンクがあるとき", () => {
+      it("PayPayリンクを含む精算メッセージを返す", () => {
+        const ctx = createSettlementContext();
+
+        const result = buildSettlementRequestMessage(ctx);
+
+        expect(result.type).toBe("text");
+        expect(result.text).toContain("精算");
+        expect(result.text).toContain("1,500");
+        expect(result.text).toContain("https://paypay.ne.jp/abc");
+      });
+    });
+
+    describe("PayPayリンクがないとき", () => {
+      it("PayPay部分を含まない精算メッセージを返す", () => {
+        const ctx = createSettlementContext({ paypayLink: null });
+
+        const result = buildSettlementRequestMessage(ctx);
+
+        expect(result.text).not.toContain("PayPay");
+      });
+    });
+  });
+
+  describe("pushMessage", () => {
+    const originalToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+
+    beforeEach(() => {
+      process.env.LINE_CHANNEL_ACCESS_TOKEN = undefined;
+    });
+
+    afterEach(() => {
+      process.env.LINE_CHANNEL_ACCESS_TOKEN = originalToken;
+    });
+
+    describe("LINE_CHANNEL_ACCESS_TOKEN が未設定のとき", () => {
+      it("エラーを返す", async () => {
+        const result = await pushMessage("user123", [
+          { type: "text", text: "テスト" },
+        ]);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("LINE_CHANNEL_ACCESS_TOKEN");
+      });
+    });
+  });
+
+  describe("createLineSender", () => {
+    describe("トークンなしで送信したとき", () => {
+      it("false を返す", async () => {
+        const sender = createLineSender(undefined);
+
+        // LINE_CHANNEL_ACCESS_TOKEN もない場合 pushMessage がエラーを返す
+        const originalToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+        process.env.LINE_CHANNEL_ACCESS_TOKEN = undefined;
+
+        const result = await sender("user123", "テストメッセージ");
+
+        expect(result).toBe(false);
+
+        process.env.LINE_CHANNEL_ACCESS_TOKEN = originalToken;
+      });
+    });
+  });
+});

--- a/packages/core/src/__tests__/modal-ai-service.test.ts
+++ b/packages/core/src/__tests__/modal-ai-service.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  generateNegotiationMessageModal,
+  generateWeeklyReportModal,
+  predictAttendanceModal,
+  recommendHelpersModal,
+} from "../lib/modal-ai-service";
+
+// --- テストヘルパー ---
+
+function createMemberInput(
+  overrides: Partial<{
+    name: string;
+    attendance_rate: number;
+    no_show_rate: number;
+  }> = {},
+) {
+  return {
+    name: "田中太郎",
+    attendance_rate: 0.8,
+    no_show_rate: 0.05,
+    ...overrides,
+  };
+}
+
+function createGameInput(
+  overrides: Partial<{ game_date: string | null; game_type: string }> = {},
+) {
+  return {
+    game_date: "2026-05-01",
+    game_type: "FRIENDLY",
+    ...overrides,
+  };
+}
+
+function createHelperInput(
+  id: string,
+  overrides: Partial<{
+    name: string;
+    reliability_score: number;
+    times_helped: number;
+  }> = {},
+) {
+  return {
+    id,
+    name: `助っ人${id}`,
+    reliability_score: 0.8,
+    times_helped: 3,
+    ...overrides,
+  };
+}
+
+function createWeeklyGameInput(
+  overrides: Partial<{
+    title: string;
+    status: string;
+    game_date: string | null;
+    available_count: number;
+    min_players: number;
+  }> = {},
+) {
+  return {
+    title: "練習試合 vs チームA",
+    status: "COLLECTING",
+    game_date: "2026-05-01",
+    available_count: 7,
+    min_players: 9,
+    ...overrides,
+  };
+}
+
+function createNegotiationContext(
+  overrides: Partial<{
+    team_name: string;
+    opponent_name: string;
+    proposed_dates: string[];
+    ground_name: string | undefined;
+  }> = {},
+) {
+  return {
+    team_name: "港北サンダース",
+    opponent_name: "横浜ベアーズ",
+    proposed_dates: ["2026-05-10", "2026-05-17"],
+    ground_name: "新横浜公園グラウンドA",
+    ...overrides,
+  };
+}
+
+// --- テスト ---
+
+describe("modal-ai-service", () => {
+  const originalUrl = process.env.MODAL_API_URL;
+  const originalKey = process.env.MODAL_API_KEY;
+
+  beforeEach(() => {
+    process.env.MODAL_API_URL = undefined;
+    process.env.MODAL_API_KEY = undefined;
+  });
+
+  afterEach(() => {
+    process.env.MODAL_API_URL = originalUrl;
+    process.env.MODAL_API_KEY = originalKey;
+  });
+
+  describe("predictAttendanceModal", () => {
+    describe("MODAL_API_URL が未設定のとき", () => {
+      it("フォールバック値として過去の出席率を返す", async () => {
+        const member = createMemberInput({ attendance_rate: 0.75 });
+        const game = createGameInput();
+
+        const result = await predictAttendanceModal(member, game);
+
+        expect(result.probability).toBe(0.75);
+        expect(result.reasoning).toContain("過去の出席率");
+      });
+    });
+
+    describe("出席率が0のメンバーのとき", () => {
+      it("フォールバックで確率0を返す", async () => {
+        const member = createMemberInput({ attendance_rate: 0 });
+        const game = createGameInput();
+
+        const result = await predictAttendanceModal(member, game);
+
+        expect(result.probability).toBe(0);
+      });
+    });
+
+    describe("出席率が1.0のメンバーのとき", () => {
+      it("フォールバックで確率1.0を返す", async () => {
+        const member = createMemberInput({ attendance_rate: 1.0 });
+        const game = createGameInput();
+
+        const result = await predictAttendanceModal(member, game);
+
+        expect(result.probability).toBe(1.0);
+      });
+    });
+  });
+
+  describe("recommendHelpersModal", () => {
+    describe("MODAL_API_URL が未設定のとき", () => {
+      it("信頼度スコア順にフォールバック推薦を返す", async () => {
+        const helpers = [
+          createHelperInput("h1", { reliability_score: 0.6 }),
+          createHelperInput("h2", { reliability_score: 0.9 }),
+          createHelperInput("h3", { reliability_score: 0.75 }),
+        ];
+
+        const result = await recommendHelpersModal(helpers, 2);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].helper_id).toBe("h2");
+        expect(result[1].helper_id).toBe("h3");
+      });
+    });
+
+    describe("必要人数が候補者数以上のとき", () => {
+      it("全候補者を返す", async () => {
+        const helpers = [createHelperInput("h1"), createHelperInput("h2")];
+
+        const result = await recommendHelpersModal(helpers, 5);
+
+        expect(result).toHaveLength(2);
+      });
+    });
+
+    describe("候補者が空のとき", () => {
+      it("空配列を返す", async () => {
+        const result = await recommendHelpersModal([], 3);
+
+        expect(result).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("generateNegotiationMessageModal", () => {
+    describe("MODAL_API_URL が未設定のとき", () => {
+      it("フォールバックメッセージを返す", async () => {
+        const context = createNegotiationContext();
+
+        const result = await generateNegotiationMessageModal(context);
+
+        expect(result).toContain("港北サンダース");
+        expect(result).toContain("横浜ベアーズ");
+        expect(result).toContain("2026-05-10");
+      });
+    });
+
+    describe("会場が未定のとき", () => {
+      it("会場なしのフォールバックメッセージを返す", async () => {
+        const context = createNegotiationContext({ ground_name: undefined });
+
+        const result = await generateNegotiationMessageModal(context);
+
+        expect(result).not.toContain("会場:");
+      });
+    });
+  });
+
+  describe("generateWeeklyReportModal", () => {
+    describe("試合が0件のとき", () => {
+      it("試合なしのメッセージを返す", async () => {
+        const result = await generateWeeklyReportModal([]);
+
+        expect(result).toBe("今週の試合予定はありません。");
+      });
+    });
+
+    describe("MODAL_API_URL が未設定で試合があるとき", () => {
+      it("フォールバックレポートを返す", async () => {
+        const games = [
+          createWeeklyGameInput({ title: "試合A", available_count: 10 }),
+          createWeeklyGameInput({
+            title: "試合B",
+            available_count: 5,
+            status: "ADJUSTING",
+          }),
+        ];
+
+        const result = await generateWeeklyReportModal(games);
+
+        expect(result).toContain("試合A");
+        expect(result).toContain("試合B");
+      });
+    });
+  });
+});

--- a/packages/web/src/app/(manager)/dashboard/page.tsx
+++ b/packages/web/src/app/(manager)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { DashboardView } from "@/components/DashboardView";
+import { OnboardingGuard } from "@/components/OnboardingGuard";
 import { createClient } from "@/lib/supabase/server";
 import Box from "@cloudscape-design/components/box";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
@@ -9,6 +10,27 @@ import Header from "@cloudscape-design/components/header";
 export default async function DashboardPage() {
   const supabase = await createClient();
   const teamId = process.env.NEXT_PUBLIC_DEFAULT_TEAM_ID;
+
+  // チームが存在するか確認する
+  const { count: teamCount } = await supabase
+    .from("teams")
+    .select("id", { count: "exact", head: true });
+
+  const hasTeams = (teamCount ?? 0) > 0;
+
+  if (!hasTeams) {
+    return (
+      <ContentLayout
+        header={
+          <Header variant="h1" description="チームをセットアップしましょう">
+            はじめに
+          </Header>
+        }
+      >
+        <OnboardingGuard />
+      </ContentLayout>
+    );
+  }
 
   const { data: games } = await supabase
     .from("games")

--- a/packages/web/src/components/OnboardingGuard.tsx
+++ b/packages/web/src/components/OnboardingGuard.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Onboarding } from "./Onboarding";
+
+/**
+ * 初回ログイン時にオンボーディングウィザードを表示する。
+ * 完了後はダッシュボードをリロードしてチーム作成後の状態を反映する。
+ */
+export function OnboardingGuard() {
+  const router = useRouter();
+
+  return (
+    <Onboarding
+      onComplete={() => {
+        router.refresh();
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- ダッシュボードにOnboardingウィザード統合 (チーム未登録時のみ表示)
- OnboardingGuardコンポーネント追加 (完了後にダッシュボードをリフレッシュ)
- テスト33件追加: Modal AI (10), LINE Messaging (11), Email Service (12)
- テスト総数: 221テスト全パス

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays an onboarding guide when no teams are configured, helping new users complete initial setup.
  * Onboarding automatically refreshes the dashboard upon completion to display newly configured teams and data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->