### PR TITLE
feat: 出席記録・試合結果入力・打席結果入力ページ

### DIFF
--- a/packages/web/src/app/(manager)/games/[id]/at-bats/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/at-bats/page.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Link from "@cloudscape-design/components/link";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+interface AttendedMember {
+  person_id: string;
+  name: string;
+}
+
+interface AtBatEntry {
+  id: string;
+  member_id: string;
+  member_name: string;
+  inning: number;
+  batting_order: number | null;
+  result: string;
+}
+
+const RESULT_OPTIONS: SelectProps.Option[] = [
+  { label: "安打 (シングル)", value: "SINGLE" },
+  { label: "二塁打", value: "DOUBLE" },
+  { label: "三塁打", value: "TRIPLE" },
+  { label: "本塁打", value: "HOMERUN" },
+  { label: "ゴロアウト", value: "GROUND_OUT" },
+  { label: "フライアウト", value: "FLY_OUT" },
+  { label: "ライナーアウト", value: "LINE_OUT" },
+  { label: "三振", value: "STRIKEOUT" },
+  { label: "併殺", value: "DOUBLE_PLAY" },
+  { label: "フィルダースチョイス", value: "FIELDERS_CHOICE" },
+  { label: "エラー", value: "ERROR" },
+  { label: "四球", value: "WALK" },
+  { label: "死球", value: "HIT_BY_PITCH" },
+  { label: "犠打", value: "SAC_BUNT" },
+  { label: "犠飛", value: "SAC_FLY" },
+];
+
+const RESULT_LABELS: Record<string, string> = {};
+for (const opt of RESULT_OPTIONS) {
+  if (opt.value) RESULT_LABELS[opt.value] = opt.label ?? opt.value;
+}
+
+export default function AtBatsPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [gameTitle, setGameTitle] = useState("");
+  const [attendedMembers, setAttendedMembers] = useState<AttendedMember[]>([]);
+  const [atBats, setAtBats] = useState<AtBatEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // New at-bat form state
+  const [selectedMember, setSelectedMember] =
+    useState<SelectProps.Option | null>(null);
+  const [inning, setInning] = useState("1");
+  const [battingOrder, setBattingOrder] = useState("");
+  const [selectedResult, setSelectedResult] =
+    useState<SelectProps.Option | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // Load game info
+      const gameRes = await fetch(`/api/games/${id}`);
+      if (gameRes.ok) {
+        const gameData = await gameRes.json();
+        setGameTitle(gameData.data.title);
+      }
+
+      // Load attendances to get members who attended
+      const attRes = await fetch(`/api/games/${id}/attendances`);
+      if (attRes.ok) {
+        const attData = await attRes.json();
+        const attended = (attData.data ?? [])
+          .filter(
+            (a: { person_type: string; status: string }) =>
+              a.person_type === "MEMBER" && a.status === "ATTENDED",
+          )
+          .map((a: { person_id: string }) => a.person_id);
+
+        // If no attendance records, fall back to AVAILABLE RSVPs
+        if (attended.length > 0) {
+          // We need member names - fetch from RSVPs
+          const rsvpRes = await fetch(`/api/games/${id}/rsvps`);
+          if (rsvpRes.ok) {
+            const rsvpData = await rsvpRes.json();
+            const memberMap = new Map<string, string>();
+            for (const r of rsvpData.data ?? []) {
+              const member = r.members as { name: string } | null;
+              if (member) memberMap.set(r.member_id, member.name);
+            }
+            setAttendedMembers(
+              attended.map((pid: string) => ({
+                person_id: pid,
+                name: memberMap.get(pid) ?? "不明",
+              })),
+            );
+          }
+        } else {
+          // Fall back to AVAILABLE RSVPs
+          const rsvpRes = await fetch(`/api/games/${id}/rsvps`);
+          if (rsvpRes.ok) {
+            const rsvpData = await rsvpRes.json();
+            const available = (rsvpData.data ?? [])
+              .filter((r: { response: string }) => r.response === "AVAILABLE")
+              .map(
+                (r: {
+                  member_id: string;
+                  members: { name: string } | null;
+                }) => ({
+                  person_id: r.member_id,
+                  name: r.members?.name ?? "不明",
+                }),
+              );
+            setAttendedMembers(available);
+          }
+        }
+      }
+
+      // Load existing at-bats
+      const abRes = await fetch(`/api/games/${id}/at-bats`);
+      if (abRes.ok) {
+        const abData = await abRes.json();
+        setAtBats(
+          (abData.data ?? []).map(
+            (ab: {
+              id: string;
+              member_id: string;
+              members: { name: string } | null;
+              inning: number;
+              batting_order: number | null;
+              result: string;
+            }) => ({
+              id: ab.id,
+              member_id: ab.member_id,
+              member_name: ab.members?.name ?? "不明",
+              inning: ab.inning,
+              batting_order: ab.batting_order,
+              result: ab.result,
+            }),
+          ),
+        );
+      }
+    } catch {
+      setError("データの読み込みに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleAddAtBat = async () => {
+    if (!selectedMember?.value || !selectedResult?.value) return;
+
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const payload = {
+        member_id: selectedMember.value,
+        inning: Number(inning),
+        batting_order: battingOrder ? Number(battingOrder) : null,
+        result: selectedResult.value,
+      };
+
+      const res = await fetch(`/api/games/${id}/at-bats`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "登録に失敗しました");
+        return;
+      }
+
+      setSuccess(true);
+      // Reset form
+      setSelectedResult(null);
+      setBattingOrder("");
+      // Reload data
+      await loadData();
+      router.refresh();
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (atBatId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/games/${id}/at-bats?at_bat_id=${atBatId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "削除に失敗しました");
+        return;
+      }
+      await loadData();
+    } catch {
+      setError("通信エラーが発生しました");
+    }
+  };
+
+  const memberOptions: SelectProps.Option[] = attendedMembers.map((m) => ({
+    label: m.name,
+    value: m.person_id,
+  }));
+
+  const inningOptions: SelectProps.Option[] = Array.from(
+    { length: 9 },
+    (_, i) => ({
+      label: `${i + 1}回`,
+      value: String(i + 1),
+    }),
+  );
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: gameTitle || "試合", href: `/games/${id}` },
+            { text: "打席結果", href: `/games/${id}/at-bats` },
+          ]}
+        />
+      }
+      header={
+        <Header variant="h1" description={gameTitle}>
+          打席結果入力
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {error && (
+          <Flashbar
+            items={[
+              {
+                type: "error",
+                content: error,
+                dismissible: true,
+                onDismiss: () => setError(null),
+                id: "at-bat-error",
+              },
+            ]}
+          />
+        )}
+
+        {success && (
+          <Flashbar
+            items={[
+              {
+                type: "success",
+                content: "打席結果を登録しました",
+                dismissible: true,
+                onDismiss: () => setSuccess(false),
+                id: "at-bat-success",
+              },
+            ]}
+          />
+        )}
+
+        {loading ? (
+          <Container header={<Header variant="h2">打席結果</Header>}>
+            <Box textAlign="center" padding="xxl">
+              <StatusIndicator type="loading">読み込み中...</StatusIndicator>
+            </Box>
+          </Container>
+        ) : (
+          <>
+            <Container
+              header={
+                <Header variant="h2" description="打席結果を1つずつ追加します">
+                  打席登録
+                </Header>
+              }
+            >
+              <SpaceBetween size="m">
+                <SpaceBetween direction="horizontal" size="m">
+                  <FormField label="打者">
+                    <Select
+                      selectedOption={selectedMember}
+                      onChange={({ detail }) =>
+                        setSelectedMember(detail.selectedOption)
+                      }
+                      options={memberOptions}
+                      placeholder="打者を選択"
+                    />
+                  </FormField>
+
+                  <FormField label="イニング">
+                    <Select
+                      selectedOption={
+                        inningOptions.find((o) => o.value === inning) ??
+                        inningOptions[0]
+                      }
+                      onChange={({ detail }) =>
+                        setInning(detail.selectedOption.value ?? "1")
+                      }
+                      options={inningOptions}
+                    />
+                  </FormField>
+
+                  <FormField label="打順">
+                    <Input
+                      type="number"
+                      value={battingOrder}
+                      onChange={({ detail }) => setBattingOrder(detail.value)}
+                      placeholder="1-9"
+                      inputMode="numeric"
+                    />
+                  </FormField>
+
+                  <FormField label="結果">
+                    <Select
+                      selectedOption={selectedResult}
+                      onChange={({ detail }) =>
+                        setSelectedResult(detail.selectedOption)
+                      }
+                      options={RESULT_OPTIONS}
+                      placeholder="結果を選択"
+                    />
+                  </FormField>
+                </SpaceBetween>
+
+                <Button
+                  variant="primary"
+                  loading={saving}
+                  disabled={!selectedMember?.value || !selectedResult?.value}
+                  onClick={handleAddAtBat}
+                >
+                  打席を追加
+                </Button>
+              </SpaceBetween>
+            </Container>
+
+            <Table
+              header={
+                <Header
+                  variant="h2"
+                  counter={atBats.length > 0 ? `(${atBats.length})` : undefined}
+                >
+                  登録済み打席
+                </Header>
+              }
+              columnDefinitions={[
+                {
+                  id: "inning",
+                  header: "イニング",
+                  cell: (item) => `${item.inning}回`,
+                  width: 100,
+                  sortingField: "inning",
+                },
+                {
+                  id: "batting_order",
+                  header: "打順",
+                  cell: (item) =>
+                    item.batting_order ? `${item.batting_order}番` : "---",
+                  width: 80,
+                },
+                {
+                  id: "member",
+                  header: "打者",
+                  cell: (item) => item.member_name,
+                  width: 150,
+                },
+                {
+                  id: "result",
+                  header: "結果",
+                  cell: (item) => RESULT_LABELS[item.result] ?? item.result,
+                  width: 180,
+                },
+                {
+                  id: "actions",
+                  header: "操作",
+                  cell: (item) => (
+                    <Button
+                      variant="link"
+                      onClick={() => handleDelete(item.id)}
+                    >
+                      削除
+                    </Button>
+                  ),
+                  width: 80,
+                },
+              ]}
+              items={atBats}
+              variant="embedded"
+              empty={
+                <Box
+                  textAlign="center"
+                  color="text-status-inactive"
+                  padding="l"
+                >
+                  打席結果がまだ登録されていません
+                </Box>
+              }
+            />
+          </>
+        )}
+
+        <Box>
+          <Link href={`/games/${id}`}>
+            <Button variant="link">試合詳細に戻る</Button>
+          </Link>
+        </Box>
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/attendance/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/attendance/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import RadioGroup from "@cloudscape-design/components/radio-group";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+interface RsvpMember {
+  member_id: string;
+  member_name: string;
+}
+
+interface AttendanceRecord {
+  person_id: string;
+  status: "ATTENDED" | "NO_SHOW" | "CANCELLED_SAME_DAY";
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  ATTENDED: "出席",
+  NO_SHOW: "無断欠席",
+  CANCELLED_SAME_DAY: "当日キャンセル",
+};
+
+const STATUS_TYPE: Record<string, "success" | "error" | "warning"> = {
+  ATTENDED: "success",
+  NO_SHOW: "error",
+  CANCELLED_SAME_DAY: "warning",
+};
+
+export default function AttendancePage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [gameTitle, setGameTitle] = useState("");
+  const [gameStatus, setGameStatus] = useState("");
+  const [members, setMembers] = useState<RsvpMember[]>([]);
+  const [attendances, setAttendances] = useState<
+    Record<string, AttendanceRecord["status"]>
+  >({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // Load game info
+      const gameRes = await fetch(`/api/games/${id}`);
+      if (!gameRes.ok) return;
+      const gameData = await gameRes.json();
+      const game = gameData.data;
+      setGameTitle(game.title);
+      setGameStatus(game.status);
+
+      // Load RSVPs with AVAILABLE response
+      const rsvpRes = await fetch(`/api/games/${id}/rsvps`);
+      if (rsvpRes.ok) {
+        const rsvpData = await rsvpRes.json();
+        const availableMembers = (rsvpData.data ?? [])
+          .filter((r: { response: string }) => r.response === "AVAILABLE")
+          .map(
+            (r: {
+              member_id: string;
+              members: { name: string } | null;
+            }) => ({
+              member_id: r.member_id,
+              member_name: r.members?.name ?? "不明",
+            }),
+          );
+        setMembers(availableMembers);
+
+        // Initialize all to ATTENDED
+        const initial: Record<string, AttendanceRecord["status"]> = {};
+        for (const m of availableMembers) {
+          initial[m.member_id] = "ATTENDED";
+        }
+        setAttendances(initial);
+      }
+
+      // Load existing attendances
+      const attRes = await fetch(`/api/games/${id}/attendances`);
+      if (attRes.ok) {
+        const attData = await attRes.json();
+        const existing = attData.data ?? [];
+        if (existing.length > 0) {
+          const map: Record<string, AttendanceRecord["status"]> = {};
+          for (const a of existing) {
+            if (a.person_type === "MEMBER") {
+              map[a.person_id] = a.status;
+            }
+          }
+          setAttendances((prev) => ({ ...prev, ...map }));
+        }
+      }
+    } catch {
+      setError("データの読み込みに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const payload = members.map((m) => ({
+        person_type: "MEMBER",
+        person_id: m.member_id,
+        status: attendances[m.member_id] ?? "ATTENDED",
+      }));
+
+      const res = await fetch(`/api/games/${id}/attendances`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ attendances: payload }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "保存に失敗しました");
+        return;
+      }
+
+      setSuccess(true);
+      router.refresh();
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isValidStatus =
+    gameStatus === "CONFIRMED" || gameStatus === "COMPLETED";
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: gameTitle || "試合", href: `/games/${id}` },
+            { text: "出席記録", href: `/games/${id}/attendance` },
+          ]}
+        />
+      }
+      header={
+        <Header variant="h1" description={gameTitle}>
+          出席記録
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {error && (
+          <Flashbar
+            items={[
+              {
+                type: "error",
+                content: error,
+                dismissible: true,
+                onDismiss: () => setError(null),
+                id: "attendance-error",
+              },
+            ]}
+          />
+        )}
+
+        {success && (
+          <Flashbar
+            items={[
+              {
+                type: "success",
+                content: "出席記録を保存しました",
+                dismissible: true,
+                onDismiss: () => setSuccess(false),
+                id: "attendance-success",
+              },
+            ]}
+          />
+        )}
+
+        {!isValidStatus && !loading && (
+          <Flashbar
+            items={[
+              {
+                type: "warning",
+                content:
+                  "出席記録は確定済み(CONFIRMED)または完了済み(COMPLETED)の試合のみ記録できます",
+                id: "attendance-status-warning",
+              },
+            ]}
+          />
+        )}
+
+        <Container
+          header={
+            <Header
+              variant="h2"
+              counter={members.length > 0 ? `(${members.length})` : undefined}
+              description="参加回答(AVAILABLE)のメンバー一覧"
+            >
+              出席状況
+            </Header>
+          }
+        >
+          {loading ? (
+            <Box textAlign="center" padding="xxl">
+              <StatusIndicator type="loading">読み込み中...</StatusIndicator>
+            </Box>
+          ) : members.length === 0 ? (
+            <Box textAlign="center" color="text-status-inactive" padding="l">
+              参加回答のメンバーがいません
+            </Box>
+          ) : (
+            <SpaceBetween size="l">
+              <Table
+                columnDefinitions={[
+                  {
+                    id: "name",
+                    header: "メンバー名",
+                    cell: (item) => item.member_name,
+                    width: 200,
+                  },
+                  {
+                    id: "status",
+                    header: "出席状況",
+                    cell: (item) => (
+                      <RadioGroup
+                        value={attendances[item.member_id] ?? "ATTENDED"}
+                        onChange={({ detail }) =>
+                          setAttendances((prev) => ({
+                            ...prev,
+                            [item.member_id]:
+                              detail.value as AttendanceRecord["status"],
+                          }))
+                        }
+                        items={[
+                          { value: "ATTENDED", label: "出席" },
+                          { value: "NO_SHOW", label: "無断欠席" },
+                          {
+                            value: "CANCELLED_SAME_DAY",
+                            label: "当日キャンセル",
+                          },
+                        ]}
+                      />
+                    ),
+                  },
+                  {
+                    id: "indicator",
+                    header: "ステータス",
+                    cell: (item) => {
+                      const status = attendances[item.member_id] ?? "ATTENDED";
+                      return (
+                        <StatusIndicator type={STATUS_TYPE[status]}>
+                          {STATUS_LABELS[status]}
+                        </StatusIndicator>
+                      );
+                    },
+                    width: 150,
+                  },
+                ]}
+                items={members}
+                variant="embedded"
+              />
+
+              <Button
+                variant="primary"
+                loading={saving}
+                disabled={!isValidStatus}
+                onClick={handleSave}
+              >
+                出席記録を保存
+              </Button>
+            </SpaceBetween>
+          )}
+        </Container>
+
+        <Box>
+          <Link href={`/games/${id}`}>
+            <Button variant="link">試合詳細に戻る</Button>
+          </Link>
+        </Box>
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -147,6 +147,25 @@ export default async function GameDetailPage({
               <Link href={`/games/${game.id}/helpers`}>
                 <Button>助っ人を管理</Button>
               </Link>
+              {(game.status === "CONFIRMED" || game.status === "COMPLETED") && (
+                <Link href={`/games/${game.id}/attendance`}>
+                  <Button>出席を記録</Button>
+                </Link>
+              )}
+              {(game.status === "COMPLETED" ||
+                game.status === "CONFIRMED" ||
+                game.status === "SETTLED") && (
+                <Link href={`/games/${game.id}/result`}>
+                  <Button>試合結果を入力</Button>
+                </Link>
+              )}
+              {(game.status === "COMPLETED" ||
+                game.status === "CONFIRMED" ||
+                game.status === "SETTLED") && (
+                <Link href={`/games/${game.id}/at-bats`}>
+                  <Button>打席結果を入力</Button>
+                </Link>
+              )}
               {(game.status === "COMPLETED" || game.status === "SETTLED") && (
                 <Link href={`/games/${game.id}/expenses`}>
                   <Button>支出・精算を管理</Button>

--- a/packages/web/src/app/(manager)/games/[id]/result/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/result/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Link from "@cloudscape-design/components/link";
+import Select from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+const INNINGS_OPTIONS = Array.from({ length: 9 }, (_, i) => ({
+  label: `${i + 1}イニング`,
+  value: String(i + 1),
+}));
+
+const RESULT_LABELS: Record<string, string> = {
+  WIN: "勝ち",
+  LOSE: "負け",
+  DRAW: "引き分け",
+};
+
+function calculateResult(
+  ourScore: number | null,
+  opponentScore: number | null,
+): string | null {
+  if (ourScore === null || opponentScore === null) return null;
+  if (ourScore > opponentScore) return "WIN";
+  if (ourScore < opponentScore) return "LOSE";
+  return "DRAW";
+}
+
+export default function ResultPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [gameTitle, setGameTitle] = useState("");
+  const [ourScore, setOurScore] = useState("");
+  const [opponentScore, setOpponentScore] = useState("");
+  const [innings, setInnings] = useState("7");
+  const [note, setNote] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [existingResult, setExistingResult] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // Load game info
+      const gameRes = await fetch(`/api/games/${id}`);
+      if (gameRes.ok) {
+        const gameData = await gameRes.json();
+        setGameTitle(gameData.data.title);
+      }
+
+      // Load existing result
+      const resultRes = await fetch(`/api/games/${id}/results`);
+      if (resultRes.ok) {
+        const resultData = await resultRes.json();
+        const result = resultData.data;
+        if (result) {
+          setExistingResult(true);
+          if (result.our_score !== null) setOurScore(String(result.our_score));
+          if (result.opponent_score !== null)
+            setOpponentScore(String(result.opponent_score));
+          if (result.innings) setInnings(String(result.innings));
+          if (result.note) setNote(result.note);
+        }
+      }
+    } catch {
+      setError("データの読み込みに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const ourScoreNum = ourScore === "" ? null : Number(ourScore);
+  const opponentScoreNum = opponentScore === "" ? null : Number(opponentScore);
+  const autoResult = calculateResult(ourScoreNum, opponentScoreNum);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const payload = {
+        our_score: ourScoreNum,
+        opponent_score: opponentScoreNum,
+        result: autoResult,
+        innings: Number(innings),
+        note: note || null,
+      };
+
+      const res = await fetch(`/api/games/${id}/results`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "保存に失敗しました");
+        return;
+      }
+
+      setSuccess(true);
+      setExistingResult(true);
+      router.refresh();
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: gameTitle || "試合", href: `/games/${id}` },
+            { text: "試合結果", href: `/games/${id}/result` },
+          ]}
+        />
+      }
+      header={
+        <Header variant="h1" description={gameTitle}>
+          試合結果入力
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {error && (
+          <Flashbar
+            items={[
+              {
+                type: "error",
+                content: error,
+                dismissible: true,
+                onDismiss: () => setError(null),
+                id: "result-error",
+              },
+            ]}
+          />
+        )}
+
+        {success && (
+          <Flashbar
+            items={[
+              {
+                type: "success",
+                content: existingResult
+                  ? "試合結果を更新しました"
+                  : "試合結果を保存しました",
+                dismissible: true,
+                onDismiss: () => setSuccess(false),
+                id: "result-success",
+              },
+            ]}
+          />
+        )}
+
+        {loading ? (
+          <Container header={<Header variant="h2">試合結果</Header>}>
+            <Box textAlign="center" padding="xxl">
+              <StatusIndicator type="loading">読み込み中...</StatusIndicator>
+            </Box>
+          </Container>
+        ) : (
+          <Container
+            header={
+              <Header
+                variant="h2"
+                description={existingResult ? "既存の結果を編集中" : "新規入力"}
+              >
+                スコア入力
+              </Header>
+            }
+          >
+            <SpaceBetween size="l">
+              <SpaceBetween direction="horizontal" size="xl">
+                <FormField label="自チーム得点" constraintText="整数で入力">
+                  <Input
+                    type="number"
+                    value={ourScore}
+                    onChange={({ detail }) => setOurScore(detail.value)}
+                    placeholder="0"
+                    inputMode="numeric"
+                  />
+                </FormField>
+
+                <Box
+                  fontSize="display-l"
+                  fontWeight="bold"
+                  padding={{ top: "l" }}
+                >
+                  -
+                </Box>
+
+                <FormField label="相手チーム得点" constraintText="整数で入力">
+                  <Input
+                    type="number"
+                    value={opponentScore}
+                    onChange={({ detail }) => setOpponentScore(detail.value)}
+                    placeholder="0"
+                    inputMode="numeric"
+                  />
+                </FormField>
+              </SpaceBetween>
+
+              {autoResult && (
+                <FormField label="結果（自動計算）">
+                  <StatusIndicator
+                    type={
+                      autoResult === "WIN"
+                        ? "success"
+                        : autoResult === "LOSE"
+                          ? "error"
+                          : "info"
+                    }
+                  >
+                    {RESULT_LABELS[autoResult]}
+                  </StatusIndicator>
+                </FormField>
+              )}
+
+              <FormField label="イニング数">
+                <Select
+                  selectedOption={
+                    INNINGS_OPTIONS.find((o) => o.value === innings) ??
+                    INNINGS_OPTIONS[6]
+                  }
+                  onChange={({ detail }) =>
+                    setInnings(detail.selectedOption.value ?? "7")
+                  }
+                  options={INNINGS_OPTIONS}
+                />
+              </FormField>
+
+              <FormField label="備考">
+                <Input
+                  value={note}
+                  onChange={({ detail }) => setNote(detail.value)}
+                  placeholder="特記事項があれば入力"
+                />
+              </FormField>
+
+              <Button variant="primary" loading={saving} onClick={handleSave}>
+                {existingResult ? "結果を更新" : "結果を保存"}
+              </Button>
+            </SpaceBetween>
+          </Container>
+        )}
+
+        <Box>
+          <Link href={`/games/${id}`}>
+            <Button variant="link">試合詳細に戻る</Button>
+          </Link>
+        </Box>
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/api/games/[id]/at-bats/route.ts
+++ b/packages/web/src/app/api/games/[id]/at-bats/route.ts
@@ -1,0 +1,157 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+const VALID_RESULTS = [
+  "SINGLE",
+  "DOUBLE",
+  "TRIPLE",
+  "HOMERUN",
+  "GROUND_OUT",
+  "FLY_OUT",
+  "LINE_OUT",
+  "STRIKEOUT",
+  "DOUBLE_PLAY",
+  "FIELDERS_CHOICE",
+  "ERROR",
+  "WALK",
+  "HIT_BY_PITCH",
+  "SAC_BUNT",
+  "SAC_FLY",
+] as const;
+
+/** POST /api/games/:id/at-bats — 打席結果登録 */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const body = await request.json();
+
+  // Validate game exists
+  const { error: gameError } = await supabase
+    .from("games")
+    .select("id")
+    .eq("id", id)
+    .single();
+
+  if (gameError) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  const atBat = body;
+  if (!atBat.member_id || !atBat.inning || !atBat.result) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "member_id, inning, result は必須です"),
+      { status: 400 },
+    );
+  }
+
+  if (!VALID_RESULTS.includes(atBat.result)) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", `無効な結果: ${atBat.result}`),
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("at_bats")
+    .insert({
+      game_id: id,
+      member_id: atBat.member_id,
+      inning: atBat.inning,
+      batting_order: atBat.batting_order ?? null,
+      result: atBat.result,
+      rbi: atBat.rbi ?? 0,
+      note: atBat.note ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "RECORD_AT_BAT",
+    target_type: "at_bat",
+    target_id: data.id,
+    after_json: data,
+  });
+
+  return NextResponse.json(apiSuccess(data, []), { status: 201 });
+}
+
+/** GET /api/games/:id/at-bats — 打席結果取得 */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("at_bats")
+    .select("*, members:member_id(name)")
+    .eq("game_id", id)
+    .order("inning", { ascending: true })
+    .order("batting_order", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data ?? [], []));
+}
+
+/** DELETE /api/games/:id/at-bats — 打席結果削除 */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const atBatId = searchParams.get("at_bat_id");
+
+  if (!atBatId) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "at_bat_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  const { error } = await supabase
+    .from("at_bats")
+    .delete()
+    .eq("id", atBatId)
+    .eq("game_id", id);
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(null, []));
+}

--- a/packages/web/src/app/api/games/[id]/attendances/route.ts
+++ b/packages/web/src/app/api/games/[id]/attendances/route.ts
@@ -1,0 +1,124 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+
+/** POST /api/games/:id/attendances — 出席記録保存 */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const body = await request.json();
+
+  // Validate game exists and is in correct status
+  const { data: game, error: gameError } = await supabase
+    .from("games")
+    .select("id, status")
+    .eq("id", id)
+    .single();
+
+  if (gameError || !game) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  if (game.status !== "CONFIRMED" && game.status !== "COMPLETED") {
+    return NextResponse.json(
+      apiError(
+        "VALIDATION_ERROR",
+        "出席記録は確定済みまたは完了済みの試合のみ可能です",
+      ),
+      { status: 400 },
+    );
+  }
+
+  const attendances = body.attendances;
+  if (!Array.isArray(attendances) || attendances.length === 0) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "attendances は必須です"),
+      { status: 400 },
+    );
+  }
+
+  // Validate each attendance entry
+  const validStatuses = ["ATTENDED", "NO_SHOW", "CANCELLED_SAME_DAY"];
+  const validPersonTypes = ["MEMBER", "HELPER"];
+  for (const a of attendances) {
+    if (!validStatuses.includes(a.status)) {
+      return NextResponse.json(
+        apiError("VALIDATION_ERROR", `無効なステータス: ${a.status}`),
+        { status: 400 },
+      );
+    }
+    if (!validPersonTypes.includes(a.person_type)) {
+      return NextResponse.json(
+        apiError("VALIDATION_ERROR", `無効な person_type: ${a.person_type}`),
+        { status: 400 },
+      );
+    }
+  }
+
+  const rows = attendances.map(
+    (a: { person_type: string; person_id: string; status: string }) => ({
+      game_id: id,
+      person_type: a.person_type,
+      person_id: a.person_id,
+      status: a.status,
+      recorded_at: new Date().toISOString(),
+      recorded_by: authResult.id,
+    }),
+  );
+
+  // Upsert (unique on game_id, person_type, person_id)
+  const { data, error } = await supabase
+    .from("attendances")
+    .upsert(rows, { onConflict: "game_id,person_type,person_id" })
+    .select();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "RECORD_ATTENDANCES",
+    target_type: "game",
+    target_id: id,
+    after_json: { count: data?.length ?? 0 },
+  });
+
+  return NextResponse.json(apiSuccess(data ?? [], []), { status: 201 });
+}
+
+/** GET /api/games/:id/attendances — 出席記録取得 */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("attendances")
+    .select("*")
+    .eq("game_id", id);
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data ?? [], []));
+}


### PR DESCRIPTION
## Summary
- 出席記録ページ (`/games/[id]/attendance`) — ATTENDED/NO_SHOW/CANCELLED_SAME_DAY をRadioGroupで記録
- 試合結果入力ページ (`/games/[id]/result`) — スコア入力、WIN/LOSE/DRAW自動判定、イニング選択
- 打席結果入力ページ (`/games/[id]/at-bats`) — 15種類の打席結果、イニング/打順、削除機能
- API Routes: attendances (GET/POST), at-bats (GET/POST/DELETE)
- 試合詳細ページにリンクボタン3つ追加

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n