### PR TITLE
feat: 成績ページ強化・メンバーポータル・テスト追加 (287テスト)

### DIFF
--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -5,21 +5,86 @@ import {
   calculateTeamStats,
 } from "../lib/stats";
 
+// ファクトリ関数
+function createAtBat(
+  overrides: Partial<{
+    result: string;
+    rbi: number;
+    runs_scored: boolean;
+    stolen_base: boolean;
+  }> = {},
+) {
+  return {
+    result: "SINGLE",
+    rbi: 0,
+    runs_scored: false,
+    stolen_base: false,
+    ...overrides,
+  };
+}
+
+function createPitchingStat(
+  overrides: Partial<{
+    innings_pitched: number;
+    earned_runs: number;
+    hits_allowed: number;
+    walks: number;
+    strikeouts: number;
+    home_runs_allowed: number;
+    is_winning_pitcher: boolean;
+    is_losing_pitcher: boolean;
+  }> = {},
+) {
+  return {
+    innings_pitched: 7,
+    earned_runs: 0,
+    hits_allowed: 0,
+    walks: 0,
+    strikeouts: 0,
+    home_runs_allowed: 0,
+    is_winning_pitcher: false,
+    is_losing_pitcher: false,
+    ...overrides,
+  };
+}
+
+function createGameResult(
+  overrides: Partial<{
+    result: string | null;
+    our_score: number | null;
+    opponent_score: number | null;
+  }> = {},
+) {
+  return {
+    result: "WIN",
+    our_score: 5,
+    opponent_score: 3,
+    ...overrides,
+  };
+}
+
 describe("calculateBattingStats", () => {
   it("打席がないとき全て0を返す", () => {
     const stats = calculateBattingStats([], 0);
     expect(stats.avg).toBe(0);
     expect(stats.obp).toBe(0);
+    expect(stats.slg).toBe(0);
     expect(stats.ops).toBe(0);
+    expect(stats.plateAppearances).toBe(0);
+    expect(stats.atBats).toBe(0);
+    expect(stats.hits).toBe(0);
+    expect(stats.homeRuns).toBe(0);
+    expect(stats.rbi).toBe(0);
+    expect(stats.stolenBases).toBe(0);
   });
 
   it("打撃成績を正しく集計する", () => {
     const atBats = [
-      { result: "SINGLE", rbi: 1, runs_scored: true, stolen_base: false },
-      { result: "DOUBLE", rbi: 2, runs_scored: false, stolen_base: false },
-      { result: "STRIKEOUT", rbi: 0, runs_scored: false, stolen_base: false },
-      { result: "WALK", rbi: 0, runs_scored: false, stolen_base: true },
-      { result: "FLY_OUT", rbi: 0, runs_scored: false, stolen_base: false },
+      createAtBat({ result: "SINGLE", rbi: 1, runs_scored: true }),
+      createAtBat({ result: "DOUBLE", rbi: 2 }),
+      createAtBat({ result: "STRIKEOUT" }),
+      createAtBat({ result: "WALK", stolen_base: true }),
+      createAtBat({ result: "FLY_OUT" }),
     ];
     const stats = calculateBattingStats(atBats, 1);
 
@@ -35,12 +100,117 @@ describe("calculateBattingStats", () => {
 
   it("本塁打の長打率を正しく計算する", () => {
     const atBats = [
-      { result: "HOMERUN", rbi: 4, runs_scored: true, stolen_base: false },
-      { result: "GROUND_OUT", rbi: 0, runs_scored: false, stolen_base: false },
+      createAtBat({ result: "HOMERUN", rbi: 4, runs_scored: true }),
+      createAtBat({ result: "GROUND_OUT" }),
     ];
     const stats = calculateBattingStats(atBats, 1);
     expect(stats.avg).toBe(0.5);
     expect(stats.slg).toBe(2.0); // 4/2
+  });
+
+  describe("全打席が四球のとき", () => {
+    it("打率0・出塁率1.0を返す", () => {
+      const atBats = [
+        createAtBat({ result: "WALK" }),
+        createAtBat({ result: "WALK" }),
+        createAtBat({ result: "WALK" }),
+      ];
+      const stats = calculateBattingStats(atBats, 1);
+      expect(stats.atBats).toBe(0);
+      expect(stats.avg).toBe(0); // 0打数なので打率0
+      expect(stats.obp).toBe(1.0); // 3/3 = 1.0
+      expect(stats.slg).toBe(0); // 0打数なので長打率0
+      expect(stats.walks).toBe(3);
+    });
+  });
+
+  describe("パーフェクト打撃のとき", () => {
+    it("打率1.000を返す", () => {
+      const atBats = [
+        createAtBat({ result: "SINGLE", rbi: 1 }),
+        createAtBat({ result: "DOUBLE", rbi: 2 }),
+        createAtBat({ result: "TRIPLE", rbi: 1 }),
+        createAtBat({ result: "HOMERUN", rbi: 4 }),
+      ];
+      const stats = calculateBattingStats(atBats, 1);
+      expect(stats.avg).toBe(1.0);
+      expect(stats.hits).toBe(4);
+      expect(stats.singles).toBe(1);
+      expect(stats.doubles).toBe(1);
+      expect(stats.triples).toBe(1);
+      expect(stats.homeRuns).toBe(1);
+      expect(stats.obp).toBe(1.0);
+      expect(stats.slg).toBe(2.5); // (1+2+3+4)/4
+      expect(stats.ops).toBe(3.5); // 1.0 + 2.5
+      expect(stats.rbi).toBe(8);
+    });
+  });
+
+  describe("死球が含まれるとき", () => {
+    it("打数から除外し出塁率に含める", () => {
+      const atBats = [
+        createAtBat({ result: "HIT_BY_PITCH" }),
+        createAtBat({ result: "SINGLE", rbi: 1 }),
+        createAtBat({ result: "GROUND_OUT" }),
+      ];
+      const stats = calculateBattingStats(atBats, 1);
+      expect(stats.plateAppearances).toBe(3);
+      expect(stats.atBats).toBe(2); // HBPは打数除外
+      expect(stats.hitByPitch).toBe(1);
+      expect(stats.avg).toBe(0.5); // 1/2
+      expect(stats.obp).toBe(0.667); // (1+0+1)/3 = round3(0.6667)
+    });
+  });
+
+  describe("犠打・犠飛が含まれるとき", () => {
+    it("打数から除外する", () => {
+      const atBats = [
+        createAtBat({ result: "SAC_BUNT", rbi: 0 }),
+        createAtBat({ result: "SAC_FLY", rbi: 1 }),
+        createAtBat({ result: "SINGLE", rbi: 0 }),
+        createAtBat({ result: "STRIKEOUT" }),
+      ];
+      const stats = calculateBattingStats(atBats, 1);
+      expect(stats.plateAppearances).toBe(4);
+      expect(stats.atBats).toBe(2); // SAC_BUNT, SAC_FLYは除外
+      expect(stats.sacBunts).toBe(1);
+      expect(stats.sacFlies).toBe(1);
+      expect(stats.avg).toBe(0.5); // 1/2
+    });
+  });
+
+  describe("得点と盗塁の集計", () => {
+    it("正しくカウントする", () => {
+      const atBats = [
+        createAtBat({ result: "SINGLE", runs_scored: true, stolen_base: true }),
+        createAtBat({
+          result: "DOUBLE",
+          runs_scored: true,
+          stolen_base: false,
+        }),
+        createAtBat({ result: "GROUND_OUT", runs_scored: false }),
+      ];
+      const stats = calculateBattingStats(atBats, 2);
+      expect(stats.runsScored).toBe(2);
+      expect(stats.stolenBases).toBe(1);
+      expect(stats.games).toBe(2);
+    });
+  });
+
+  describe("三振のみのとき", () => {
+    it("打率0・出塁率0を返す", () => {
+      const atBats = [
+        createAtBat({ result: "STRIKEOUT" }),
+        createAtBat({ result: "STRIKEOUT" }),
+        createAtBat({ result: "STRIKEOUT" }),
+      ];
+      const stats = calculateBattingStats(atBats, 1);
+      expect(stats.avg).toBe(0);
+      expect(stats.obp).toBe(0);
+      expect(stats.slg).toBe(0);
+      expect(stats.ops).toBe(0);
+      expect(stats.strikeouts).toBe(3);
+    });
   });
 });
 
@@ -49,11 +219,17 @@ describe("calculatePitchingStats", () => {
     const stats = calculatePitchingStats([]);
     expect(stats.era).toBe(0);
     expect(stats.whip).toBe(0);
+    expect(stats.games).toBe(0);
+    expect(stats.wins).toBe(0);
+    expect(stats.losses).toBe(0);
+    expect(stats.strikeouts).toBe(0);
+    expect(stats.k9).toBe(0);
+    expect(stats.bb9).toBe(0);
   });
 
   it("投球成績を正しく集計する", () => {
     const stats = calculatePitchingStats([
-      {
+      createPitchingStat({
         innings_pitched: 7,
         earned_runs: 2,
         hits_allowed: 5,
@@ -61,14 +237,97 @@ describe("calculatePitchingStats", () => {
         strikeouts: 8,
         home_runs_allowed: 1,
         is_winning_pitcher: true,
-        is_losing_pitcher: false,
-      },
+      }),
     ]);
     expect(stats.games).toBe(1);
     expect(stats.wins).toBe(1);
     expect(stats.era).toBe(2); // (2/7)*7
     expect(stats.whip).toBe(1.14); // (5+3)/7
     expect(stats.strikeouts).toBe(8);
+  });
+
+  describe("完封投球のとき", () => {
+    it("ERA 0.00を返す", () => {
+      const stats = calculatePitchingStats([
+        createPitchingStat({
+          innings_pitched: 7,
+          earned_runs: 0,
+          hits_allowed: 3,
+          walks: 1,
+          strikeouts: 10,
+          is_winning_pitcher: true,
+        }),
+      ]);
+      expect(stats.era).toBe(0);
+      expect(stats.whip).toBe(0.57); // (3+1)/7 = 0.571...
+      expect(stats.wins).toBe(1);
+      expect(stats.losses).toBe(0);
+      expect(stats.strikeouts).toBe(10);
+    });
+  });
+
+  describe("複数登板の集計のとき", () => {
+    it("合計で正しく計算する", () => {
+      const stats = calculatePitchingStats([
+        createPitchingStat({
+          innings_pitched: 7,
+          earned_runs: 1,
+          hits_allowed: 4,
+          walks: 2,
+          strikeouts: 6,
+          is_winning_pitcher: true,
+        }),
+        createPitchingStat({
+          innings_pitched: 7,
+          earned_runs: 3,
+          hits_allowed: 6,
+          walks: 4,
+          strikeouts: 4,
+          is_losing_pitcher: true,
+        }),
+      ]);
+      expect(stats.games).toBe(2);
+      expect(stats.inningsPitched).toBe(14);
+      expect(stats.earnedRuns).toBe(4);
+      expect(stats.era).toBe(2); // (4/14)*7 = 2.0
+      expect(stats.whip).toBe(1.14); // (10+6)/14 = 1.142...
+      expect(stats.wins).toBe(1);
+      expect(stats.losses).toBe(1);
+      expect(stats.strikeouts).toBe(10);
+    });
+  });
+
+  describe("K/9とBB/9の計算のとき", () => {
+    it("正しい奪三振率・与四球率を返す", () => {
+      const stats = calculatePitchingStats([
+        createPitchingStat({
+          innings_pitched: 9,
+          earned_runs: 0,
+          hits_allowed: 0,
+          walks: 3,
+          strikeouts: 9,
+        }),
+      ]);
+      expect(stats.k9).toBe(9.0); // (9/9)*9
+      expect(stats.bb9).toBe(3.0); // (3/9)*9
+    });
+  });
+
+  describe("大量失点の登板のとき", () => {
+    it("高いERAを返す", () => {
+      const stats = calculatePitchingStats([
+        createPitchingStat({
+          innings_pitched: 1,
+          earned_runs: 10,
+          hits_allowed: 8,
+          walks: 5,
+          is_losing_pitcher: true,
+        }),
+      ]);
+      expect(stats.era).toBe(70); // (10/1)*7
+      expect(stats.whip).toBe(13); // (8+5)/1
+      expect(stats.losses).toBe(1);
+    });
   });
 });
 
@@ -77,14 +336,20 @@ describe("calculateTeamStats", () => {
     const stats = calculateTeamStats([]);
     expect(stats.totalGames).toBe(0);
     expect(stats.winRate).toBe(0);
+    expect(stats.wins).toBe(0);
+    expect(stats.losses).toBe(0);
+    expect(stats.draws).toBe(0);
+    expect(stats.totalRunsScored).toBe(0);
+    expect(stats.totalRunsAllowed).toBe(0);
+    expect(stats.runDifferential).toBe(0);
   });
 
   it("チーム統計を正しく集計する", () => {
     const stats = calculateTeamStats([
-      { result: "WIN", our_score: 5, opponent_score: 3 },
-      { result: "WIN", our_score: 7, opponent_score: 2 },
-      { result: "LOSE", our_score: 1, opponent_score: 4 },
-      { result: "DRAW", our_score: 3, opponent_score: 3 },
+      createGameResult({ result: "WIN", our_score: 5, opponent_score: 3 }),
+      createGameResult({ result: "WIN", our_score: 7, opponent_score: 2 }),
+      createGameResult({ result: "LOSE", our_score: 1, opponent_score: 4 }),
+      createGameResult({ result: "DRAW", our_score: 3, opponent_score: 3 }),
     ]);
     expect(stats.totalGames).toBe(4);
     expect(stats.wins).toBe(2);
@@ -92,5 +357,62 @@ describe("calculateTeamStats", () => {
     expect(stats.draws).toBe(1);
     expect(stats.winRate).toBe(0.667);
     expect(stats.runDifferential).toBe(4); // 16-12
+  });
+
+  describe("全勝のとき", () => {
+    it("勝率1.000を返す", () => {
+      const stats = calculateTeamStats([
+        createGameResult({ result: "WIN", our_score: 10, opponent_score: 0 }),
+        createGameResult({ result: "WIN", our_score: 5, opponent_score: 3 }),
+        createGameResult({ result: "WIN", our_score: 7, opponent_score: 1 }),
+      ]);
+      expect(stats.winRate).toBe(1.0);
+      expect(stats.wins).toBe(3);
+      expect(stats.losses).toBe(0);
+      expect(stats.totalRunsScored).toBe(22);
+      expect(stats.totalRunsAllowed).toBe(4);
+      expect(stats.runDifferential).toBe(18);
+    });
+  });
+
+  describe("全敗のとき", () => {
+    it("勝率0.000を返す", () => {
+      const stats = calculateTeamStats([
+        createGameResult({ result: "LOSE", our_score: 0, opponent_score: 5 }),
+        createGameResult({ result: "LOSE", our_score: 1, opponent_score: 10 }),
+      ]);
+      expect(stats.winRate).toBe(0);
+      expect(stats.wins).toBe(0);
+      expect(stats.losses).toBe(2);
+      expect(stats.runDifferential).toBe(-14);
+    });
+  });
+
+  describe("引き分けのみのとき", () => {
+    it("勝率0を返す (勝ち負けなし)", () => {
+      const stats = calculateTeamStats([
+        createGameResult({ result: "DRAW", our_score: 3, opponent_score: 3 }),
+        createGameResult({ result: "DRAW", our_score: 0, opponent_score: 0 }),
+      ]);
+      expect(stats.winRate).toBe(0); // 0勝0敗 → 0
+      expect(stats.draws).toBe(2);
+      expect(stats.runDifferential).toBe(0);
+    });
+  });
+
+  describe("スコアがnullの試合があるとき", () => {
+    it("nullを0として扱い集計する", () => {
+      const stats = calculateTeamStats([
+        createGameResult({
+          result: "WIN",
+          our_score: null,
+          opponent_score: null,
+        }),
+        createGameResult({ result: "WIN", our_score: 5, opponent_score: 3 }),
+      ]);
+      expect(stats.totalGames).toBe(2);
+      expect(stats.totalRunsScored).toBe(5); // null → 0
+      expect(stats.totalRunsAllowed).toBe(3);
+    });
   });
 });

--- a/packages/web/src/app/(manager)/members/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/members/[id]/page.tsx
@@ -1,0 +1,439 @@
+import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { calculateBattingStats } from "@match-engine/core";
+
+const TIER_LABELS: Record<string, string> = {
+  PRO: "プロ",
+  LITE: "ライト",
+};
+
+const TIER_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  PRO: "success",
+  LITE: "info",
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  SUPER_ADMIN: "管理者(代表)",
+  ADMIN: "管理者",
+  MEMBER: "メンバー",
+};
+
+const RESULT_LABELS: Record<string, string> = {
+  WIN: "勝ち",
+  LOSE: "負け",
+  DRAW: "引き分け",
+};
+
+const RESULT_TYPE: Record<
+  string,
+  "success" | "error" | "info" | "warning" | "stopped" | "pending"
+> = {
+  WIN: "success",
+  LOSE: "error",
+  DRAW: "info",
+};
+
+const ATTENDANCE_STATUS_LABELS: Record<string, string> = {
+  ATTENDED: "出席",
+  NO_SHOW: "無断欠席",
+  CANCELLED_SAME_DAY: "当日キャンセル",
+};
+
+const ATTENDANCE_STATUS_TYPE: Record<
+  string,
+  "success" | "error" | "warning" | "info" | "stopped" | "pending"
+> = {
+  ATTENDED: "success",
+  NO_SHOW: "error",
+  CANCELLED_SAME_DAY: "warning",
+};
+
+export default async function MemberProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // メンバー情報取得
+  const { data: member } = await supabase
+    .from("members")
+    .select("*, teams(id, name)")
+    .eq("id", id)
+    .single();
+
+  if (!member) {
+    return (
+      <ContentLayout header={<Header variant="h1">メンバー詳細</Header>}>
+        <Box textAlign="center" color="text-status-inactive" padding="xxl">
+          メンバーが見つかりません
+        </Box>
+      </ContentLayout>
+    );
+  }
+
+  const teamId = member.team_id;
+  const teamName =
+    (member.teams as unknown as { id: string; name: string } | null)?.name ??
+    "チーム";
+
+  // 打撃成績
+  const { data: atBats } = await supabase
+    .from("at_bats")
+    .select("result, rbi, runs_scored, stolen_base")
+    .eq("member_id", id);
+
+  // 出席記録
+  const { data: attendances } = await supabase
+    .from("attendances")
+    .select("id, game_id, status, recorded_at, games(title, game_date)")
+    .eq("person_id", id)
+    .order("recorded_at", { ascending: false });
+
+  const attendedCount =
+    attendances?.filter((a) => a.status === "ATTENDED").length ?? 0;
+
+  const battingStats = calculateBattingStats(atBats ?? [], attendedCount);
+
+  // 最近の試合結果 (最大5件)
+  const { data: recentGames } = await supabase
+    .from("attendances")
+    .select(
+      "game_id, status, games!inner(title, game_date, game_results(result, our_score, opponent_score))",
+    )
+    .eq("person_id", id)
+    .eq("status", "ATTENDED")
+    .order("recorded_at", { ascending: false })
+    .limit(5);
+
+  const positions = (member.positions_json as string[]) ?? [];
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: teamName, href: `/teams/${teamId}` },
+            { text: member.name, href: `/members/${id}` },
+          ]}
+        />
+      }
+      header={
+        <Header
+          variant="h1"
+          description={`${teamName} - ${ROLE_LABELS[member.role] ?? member.role}`}
+          actions={
+            <Link href={`/teams/${teamId}/stats`}>チーム成績に戻る</Link>
+          }
+        >
+          {member.name}
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {/* メンバー情報 */}
+        <Container header={<Header variant="h2">プロフィール</Header>}>
+          <ColumnLayout columns={3} variant="text-grid">
+            <KeyValuePairs
+              items={[
+                {
+                  label: "背番号",
+                  value:
+                    member.jersey_number != null
+                      ? `#${member.jersey_number}`
+                      : "未設定",
+                },
+                {
+                  label: "ポジション",
+                  value: positions.length > 0 ? positions.join(", ") : "未設定",
+                },
+              ]}
+            />
+            <KeyValuePairs
+              items={[
+                {
+                  label: "区分",
+                  value: (
+                    <StatusIndicator type={TIER_TYPE[member.tier] ?? "pending"}>
+                      {TIER_LABELS[member.tier] ?? member.tier}
+                    </StatusIndicator>
+                  ),
+                },
+                {
+                  label: "出席率",
+                  value: (
+                    <StatusIndicator
+                      type={
+                        member.attendance_rate >= 70
+                          ? "success"
+                          : member.attendance_rate >= 40
+                            ? "warning"
+                            : "error"
+                      }
+                    >
+                      {member.attendance_rate}%
+                    </StatusIndicator>
+                  ),
+                },
+              ]}
+            />
+            <KeyValuePairs
+              items={[
+                {
+                  label: "出席試合数",
+                  value: `${attendedCount}`,
+                },
+                {
+                  label: "入団日",
+                  value: member.joined_at
+                    ? new Date(member.joined_at).toLocaleDateString("ja-JP")
+                    : "不明",
+                },
+              ]}
+            />
+          </ColumnLayout>
+        </Container>
+
+        {/* 打撃成績 */}
+        <Container header={<Header variant="h2">打撃成績</Header>}>
+          {battingStats.plateAppearances === 0 ? (
+            <Box textAlign="center" color="text-body-secondary" padding="xxl">
+              打席データがまだありません
+            </Box>
+          ) : (
+            <ColumnLayout columns={4}>
+              <KeyValuePairs
+                items={[
+                  {
+                    label: "打率 (AVG)",
+                    value: (
+                      <Box fontSize="heading-m" fontWeight="bold">
+                        {battingStats.avg.toFixed(3)}
+                      </Box>
+                    ),
+                  },
+                  {
+                    label: "出塁率 (OBP)",
+                    value: battingStats.obp.toFixed(3),
+                  },
+                ]}
+              />
+              <KeyValuePairs
+                items={[
+                  {
+                    label: "長打率 (SLG)",
+                    value: battingStats.slg.toFixed(3),
+                  },
+                  {
+                    label: "OPS",
+                    value: (
+                      <StatusIndicator
+                        type={
+                          battingStats.ops >= 0.8
+                            ? "success"
+                            : battingStats.ops >= 0.6
+                              ? "info"
+                              : "pending"
+                        }
+                      >
+                        {battingStats.ops.toFixed(3)}
+                      </StatusIndicator>
+                    ),
+                  },
+                ]}
+              />
+              <KeyValuePairs
+                items={[
+                  {
+                    label: "安打",
+                    value: `${battingStats.hits}`,
+                  },
+                  {
+                    label: "本塁打",
+                    value: `${battingStats.homeRuns}`,
+                  },
+                ]}
+              />
+              <KeyValuePairs
+                items={[
+                  {
+                    label: "打点",
+                    value: `${battingStats.rbi}`,
+                  },
+                  {
+                    label: "盗塁",
+                    value: `${battingStats.stolenBases}`,
+                  },
+                ]}
+              />
+            </ColumnLayout>
+          )}
+        </Container>
+
+        {/* 最近の試合 */}
+        <Table
+          header={<Header variant="h2">最近の試合</Header>}
+          columnDefinitions={[
+            {
+              id: "date",
+              header: "日付",
+              cell: (item) => {
+                const game = item.games as unknown as {
+                  title: string;
+                  game_date: string | null;
+                  game_results: Array<{
+                    result: string | null;
+                    our_score: number | null;
+                    opponent_score: number | null;
+                  }>;
+                };
+                return game.game_date
+                  ? new Date(game.game_date).toLocaleDateString("ja-JP")
+                  : "—";
+              },
+            },
+            {
+              id: "title",
+              header: "試合",
+              cell: (item) => {
+                const game = item.games as unknown as {
+                  title: string;
+                  game_date: string | null;
+                  game_results: Array<{
+                    result: string | null;
+                    our_score: number | null;
+                    opponent_score: number | null;
+                  }>;
+                };
+                return (
+                  <Link href={`/games/${item.game_id}`}>{game.title}</Link>
+                );
+              },
+            },
+            {
+              id: "result",
+              header: "結果",
+              cell: (item) => {
+                const game = item.games as unknown as {
+                  title: string;
+                  game_date: string | null;
+                  game_results: Array<{
+                    result: string | null;
+                    our_score: number | null;
+                    opponent_score: number | null;
+                  }>;
+                };
+                const gr = game.game_results?.[0];
+                if (!gr?.result) return "—";
+                return (
+                  <StatusIndicator type={RESULT_TYPE[gr.result] ?? "pending"}>
+                    {RESULT_LABELS[gr.result] ?? gr.result}
+                  </StatusIndicator>
+                );
+              },
+            },
+            {
+              id: "score",
+              header: "スコア",
+              cell: (item) => {
+                const game = item.games as unknown as {
+                  title: string;
+                  game_date: string | null;
+                  game_results: Array<{
+                    result: string | null;
+                    our_score: number | null;
+                    opponent_score: number | null;
+                  }>;
+                };
+                const gr = game.game_results?.[0];
+                if (gr?.our_score == null) return "—";
+                return `${gr.our_score} - ${gr.opponent_score}`;
+              },
+            },
+          ]}
+          items={recentGames ?? []}
+          empty={
+            <Box textAlign="center" color="text-body-secondary" padding="xxl">
+              試合履歴がまだありません
+            </Box>
+          }
+          variant="embedded"
+        />
+
+        {/* 出席履歴 */}
+        <Table
+          header={
+            <Header variant="h2" counter={`(${attendances?.length ?? 0})`}>
+              出席履歴
+            </Header>
+          }
+          columnDefinitions={[
+            {
+              id: "date",
+              header: "日付",
+              cell: (item) => {
+                const game = item.games as unknown as {
+                  title: string;
+                  game_date: string | null;
+                } | null;
+                return game?.game_date
+                  ? new Date(game.game_date).toLocaleDateString("ja-JP")
+                  : item.recorded_at
+                    ? new Date(item.recorded_at).toLocaleDateString("ja-JP")
+                    : "—";
+              },
+            },
+            {
+              id: "game",
+              header: "試合",
+              cell: (item) => {
+                const game = item.games as unknown as {
+                  title: string;
+                  game_date: string | null;
+                } | null;
+                return game?.title ? (
+                  <Link href={`/games/${item.game_id}`}>{game.title}</Link>
+                ) : (
+                  "—"
+                );
+              },
+            },
+            {
+              id: "status",
+              header: "ステータス",
+              cell: (item) => (
+                <StatusIndicator
+                  type={ATTENDANCE_STATUS_TYPE[item.status] ?? "pending"}
+                >
+                  {ATTENDANCE_STATUS_LABELS[item.status] ?? item.status}
+                </StatusIndicator>
+              ),
+            },
+          ]}
+          items={attendances ?? []}
+          empty={
+            <Box textAlign="center" color="text-body-secondary" padding="xxl">
+              出席記録がまだありません
+            </Box>
+          }
+          variant="embedded"
+        />
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/stats/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/stats/page.tsx
@@ -60,6 +60,29 @@ export default async function StatsPage({
 
   memberStats.sort((a, b) => b.avg - a.avg);
 
+  // チーム打撃平均
+  const teamBattingAvg =
+    memberStats.length > 0
+      ? memberStats.reduce((sum, s) => sum + s.avg, 0) / memberStats.length
+      : 0;
+
+  // リーダーボード (rank付き)
+  const battingAvgLeaders = [...memberStats]
+    .filter((s) => s.atBats >= 1)
+    .sort((a, b) => b.avg - a.avg)
+    .slice(0, 5)
+    .map((s, i) => ({ ...s, rank: i + 1 }));
+  const hrLeaders = [...memberStats]
+    .filter((s) => s.homeRuns >= 1)
+    .sort((a, b) => b.homeRuns - a.homeRuns)
+    .slice(0, 5)
+    .map((s, i) => ({ ...s, rank: i + 1 }));
+  const rbiLeaders = [...memberStats]
+    .filter((s) => s.rbi >= 1)
+    .sort((a, b) => b.rbi - a.rbi)
+    .slice(0, 5)
+    .map((s, i) => ({ ...s, rank: i + 1 }));
+
   return (
     <ContentLayout
       breadcrumbs={
@@ -82,6 +105,7 @@ export default async function StatsPage({
       }
     >
       <SpaceBetween size="l">
+        {/* チーム戦績サマリー */}
         <Container header={<Header variant="h2">チーム戦績</Header>}>
           {teamStats.totalGames === 0 ? (
             <Box textAlign="center" color="text-body-secondary" padding="xxl">
@@ -92,8 +116,12 @@ export default async function StatsPage({
               <KeyValuePairs
                 items={[
                   {
-                    label: "勝敗",
-                    value: `${teamStats.wins}勝${teamStats.losses}敗${teamStats.draws}分`,
+                    label: "戦績 (W-L-D)",
+                    value: (
+                      <Box fontSize="heading-m" fontWeight="bold">
+                        {teamStats.wins}-{teamStats.losses}-{teamStats.draws}
+                      </Box>
+                    ),
                   },
                 ]}
               />
@@ -108,6 +136,14 @@ export default async function StatsPage({
                         {teamStats.winRate.toFixed(3)}
                       </StatusIndicator>
                     ),
+                  },
+                ]}
+              />
+              <KeyValuePairs
+                items={[
+                  {
+                    label: "チーム打率",
+                    value: teamBattingAvg.toFixed(3),
                   },
                 ]}
               />
@@ -130,13 +166,132 @@ export default async function StatsPage({
                   },
                 ]}
               />
-              <KeyValuePairs
-                items={[{ label: "試合数", value: `${teamStats.totalGames}` }]}
-              />
             </ColumnLayout>
           )}
         </Container>
 
+        {/* 個人リーダーボード */}
+        {memberStats.length > 0 && (
+          <ColumnLayout columns={3}>
+            <Container header={<Header variant="h3">打率リーダー</Header>}>
+              {battingAvgLeaders.length === 0 ? (
+                <Box textAlign="center" color="text-body-secondary" padding="s">
+                  データなし
+                </Box>
+              ) : (
+                <Table
+                  variant="embedded"
+                  columnDefinitions={[
+                    {
+                      id: "rank",
+                      header: "#",
+                      cell: (item) => item.rank,
+                      width: 50,
+                    },
+                    {
+                      id: "name",
+                      header: "選手",
+                      cell: (item) => (
+                        <Link
+                          href={`/members/${item.member_id}`}
+                          variant="secondary"
+                        >
+                          {item.name}
+                        </Link>
+                      ),
+                    },
+                    {
+                      id: "avg",
+                      header: "打率",
+                      cell: (item) => (
+                        <Box fontWeight="bold">{item.avg.toFixed(3)}</Box>
+                      ),
+                    },
+                  ]}
+                  items={battingAvgLeaders}
+                />
+              )}
+            </Container>
+            <Container header={<Header variant="h3">本塁打リーダー</Header>}>
+              {hrLeaders.length === 0 ? (
+                <Box textAlign="center" color="text-body-secondary" padding="s">
+                  データなし
+                </Box>
+              ) : (
+                <Table
+                  variant="embedded"
+                  columnDefinitions={[
+                    {
+                      id: "rank",
+                      header: "#",
+                      cell: (item) => item.rank,
+                      width: 50,
+                    },
+                    {
+                      id: "name",
+                      header: "選手",
+                      cell: (item) => (
+                        <Link
+                          href={`/members/${item.member_id}`}
+                          variant="secondary"
+                        >
+                          {item.name}
+                        </Link>
+                      ),
+                    },
+                    {
+                      id: "hr",
+                      header: "HR",
+                      cell: (item) => (
+                        <Box fontWeight="bold">{item.homeRuns}</Box>
+                      ),
+                    },
+                  ]}
+                  items={hrLeaders}
+                />
+              )}
+            </Container>
+            <Container header={<Header variant="h3">打点リーダー</Header>}>
+              {rbiLeaders.length === 0 ? (
+                <Box textAlign="center" color="text-body-secondary" padding="s">
+                  データなし
+                </Box>
+              ) : (
+                <Table
+                  variant="embedded"
+                  columnDefinitions={[
+                    {
+                      id: "rank",
+                      header: "#",
+                      cell: (item) => item.rank,
+                      width: 50,
+                    },
+                    {
+                      id: "name",
+                      header: "選手",
+                      cell: (item) => (
+                        <Link
+                          href={`/members/${item.member_id}`}
+                          variant="secondary"
+                        >
+                          {item.name}
+                        </Link>
+                      ),
+                    },
+                    {
+                      id: "rbi",
+                      header: "打点",
+                      cell: (item) => <Box fontWeight="bold">{item.rbi}</Box>,
+                    },
+                  ]}
+                  items={rbiLeaders}
+                />
+              )}
+            </Container>
+          </ColumnLayout>
+        )}
+
+        {/* 個人打撃成績テーブル */}
         <Table
           header={
             <Header variant="h2" counter={`(${memberStats.length})`}>
@@ -147,60 +302,84 @@ export default async function StatsPage({
             {
               id: "name",
               header: "選手",
-              cell: (item) => item.name,
+              cell: (item) => (
+                <Link href={`/members/${item.member_id}`}>{item.name}</Link>
+              ),
               sortingField: "name",
             },
             {
               id: "games",
               header: "試合",
               cell: (item) => item.games,
+              sortingField: "games",
             },
             {
               id: "avg",
               header: "打率",
-              cell: (item) => item.avg.toFixed(3),
+              cell: (item) => (
+                <Box fontWeight="bold">{item.avg.toFixed(3)}</Box>
+              ),
               sortingField: "avg",
             },
             {
               id: "pa",
               header: "打席",
               cell: (item) => item.plateAppearances,
+              sortingField: "plateAppearances",
             },
             {
               id: "hits",
               header: "安打",
               cell: (item) => item.hits,
+              sortingField: "hits",
             },
             {
               id: "hr",
               header: "本塁打",
               cell: (item) => item.homeRuns,
+              sortingField: "homeRuns",
             },
             {
               id: "rbi",
               header: "打点",
               cell: (item) => item.rbi,
+              sortingField: "rbi",
             },
             {
               id: "obp",
               header: "出塁率",
               cell: (item) => item.obp.toFixed(3),
+              sortingField: "obp",
             },
             {
               id: "slg",
               header: "長打率",
               cell: (item) => item.slg.toFixed(3),
+              sortingField: "slg",
             },
             {
               id: "ops",
               header: "OPS",
-              cell: (item) => item.ops.toFixed(3),
+              cell: (item) => (
+                <StatusIndicator
+                  type={
+                    item.ops >= 0.8
+                      ? "success"
+                      : item.ops >= 0.6
+                        ? "info"
+                        : "pending"
+                  }
+                >
+                  {item.ops.toFixed(3)}
+                </StatusIndicator>
+              ),
               sortingField: "ops",
             },
             {
               id: "sb",
               header: "盗塁",
               cell: (item) => item.stolenBases,
+              sortingField: "stolenBases",
             },
           ]}
           items={memberStats}
@@ -211,6 +390,7 @@ export default async function StatsPage({
           }
           variant="full-page"
           stickyHeader
+          sortingDisabled={false}
         />
       </SpaceBetween>
     </ContentLayout>


### PR DESCRIPTION
## Summary
- 成績ページ強化: チーム戦績 (W-L-D)、打率リーダーボード (TOP5)、HR/RBIランキング
- メンバーポータル (`/members/[id]`): プロフィール、打撃成績、直近試合、出席履歴
- 成績テスト12件追加: エッジケース (全四球、完全打率、投手ERA) — 計287テスト

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n