### PR TITLE
feat: 助っ人管理UI + カレンダー改善 + 試合作成ウィザード強化

### DIFF
--- a/packages/web/src/app/(manager)/games/[id]/helpers/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/helpers/page.tsx
@@ -1,0 +1,292 @@
+import { createClient } from "@/lib/supabase/server";
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+
+const HELPER_REQUEST_STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  PENDING: "pending",
+  ACCEPTED: "success",
+  DECLINED: "error",
+  CANCELLED: "stopped",
+};
+
+const HELPER_REQUEST_STATUS_LABELS: Record<string, string> = {
+  PENDING: "打診中",
+  ACCEPTED: "承諾",
+  DECLINED: "辞退",
+  CANCELLED: "キャンセル",
+};
+
+export default async function GameHelpersPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: game } = await supabase
+    .from("games")
+    .select("id, title, team_id")
+    .eq("id", id)
+    .single();
+
+  if (!game) {
+    return (
+      <ContentLayout header={<Header variant="h1">助っ人管理</Header>}>
+        <Box textAlign="center" color="text-status-inactive" padding="xxl">
+          試合が見つかりません
+        </Box>
+      </ContentLayout>
+    );
+  }
+
+  const { data: helperRequests } = await supabase
+    .from("helper_requests")
+    .select("*, helpers(name, note, reliability_score)")
+    .eq("game_id", id)
+    .order("created_at", { ascending: false });
+
+  const requests = helperRequests ?? [];
+  const summary = {
+    pending: requests.filter((r) => r.status === "PENDING").length,
+    accepted: requests.filter((r) => r.status === "ACCEPTED").length,
+    declined: requests.filter((r) => r.status === "DECLINED").length,
+    cancelled: requests.filter((r) => r.status === "CANCELLED").length,
+    total: requests.length,
+  };
+
+  // チームの助っ人一覧 (新規打診用)
+  const { data: helpers } = await supabase
+    .from("helpers")
+    .select("id, name, reliability_score")
+    .eq("team_id", game.team_id)
+    .order("reliability_score", { ascending: false });
+
+  // 既に打診済みの助っ人IDを除外
+  const requestedHelperIds = new Set(requests.map((r) => r.helper_id));
+  const availableHelpers = (helpers ?? []).filter(
+    (h) => !requestedHelperIds.has(h.id),
+  );
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: game.title, href: `/games/${id}` },
+            { text: "助っ人管理", href: `/games/${id}/helpers` },
+          ]}
+        />
+      }
+      header={
+        <Header
+          variant="h1"
+          counter={requests.length > 0 ? `(${requests.length})` : undefined}
+          description={`${game.title} の助っ人打診状況`}
+        >
+          助っ人管理
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Container header={<Header variant="h2">打診サマリ</Header>}>
+          <SpaceBetween direction="horizontal" size="xl">
+            <Box>
+              <Box variant="awsui-key-label">打診中</Box>
+              <Box fontSize="display-l" fontWeight="bold">
+                {summary.pending}
+              </Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">承諾</Box>
+              <Box
+                fontSize="display-l"
+                fontWeight="bold"
+                color="text-status-success"
+              >
+                {summary.accepted}
+              </Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">辞退</Box>
+              <Box
+                fontSize="display-l"
+                fontWeight="bold"
+                color="text-status-error"
+              >
+                {summary.declined}
+              </Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">キャンセル</Box>
+              <Box fontSize="display-l" fontWeight="bold">
+                {summary.cancelled}
+              </Box>
+            </Box>
+          </SpaceBetween>
+        </Container>
+
+        {requests.length > 0 ? (
+          <Table
+            header={
+              <Header variant="h2" counter={`(${requests.length})`}>
+                打診一覧
+              </Header>
+            }
+            columnDefinitions={[
+              {
+                id: "name",
+                header: "助っ人名",
+                cell: (item) => {
+                  const helper = item.helpers as {
+                    name: string;
+                    note: string | null;
+                    reliability_score: number;
+                  } | null;
+                  return helper?.name ?? "—";
+                },
+                sortingField: "name",
+              },
+              {
+                id: "reliability",
+                header: "信頼度",
+                cell: (item) => {
+                  const helper = item.helpers as {
+                    name: string;
+                    note: string | null;
+                    reliability_score: number;
+                  } | null;
+                  if (!helper) return "—";
+                  const score = Number(helper.reliability_score);
+                  const type =
+                    score >= 0.8
+                      ? "success"
+                      : score >= 0.5
+                        ? "warning"
+                        : "error";
+                  return (
+                    <StatusIndicator
+                      type={type as "success" | "warning" | "error"}
+                    >
+                      {(score * 100).toFixed(0)}%
+                    </StatusIndicator>
+                  );
+                },
+              },
+              {
+                id: "status",
+                header: "ステータス",
+                cell: (item) => (
+                  <StatusIndicator
+                    type={HELPER_REQUEST_STATUS_TYPE[item.status] ?? "pending"}
+                  >
+                    {HELPER_REQUEST_STATUS_LABELS[item.status] ?? item.status}
+                  </StatusIndicator>
+                ),
+              },
+              {
+                id: "sent_at",
+                header: "打診日",
+                cell: (item) =>
+                  item.sent_at
+                    ? new Date(item.sent_at).toLocaleDateString("ja-JP")
+                    : "—",
+              },
+              {
+                id: "responded_at",
+                header: "回答日",
+                cell: (item) =>
+                  item.responded_at
+                    ? new Date(item.responded_at).toLocaleDateString("ja-JP")
+                    : "—",
+              },
+              {
+                id: "message",
+                header: "メッセージ",
+                cell: (item) => item.message ?? "—",
+                maxWidth: 200,
+              },
+            ]}
+            items={requests}
+            variant="embedded"
+          />
+        ) : (
+          <Container header={<Header variant="h2">打診一覧</Header>}>
+            <Box textAlign="center" color="text-status-inactive" padding="l">
+              助っ人への打診がありません
+            </Box>
+          </Container>
+        )}
+
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="まだ打診していない助っ人の一覧です"
+            >
+              新規打診
+            </Header>
+          }
+        >
+          {availableHelpers.length > 0 ? (
+            <Table
+              columnDefinitions={[
+                {
+                  id: "name",
+                  header: "助っ人名",
+                  cell: (item) => item.name,
+                },
+                {
+                  id: "reliability",
+                  header: "信頼度",
+                  cell: (item) => {
+                    const score = Number(item.reliability_score);
+                    const type =
+                      score >= 0.8
+                        ? "success"
+                        : score >= 0.5
+                          ? "warning"
+                          : "error";
+                    return (
+                      <StatusIndicator
+                        type={type as "success" | "warning" | "error"}
+                      >
+                        {(score * 100).toFixed(0)}%
+                      </StatusIndicator>
+                    );
+                  },
+                },
+              ]}
+              items={availableHelpers}
+              variant="embedded"
+            />
+          ) : (
+            <Box textAlign="center" color="text-status-inactive" padding="l">
+              {(helpers ?? []).length === 0
+                ? "チームに助っ人が登録されていません"
+                : "すべての助っ人に打診済みです"}
+            </Box>
+          )}
+        </Container>
+
+        <Box>
+          <Link href={`/games/${id}`}>
+            <Button variant="link">試合詳細に戻る</Button>
+          </Link>
+        </Box>
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -144,6 +144,9 @@ export default async function GameDetailPage({
               <Link href={`/games/${game.id}/negotiations`}>
                 <Button>対戦交渉を管理</Button>
               </Link>
+              <Link href={`/games/${game.id}/helpers`}>
+                <Button>助っ人を管理</Button>
+              </Link>
               {(game.status === "COMPLETED" || game.status === "SETTLED") && (
                 <Link href={`/games/${game.id}/expenses`}>
                   <Button>支出・精算を管理</Button>

--- a/packages/web/src/app/(manager)/games/new/page.tsx
+++ b/packages/web/src/app/(manager)/games/new/page.tsx
@@ -5,20 +5,21 @@ import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
-import DateInput from "@cloudscape-design/components/date-input";
+import DatePicker from "@cloudscape-design/components/date-picker";
 import Flashbar from "@cloudscape-design/components/flashbar";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
 import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import Select from "@cloudscape-design/components/select";
+import type { SelectProps } from "@cloudscape-design/components/select";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Textarea from "@cloudscape-design/components/textarea";
 import TimeInput from "@cloudscape-design/components/time-input";
 import Wizard from "@cloudscape-design/components/wizard";
 import type { GameType } from "@match-engine/core";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const GAME_TYPE_OPTIONS = [
   { label: "練習", value: "PRACTICE" },
@@ -27,6 +28,18 @@ const GAME_TYPE_OPTIONS = [
   { label: "トーナメント", value: "TOURNAMENT" },
 ];
 
+interface GroundOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+interface OpponentOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
 export default function NewGamePage() {
   const router = useRouter();
   const [activeStepIndex, setActiveStepIndex] = useState(0);
@@ -34,27 +47,99 @@ export default function NewGamePage() {
   const [gameType, setGameType] = useState<GameType>("FRIENDLY");
   const [gameDate, setGameDate] = useState("");
   const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
   const [groundName, setGroundName] = useState("");
+  const [selectedGround, setSelectedGround] =
+    useState<SelectProps.Option | null>(null);
+  const [selectedOpponent, setSelectedOpponent] =
+    useState<SelectProps.Option | null>(null);
   const [minPlayers, setMinPlayers] = useState("9");
   const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [groundOptions, setGroundOptions] = useState<GroundOption[]>([]);
+  const [opponentOptions, setOpponentOptions] = useState<OpponentOption[]>([]);
+  const [loadingGrounds, setLoadingGrounds] = useState(true);
+  const [loadingOpponents, setLoadingOpponents] = useState(true);
+
+  const teamId = process.env.NEXT_PUBLIC_DEFAULT_TEAM_ID;
+
+  useEffect(() => {
+    const fetchGrounds = async () => {
+      if (!teamId) {
+        setLoadingGrounds(false);
+        return;
+      }
+      try {
+        const res = await fetch(`/api/grounds?team_id=${teamId}`);
+        if (res.ok) {
+          const data = await res.json();
+          const grounds = data.data ?? [];
+          setGroundOptions(
+            grounds.map(
+              (g: { id: string; name: string; municipality?: string }) => ({
+                label: g.name,
+                value: g.id,
+                description: g.municipality ?? undefined,
+              }),
+            ),
+          );
+        }
+      } catch {
+        // ignore
+      } finally {
+        setLoadingGrounds(false);
+      }
+    };
+
+    const fetchOpponents = async () => {
+      if (!teamId) {
+        setLoadingOpponents(false);
+        return;
+      }
+      try {
+        const res = await fetch(`/api/teams/${teamId}/opponents`);
+        if (res.ok) {
+          const data = await res.json();
+          const opponents = data.data ?? [];
+          setOpponentOptions(
+            opponents.map((o: { id: string; name: string; area?: string }) => ({
+              label: o.name,
+              value: o.id,
+              description: o.area ?? undefined,
+            })),
+          );
+        }
+      } catch {
+        // ignore
+      } finally {
+        setLoadingOpponents(false);
+      }
+    };
+
+    fetchGrounds();
+    fetchOpponents();
+  }, [teamId]);
+
   const handleSubmit = async () => {
     setSubmitting(true);
     setError(null);
+
+    const resolvedGroundName = selectedGround?.label ?? (groundName || null);
 
     try {
       const res = await fetch("/api/games", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          team_id: process.env.NEXT_PUBLIC_DEFAULT_TEAM_ID,
+          team_id: teamId,
           title,
           game_type: gameType,
           game_date: gameDate || null,
           start_time: startTime || null,
-          ground_name: groundName || null,
+          end_time: endTime || null,
+          ground_name: resolvedGroundName,
           min_players: Number.parseInt(minPlayers) || 9,
           note: note || null,
         }),
@@ -76,6 +161,9 @@ export default function NewGamePage() {
 
   const gameTypeLabel =
     GAME_TYPE_OPTIONS.find((o) => o.value === gameType)?.label ?? gameType;
+
+  const resolvedGroundDisplay = selectedGround?.label ?? (groundName || "未定");
+  const resolvedOpponentDisplay = selectedOpponent?.label ?? "未選択";
 
   return (
     <ContentLayout
@@ -150,37 +238,96 @@ export default function NewGamePage() {
                     />
                   </FormField>
                   <FormField label="試合日">
-                    <DateInput
+                    <DatePicker
                       value={gameDate}
                       onChange={({ detail }) => setGameDate(detail.value)}
                       placeholder="YYYY/MM/DD"
+                      openCalendarAriaLabel={(selectedDate) =>
+                        selectedDate
+                          ? `選択中の日付: ${selectedDate}`
+                          : "日付を選択"
+                      }
                     />
                   </FormField>
-                  <FormField label="開始時刻">
-                    <TimeInput
-                      value={startTime}
-                      onChange={({ detail }) => setStartTime(detail.value)}
-                      format="hh:mm"
-                      placeholder="HH:mm"
-                    />
-                  </FormField>
+                  <ColumnLayout columns={2}>
+                    <FormField label="開始時刻">
+                      <TimeInput
+                        value={startTime}
+                        onChange={({ detail }) => setStartTime(detail.value)}
+                        format="hh:mm"
+                        placeholder="HH:mm"
+                      />
+                    </FormField>
+                    <FormField label="終了時刻">
+                      <TimeInput
+                        value={endTime}
+                        onChange={({ detail }) => setEndTime(detail.value)}
+                        format="hh:mm"
+                        placeholder="HH:mm"
+                      />
+                    </FormField>
+                  </ColumnLayout>
                 </SpaceBetween>
               </Container>
             ),
           },
           {
             title: "グラウンド・相手",
-            description: "グラウンドと人数の設定を行います",
+            description: "グラウンドと対戦相手の設定を行います",
             content: (
               <Container
                 header={<Header variant="h2">グラウンド・相手</Header>}
               >
                 <SpaceBetween size="l">
-                  <FormField label="グラウンド">
-                    <Input
-                      value={groundName}
-                      onChange={({ detail }) => setGroundName(detail.value)}
-                      placeholder="例: 八部公園野球場"
+                  <FormField
+                    label="グラウンド"
+                    description="登録済みのグラウンドから選択するか、名前を直接入力してください"
+                  >
+                    <SpaceBetween size="xs">
+                      <Select
+                        selectedOption={selectedGround}
+                        onChange={({ detail }) => {
+                          setSelectedGround(detail.selectedOption);
+                          if (detail.selectedOption?.label) {
+                            setGroundName(detail.selectedOption.label);
+                          }
+                        }}
+                        options={groundOptions}
+                        placeholder="登録済みグラウンドから選択"
+                        loadingText="読み込み中..."
+                        statusType={loadingGrounds ? "loading" : "finished"}
+                        empty="登録済みグラウンドがありません"
+                        filteringType="auto"
+                      />
+                      <FormField label="または直接入力">
+                        <Input
+                          value={groundName}
+                          onChange={({ detail }) => {
+                            setGroundName(detail.value);
+                            if (detail.value !== selectedGround?.label) {
+                              setSelectedGround(null);
+                            }
+                          }}
+                          placeholder="例: 八部公園野球場"
+                        />
+                      </FormField>
+                    </SpaceBetween>
+                  </FormField>
+                  <FormField
+                    label="対戦相手"
+                    description="登録済みの対戦相手から選択できます (任意)"
+                  >
+                    <Select
+                      selectedOption={selectedOpponent}
+                      onChange={({ detail }) =>
+                        setSelectedOpponent(detail.selectedOption)
+                      }
+                      options={opponentOptions}
+                      placeholder="対戦相手を選択 (任意)"
+                      loadingText="読み込み中..."
+                      statusType={loadingOpponents ? "loading" : "finished"}
+                      empty="登録済み対戦相手がありません"
+                      filteringType="auto"
                     />
                   </FormField>
                   <FormField label="最低人数">
@@ -217,13 +364,21 @@ export default function NewGamePage() {
                           label: "開始時刻",
                           value: startTime || "未定",
                         },
+                        {
+                          label: "終了時刻",
+                          value: endTime || "未定",
+                        },
                       ]}
                     />
                     <KeyValuePairs
                       items={[
                         {
                           label: "グラウンド",
-                          value: groundName || "未定",
+                          value: resolvedGroundDisplay,
+                        },
+                        {
+                          label: "対戦相手",
+                          value: resolvedOpponentDisplay,
                         },
                         {
                           label: "最低人数",

--- a/packages/web/src/app/(manager)/teams/[id]/calendar/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/calendar/page.tsx
@@ -8,8 +8,41 @@ import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
+import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { use, useMemo, useState } from "react";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { use, useEffect, useMemo, useState } from "react";
+
+interface UpcomingGame {
+  id: string;
+  title: string;
+  game_date: string | null;
+  start_time: string | null;
+  ground_name: string | null;
+  status: string;
+}
+
+const STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  COLLECTING: "info",
+  CONFIRMED: "success",
+  COMPLETED: "success",
+  SETTLED: "stopped",
+  CANCELLED: "error",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: "下書き",
+  COLLECTING: "出欠収集中",
+  CONFIRMED: "確定",
+  COMPLETED: "完了",
+  SETTLED: "精算済み",
+  CANCELLED: "中止",
+};
 
 export default function CalendarPage({
   params,
@@ -18,16 +51,60 @@ export default function CalendarPage({
 }) {
   const { id } = use(params);
   const [copied, setCopied] = useState(false);
+  const [upcomingGames, setUpcomingGames] = useState<UpcomingGame[]>([]);
+  const [loading, setLoading] = useState(true);
 
   const calendarUrl = useMemo(() => {
     if (typeof window === "undefined") return "";
     return `${window.location.origin}/api/teams/${id}/calendar`;
   }, [id]);
 
+  const googleCalendarUrl = useMemo(() => {
+    if (!calendarUrl) return "";
+    // Google Calendar uses webcal:// protocol for subscriptions
+    const webcalUrl = calendarUrl.replace(/^https?:\/\//, "webcal://");
+    return `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(webcalUrl)}`;
+  }, [calendarUrl]);
+
+  useEffect(() => {
+    const fetchGames = async () => {
+      try {
+        const res = await fetch(`/api/teams/${id}/calendar`);
+        if (!res.ok) {
+          setLoading(false);
+          return;
+        }
+        // The calendar API returns ics text, so we fetch games from the games API instead
+        const gamesRes = await fetch(
+          `/api/games?team_id=${id}&limit=5&upcoming=true`,
+        );
+        if (gamesRes.ok) {
+          const data = await gamesRes.json();
+          setUpcomingGames(data.data ?? []);
+        }
+      } catch {
+        // ignore errors
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchGames();
+  }, [id]);
+
   const handleCopy = async () => {
     await navigator.clipboard.writeText(calendarUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownloadIcs = () => {
+    // Trigger download of .ics file
+    const link = document.createElement("a");
+    link.href = calendarUrl;
+    link.download = "games.ics";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
 
   return (
@@ -61,6 +138,79 @@ export default function CalendarPage({
           </SpaceBetween>
         </Container>
 
+        <Container header={<Header variant="h2">エクスポート</Header>}>
+          <SpaceBetween size="m">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={handleDownloadIcs} iconName="download">
+                .ics ファイルをダウンロード
+              </Button>
+              <Link href={googleCalendarUrl} external>
+                <Button iconName="external">Google カレンダーに追加</Button>
+              </Link>
+            </SpaceBetween>
+            <Box variant="small" color="text-body-secondary">
+              .ics ファイルはカレンダーアプリに直接インポートできます。Google
+              カレンダーボタンは購読URLを自動登録します。
+            </Box>
+          </SpaceBetween>
+        </Container>
+
+        <Container
+          header={
+            <Header variant="h2" description="直近の試合予定を表示しています">
+              直近の試合
+            </Header>
+          }
+        >
+          {loading ? (
+            <Box textAlign="center" padding="l">
+              <StatusIndicator type="loading">読み込み中...</StatusIndicator>
+            </Box>
+          ) : upcomingGames.length > 0 ? (
+            <Table
+              columnDefinitions={[
+                {
+                  id: "title",
+                  header: "タイトル",
+                  cell: (item) => (
+                    <Link href={`/games/${item.id}`}>{item.title}</Link>
+                  ),
+                },
+                {
+                  id: "game_date",
+                  header: "試合日",
+                  cell: (item) => item.game_date ?? "未定",
+                },
+                {
+                  id: "start_time",
+                  header: "開始時刻",
+                  cell: (item) => item.start_time ?? "未定",
+                },
+                {
+                  id: "ground_name",
+                  header: "グラウンド",
+                  cell: (item) => item.ground_name ?? "未定",
+                },
+                {
+                  id: "status",
+                  header: "ステータス",
+                  cell: (item) => (
+                    <StatusIndicator type={STATUS_TYPE[item.status] ?? "info"}>
+                      {STATUS_LABELS[item.status] ?? item.status}
+                    </StatusIndicator>
+                  ),
+                },
+              ]}
+              items={upcomingGames}
+              variant="embedded"
+            />
+          ) : (
+            <Box textAlign="center" color="text-status-inactive" padding="l">
+              直近の試合予定はありません
+            </Box>
+          )}
+        </Container>
+
         <Container
           header={<Header variant="h2">カレンダーアプリへの登録方法</Header>}
         >
@@ -68,7 +218,8 @@ export default function CalendarPage({
             <Alert type="info" header="Google カレンダー">
               <ol>
                 <li>
-                  Google カレンダーを開き、左メニューの「他のカレンダー」横の
+                  上の「Google カレンダーに追加」ボタンをクリック、または Google
+                  カレンダーを開き、左メニューの「他のカレンダー」横の
                   「+」をクリック
                 </li>
                 <li>「URL で追加」を選択</li>


### PR DESCRIPTION
## Summary
- 助っ人リクエスト管理ページ (`/games/[id]/helpers`) — ステータスダッシュボード、リクエスト一覧、新規依頼
- 試合詳細ページに「助っ人を管理」ボタン追加
- カレンダーページ改善: .icsダウンロード、Google Calendar購読URL、直近試合リスト
- 試合作成ウィザード改善: グラウンド/対戦相手をDBから選択、DatePicker、終了時刻追加

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n