### PR TITLE
feat: 投球成績入力・試合一覧・チーム設定強化

### DIFF
--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -166,6 +166,13 @@ export default async function GameDetailPage({
                   <Button>打席結果を入力</Button>
                 </Link>
               )}
+              {(game.status === "COMPLETED" ||
+                game.status === "CONFIRMED" ||
+                game.status === "SETTLED") && (
+                <Link href={`/games/${game.id}/pitching`}>
+                  <Button>投球成績を入力</Button>
+                </Link>
+              )}
               {(game.status === "COMPLETED" || game.status === "SETTLED") && (
                 <Link href={`/games/${game.id}/expenses`}>
                   <Button>支出・精算を管理</Button>

--- a/packages/web/src/app/(manager)/games/[id]/pitching/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/pitching/page.tsx
@@ -1,0 +1,544 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import Button from "@cloudscape-design/components/button";
+import Checkbox from "@cloudscape-design/components/checkbox";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import FormField from "@cloudscape-design/components/form-field";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Link from "@cloudscape-design/components/link";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+interface AttendedMember {
+  person_id: string;
+  name: string;
+}
+
+interface PitchingStatEntry {
+  id: string;
+  member_id: string;
+  member_name: string;
+  role: string;
+  innings_pitched: number;
+  hits_allowed: number;
+  runs_allowed: number;
+  earned_runs: number;
+  strikeouts: number;
+  walks: number;
+  is_winning_pitcher: boolean;
+  is_losing_pitcher: boolean;
+}
+
+const ROLE_OPTIONS: SelectProps.Option[] = [
+  { label: "先発 (STARTER)", value: "STARTER" },
+  { label: "中継ぎ (RELIEVER)", value: "RELIEVER" },
+  { label: "抑え (CLOSER)", value: "CLOSER" },
+];
+
+const ROLE_LABELS: Record<string, string> = {
+  STARTER: "先発",
+  RELIEVER: "中継ぎ",
+  CLOSER: "抑え",
+};
+
+export default function PitchingPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [gameTitle, setGameTitle] = useState("");
+  const [attendedMembers, setAttendedMembers] = useState<AttendedMember[]>([]);
+  const [stats, setStats] = useState<PitchingStatEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  // Form state
+  const [selectedMember, setSelectedMember] =
+    useState<SelectProps.Option | null>(null);
+  const [selectedRole, setSelectedRole] = useState<SelectProps.Option | null>(
+    null,
+  );
+  const [inningsPitched, setInningsPitched] = useState("0");
+  const [hitsAllowed, setHitsAllowed] = useState("0");
+  const [runsAllowed, setRunsAllowed] = useState("0");
+  const [earnedRuns, setEarnedRuns] = useState("0");
+  const [strikeouts, setStrikeouts] = useState("0");
+  const [walks, setWalks] = useState("0");
+  const [isWinningPitcher, setIsWinningPitcher] = useState(false);
+  const [isLosingPitcher, setIsLosingPitcher] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // Load game info
+      const gameRes = await fetch(`/api/games/${id}`);
+      if (gameRes.ok) {
+        const gameData = await gameRes.json();
+        setGameTitle(gameData.data.title);
+      }
+
+      // Load attendances to get members who attended
+      const attRes = await fetch(`/api/games/${id}/attendances`);
+      if (attRes.ok) {
+        const attData = await attRes.json();
+        const attended = (attData.data ?? [])
+          .filter(
+            (a: { person_type: string; status: string }) =>
+              a.person_type === "MEMBER" && a.status === "ATTENDED",
+          )
+          .map((a: { person_id: string }) => a.person_id);
+
+        if (attended.length > 0) {
+          const rsvpRes = await fetch(`/api/games/${id}/rsvps`);
+          if (rsvpRes.ok) {
+            const rsvpData = await rsvpRes.json();
+            const memberMap = new Map<string, string>();
+            for (const r of rsvpData.data ?? []) {
+              const member = r.members as { name: string } | null;
+              if (member) memberMap.set(r.member_id, member.name);
+            }
+            setAttendedMembers(
+              attended.map((pid: string) => ({
+                person_id: pid,
+                name: memberMap.get(pid) ?? "不明",
+              })),
+            );
+          }
+        } else {
+          // Fall back to AVAILABLE RSVPs
+          const rsvpRes = await fetch(`/api/games/${id}/rsvps`);
+          if (rsvpRes.ok) {
+            const rsvpData = await rsvpRes.json();
+            const available = (rsvpData.data ?? [])
+              .filter((r: { response: string }) => r.response === "AVAILABLE")
+              .map(
+                (r: {
+                  member_id: string;
+                  members: { name: string } | null;
+                }) => ({
+                  person_id: r.member_id,
+                  name: r.members?.name ?? "不明",
+                }),
+              );
+            setAttendedMembers(available);
+          }
+        }
+      }
+
+      // Load existing pitching stats
+      const psRes = await fetch(`/api/games/${id}/pitching`);
+      if (psRes.ok) {
+        const psData = await psRes.json();
+        setStats(
+          (psData.data ?? []).map(
+            (ps: {
+              id: string;
+              member_id: string;
+              members: { name: string } | null;
+              role: string;
+              innings_pitched: number;
+              hits_allowed: number;
+              runs_allowed: number;
+              earned_runs: number;
+              strikeouts: number;
+              walks: number;
+              is_winning_pitcher: boolean;
+              is_losing_pitcher: boolean;
+            }) => ({
+              id: ps.id,
+              member_id: ps.member_id,
+              member_name: ps.members?.name ?? "不明",
+              role: ps.role,
+              innings_pitched: ps.innings_pitched,
+              hits_allowed: ps.hits_allowed,
+              runs_allowed: ps.runs_allowed,
+              earned_runs: ps.earned_runs,
+              strikeouts: ps.strikeouts,
+              walks: ps.walks,
+              is_winning_pitcher: ps.is_winning_pitcher,
+              is_losing_pitcher: ps.is_losing_pitcher,
+            }),
+          ),
+        );
+      }
+    } catch {
+      setError("データの読み込みに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleAdd = async () => {
+    if (!selectedMember?.value || !selectedRole?.value) return;
+
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const payload = {
+        member_id: selectedMember.value,
+        role: selectedRole.value,
+        innings_pitched: Number(inningsPitched) || 0,
+        hits_allowed: Number(hitsAllowed) || 0,
+        runs_allowed: Number(runsAllowed) || 0,
+        earned_runs: Number(earnedRuns) || 0,
+        strikeouts: Number(strikeouts) || 0,
+        walks: Number(walks) || 0,
+        is_winning_pitcher: isWinningPitcher,
+        is_losing_pitcher: isLosingPitcher,
+      };
+
+      const res = await fetch(`/api/games/${id}/pitching`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "登録に失敗しました");
+        return;
+      }
+
+      setSuccess(true);
+      // Reset form
+      setSelectedRole(null);
+      setInningsPitched("0");
+      setHitsAllowed("0");
+      setRunsAllowed("0");
+      setEarnedRuns("0");
+      setStrikeouts("0");
+      setWalks("0");
+      setIsWinningPitcher(false);
+      setIsLosingPitcher(false);
+      // Reload data
+      await loadData();
+      router.refresh();
+    } catch {
+      setError("通信エラーが発生しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (statId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/games/${id}/pitching?stat_id=${statId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "削除に失敗しました");
+        return;
+      }
+      await loadData();
+    } catch {
+      setError("通信エラーが発生しました");
+    }
+  };
+
+  const memberOptions: SelectProps.Option[] = attendedMembers.map((m) => ({
+    label: m.name,
+    value: m.person_id,
+  }));
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: gameTitle || "試合", href: `/games/${id}` },
+            { text: "投球成績", href: `/games/${id}/pitching` },
+          ]}
+        />
+      }
+      header={
+        <Header variant="h1" description={gameTitle}>
+          投球成績入力
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        {error && (
+          <Flashbar
+            items={[
+              {
+                type: "error",
+                content: error,
+                dismissible: true,
+                onDismiss: () => setError(null),
+                id: "pitching-error",
+              },
+            ]}
+          />
+        )}
+
+        {success && (
+          <Flashbar
+            items={[
+              {
+                type: "success",
+                content: "投球成績を登録しました",
+                dismissible: true,
+                onDismiss: () => setSuccess(false),
+                id: "pitching-success",
+              },
+            ]}
+          />
+        )}
+
+        {loading ? (
+          <Container header={<Header variant="h2">投球成績</Header>}>
+            <Box textAlign="center" padding="xxl">
+              <StatusIndicator type="loading">読み込み中...</StatusIndicator>
+            </Box>
+          </Container>
+        ) : (
+          <>
+            <Container
+              header={
+                <Header
+                  variant="h2"
+                  description="投手の成績を1件ずつ追加します"
+                >
+                  投球成績登録
+                </Header>
+              }
+            >
+              <SpaceBetween size="m">
+                <SpaceBetween direction="horizontal" size="m">
+                  <FormField label="投手">
+                    <Select
+                      selectedOption={selectedMember}
+                      onChange={({ detail }) =>
+                        setSelectedMember(detail.selectedOption)
+                      }
+                      options={memberOptions}
+                      placeholder="投手を選択"
+                    />
+                  </FormField>
+
+                  <FormField label="役割">
+                    <Select
+                      selectedOption={selectedRole}
+                      onChange={({ detail }) =>
+                        setSelectedRole(detail.selectedOption)
+                      }
+                      options={ROLE_OPTIONS}
+                      placeholder="役割を選択"
+                    />
+                  </FormField>
+
+                  <FormField label="投球回">
+                    <Input
+                      type="number"
+                      value={inningsPitched}
+                      onChange={({ detail }) => setInningsPitched(detail.value)}
+                      inputMode="decimal"
+                    />
+                  </FormField>
+                </SpaceBetween>
+
+                <SpaceBetween direction="horizontal" size="m">
+                  <FormField label="被安打">
+                    <Input
+                      type="number"
+                      value={hitsAllowed}
+                      onChange={({ detail }) => setHitsAllowed(detail.value)}
+                      inputMode="numeric"
+                    />
+                  </FormField>
+
+                  <FormField label="失点">
+                    <Input
+                      type="number"
+                      value={runsAllowed}
+                      onChange={({ detail }) => setRunsAllowed(detail.value)}
+                      inputMode="numeric"
+                    />
+                  </FormField>
+
+                  <FormField label="自責点">
+                    <Input
+                      type="number"
+                      value={earnedRuns}
+                      onChange={({ detail }) => setEarnedRuns(detail.value)}
+                      inputMode="numeric"
+                    />
+                  </FormField>
+
+                  <FormField label="奪三振">
+                    <Input
+                      type="number"
+                      value={strikeouts}
+                      onChange={({ detail }) => setStrikeouts(detail.value)}
+                      inputMode="numeric"
+                    />
+                  </FormField>
+
+                  <FormField label="四球">
+                    <Input
+                      type="number"
+                      value={walks}
+                      onChange={({ detail }) => setWalks(detail.value)}
+                      inputMode="numeric"
+                    />
+                  </FormField>
+                </SpaceBetween>
+
+                <SpaceBetween direction="horizontal" size="m">
+                  <Checkbox
+                    checked={isWinningPitcher}
+                    onChange={({ detail }) => {
+                      setIsWinningPitcher(detail.checked);
+                      if (detail.checked) setIsLosingPitcher(false);
+                    }}
+                  >
+                    勝ち投手
+                  </Checkbox>
+
+                  <Checkbox
+                    checked={isLosingPitcher}
+                    onChange={({ detail }) => {
+                      setIsLosingPitcher(detail.checked);
+                      if (detail.checked) setIsWinningPitcher(false);
+                    }}
+                  >
+                    負け投手
+                  </Checkbox>
+                </SpaceBetween>
+
+                <Button
+                  variant="primary"
+                  loading={saving}
+                  disabled={!selectedMember?.value || !selectedRole?.value}
+                  onClick={handleAdd}
+                >
+                  投球成績を追加
+                </Button>
+              </SpaceBetween>
+            </Container>
+
+            <Table
+              header={
+                <Header
+                  variant="h2"
+                  counter={stats.length > 0 ? `(${stats.length})` : undefined}
+                >
+                  登録済み投球成績
+                </Header>
+              }
+              columnDefinitions={[
+                {
+                  id: "member",
+                  header: "投手",
+                  cell: (item) => item.member_name,
+                  width: 120,
+                },
+                {
+                  id: "role",
+                  header: "役割",
+                  cell: (item) => ROLE_LABELS[item.role] ?? item.role,
+                  width: 80,
+                },
+                {
+                  id: "ip",
+                  header: "投球回",
+                  cell: (item) => String(item.innings_pitched),
+                  width: 80,
+                },
+                {
+                  id: "h",
+                  header: "被安打",
+                  cell: (item) => String(item.hits_allowed),
+                  width: 70,
+                },
+                {
+                  id: "r",
+                  header: "失点",
+                  cell: (item) => String(item.runs_allowed),
+                  width: 60,
+                },
+                {
+                  id: "er",
+                  header: "自責点",
+                  cell: (item) => String(item.earned_runs),
+                  width: 70,
+                },
+                {
+                  id: "k",
+                  header: "奪三振",
+                  cell: (item) => String(item.strikeouts),
+                  width: 70,
+                },
+                {
+                  id: "bb",
+                  header: "四球",
+                  cell: (item) => String(item.walks),
+                  width: 60,
+                },
+                {
+                  id: "wp",
+                  header: "勝敗",
+                  cell: (item) =>
+                    item.is_winning_pitcher
+                      ? "勝"
+                      : item.is_losing_pitcher
+                        ? "敗"
+                        : "---",
+                  width: 60,
+                },
+                {
+                  id: "actions",
+                  header: "操作",
+                  cell: (item) => (
+                    <Button
+                      variant="link"
+                      onClick={() => handleDelete(item.id)}
+                    >
+                      削除
+                    </Button>
+                  ),
+                  width: 80,
+                },
+              ]}
+              items={stats}
+              variant="embedded"
+              empty={
+                <Box
+                  textAlign="center"
+                  color="text-status-inactive"
+                  padding="l"
+                >
+                  投球成績がまだ登録されていません
+                </Box>
+              }
+            />
+          </>
+        )}
+
+        <Box>
+          <Link href={`/games/${id}`}>
+            <Button variant="link">試合詳細に戻る</Button>
+          </Link>
+        </Box>
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/page.tsx
+++ b/packages/web/src/app/(manager)/games/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
+import Button from "@cloudscape-design/components/button";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import Pagination from "@cloudscape-design/components/pagination";
+import Select, { type SelectProps } from "@cloudscape-design/components/select";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+import Table from "@cloudscape-design/components/table";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+const TEAM_ID = process.env.NEXT_PUBLIC_DEFAULT_TEAM_ID ?? "";
+
+interface GameRow {
+  id: string;
+  title: string;
+  game_date: string | null;
+  game_type: string;
+  status: string;
+  ground_name: string | null;
+  available_count: number;
+  min_players: number;
+}
+
+const STATUS_TYPE: Record<
+  string,
+  "success" | "info" | "warning" | "error" | "stopped" | "pending"
+> = {
+  DRAFT: "pending",
+  COLLECTING: "info",
+  ASSESSING: "info",
+  ARRANGING: "info",
+  CONFIRMED: "success",
+  COMPLETED: "success",
+  SETTLED: "stopped",
+  CANCELLED: "error",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: "下書き",
+  COLLECTING: "出欠収集中",
+  ASSESSING: "査定中",
+  ARRANGING: "手配中",
+  CONFIRMED: "確定",
+  COMPLETED: "完了",
+  SETTLED: "精算済み",
+  CANCELLED: "中止",
+};
+
+const ALL_OPTION: SelectProps.Option = { label: "すべて", value: "ALL" };
+
+const STATUS_FILTER_OPTIONS: SelectProps.Option[] = [
+  ALL_OPTION,
+  { label: "下書き", value: "DRAFT" },
+  { label: "出欠収集中", value: "COLLECTING" },
+  { label: "確定", value: "CONFIRMED" },
+  { label: "完了", value: "COMPLETED" },
+  { label: "精算済み", value: "SETTLED" },
+  { label: "中止", value: "CANCELLED" },
+];
+
+const PAGE_SIZE = 20;
+
+export default function GamesListPage() {
+  const router = useRouter();
+  const [games, setGames] = useState<GameRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] =
+    useState<SelectProps.Option>(ALL_OPTION);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const loadGames = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/games?team_id=${TEAM_ID}&limit=100`);
+      if (res.ok) {
+        const json = await res.json();
+        setGames(json.data ?? []);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadGames();
+  }, [loadGames]);
+
+  const filteredGames =
+    statusFilter.value === "ALL"
+      ? games
+      : games.filter((g) => g.status === statusFilter.value);
+
+  const totalPages = Math.max(1, Math.ceil(filteredGames.length / PAGE_SIZE));
+  const paginatedGames = filteredGames.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE,
+  );
+
+  return (
+    <ContentLayout
+      breadcrumbs={
+        <BreadcrumbGroup
+          items={[
+            { text: "ダッシュボード", href: "/dashboard" },
+            { text: "試合一覧", href: "/games" },
+          ]}
+        />
+      }
+      header={
+        <Header
+          variant="h1"
+          actions={
+            <Button variant="primary" onClick={() => router.push("/games/new")}>
+              試合を作成
+            </Button>
+          }
+          counter={`(${filteredGames.length})`}
+        >
+          試合一覧
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Table
+          header={
+            <Header
+              variant="h2"
+              actions={
+                <Select
+                  selectedOption={statusFilter}
+                  onChange={({ detail }) => {
+                    setStatusFilter(detail.selectedOption);
+                    setCurrentPage(1);
+                  }}
+                  options={STATUS_FILTER_OPTIONS}
+                />
+              }
+            >
+              試合
+            </Header>
+          }
+          loading={loading}
+          loadingText="読み込み中..."
+          columnDefinitions={[
+            {
+              id: "date",
+              header: "試合日",
+              cell: (item) => item.game_date ?? "未定",
+              width: 120,
+              sortingField: "game_date",
+            },
+            {
+              id: "title",
+              header: "タイトル",
+              cell: (item) => (
+                <Link href={`/games/${item.id}`}>{item.title}</Link>
+              ),
+              width: 250,
+            },
+            {
+              id: "status",
+              header: "ステータス",
+              cell: (item) => (
+                <StatusIndicator type={STATUS_TYPE[item.status] ?? "info"}>
+                  {STATUS_LABELS[item.status] ?? item.status}
+                </StatusIndicator>
+              ),
+              width: 140,
+            },
+            {
+              id: "type",
+              header: "種別",
+              cell: (item) => item.game_type,
+              width: 100,
+            },
+            {
+              id: "ground",
+              header: "グラウンド",
+              cell: (item) => item.ground_name ?? "---",
+              width: 160,
+            },
+            {
+              id: "players",
+              header: "出欠",
+              cell: (item) => (
+                <StatusIndicator
+                  type={
+                    item.available_count >= item.min_players
+                      ? "success"
+                      : "warning"
+                  }
+                >
+                  {item.available_count}/{item.min_players}人
+                </StatusIndicator>
+              ),
+              width: 100,
+            },
+          ]}
+          items={paginatedGames}
+          onRowClick={({ detail }) => router.push(`/games/${detail.item.id}`)}
+          variant="full-page"
+          empty={
+            <Box textAlign="center" color="text-status-inactive" padding="xxl">
+              <SpaceBetween size="m">
+                <b>試合がありません</b>
+                <Button onClick={() => router.push("/games/new")}>
+                  試合を作成する
+                </Button>
+              </SpaceBetween>
+            </Box>
+          }
+          pagination={
+            <Pagination
+              currentPageIndex={currentPage}
+              pagesCount={totalPages}
+              onChange={({ detail }) => setCurrentPage(detail.currentPageIndex)}
+            />
+          }
+        />
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/layout.tsx
+++ b/packages/web/src/app/(manager)/layout.tsx
@@ -46,6 +46,7 @@ export default function ManagerLayout({
             header={{ text: "メニュー", href: "/dashboard" }}
             items={[
               { type: "link", text: "ダッシュボード", href: "/dashboard" },
+              { type: "link", text: "試合一覧", href: "/games" },
               { type: "link", text: "試合作成", href: "/games/new" },
               { type: "divider" },
               {

--- a/packages/web/src/app/(manager)/settings/page.tsx
+++ b/packages/web/src/app/(manager)/settings/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Box from "@cloudscape-design/components/box";
 import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
 import Button from "@cloudscape-design/components/button";
+import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Container from "@cloudscape-design/components/container";
 import ContentLayout from "@cloudscape-design/components/content-layout";
 import Flashbar, {
@@ -11,6 +13,7 @@ import Form from "@cloudscape-design/components/form";
 import FormField from "@cloudscape-design/components/form-field";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
+import KeyValuePairs from "@cloudscape-design/components/key-value-pairs";
 import Multiselect, {
   type MultiselectProps,
 } from "@cloudscape-design/components/multiselect";
@@ -53,7 +56,14 @@ const COST_SPLIT_OPTIONS: SelectProps.Option[] = [
 export default function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [savingTeam, setSavingTeam] = useState(false);
   const [flash, setFlash] = useState<FlashbarProps.MessageDefinition[]>([]);
+
+  // Team profile state
+  const [teamName, setTeamName] = useState("");
+  const [homeArea, setHomeArea] = useState("");
+  const [activityDay, setActivityDay] = useState("");
+  const [inviteLink, setInviteLink] = useState("");
 
   // Policy state
   const [autoAccept, setAutoAccept] = useState(false);
@@ -97,16 +107,30 @@ export default function SettingsPage() {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`/api/teams/${TEAM_ID}/policy`);
-        const json = await res.json();
-        if (json.data) {
-          applyPolicy(json.data as NegotiationPolicy);
+        const [policyRes, teamsRes] = await Promise.all([
+          fetch(`/api/teams/${TEAM_ID}/policy`),
+          fetch("/api/teams"),
+        ]);
+
+        const policyJson = await policyRes.json();
+        if (policyJson.data) {
+          applyPolicy(policyJson.data as NegotiationPolicy);
+        }
+
+        const teamsJson = await teamsRes.json();
+        const team = (teamsJson.data ?? []).find(
+          (t: { id: string }) => t.id === TEAM_ID,
+        );
+        if (team) {
+          setTeamName(team.name ?? "");
+          setHomeArea(team.home_area ?? "");
+          setActivityDay(team.activity_day ?? "");
         }
       } catch {
         setFlash([
           {
             type: "error",
-            content: "ポリシーの読み込みに失敗しました",
+            content: "設定の読み込みに失敗しました",
             dismissible: true,
             onDismiss: () => setFlash([]),
           },
@@ -184,6 +208,59 @@ export default function SettingsPage() {
     }
   };
 
+  const handleSaveTeam = async () => {
+    setSavingTeam(true);
+    try {
+      const res = await fetch(`/api/teams/${TEAM_ID}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: teamName,
+          home_area: homeArea,
+          activity_day: activityDay || null,
+        }),
+      });
+
+      if (res.ok) {
+        setFlash([
+          {
+            type: "success",
+            content: "チーム情報を保存しました",
+            dismissible: true,
+            onDismiss: () => setFlash([]),
+          },
+        ]);
+      } else {
+        const json = await res.json();
+        setFlash([
+          {
+            type: "error",
+            content: json.error?.message ?? "チーム情報の保存に失敗しました",
+            dismissible: true,
+            onDismiss: () => setFlash([]),
+          },
+        ]);
+      }
+    } catch {
+      setFlash([
+        {
+          type: "error",
+          content: "チーム情報の保存に失敗しました",
+          dismissible: true,
+          onDismiss: () => setFlash([]),
+        },
+      ]);
+    } finally {
+      setSavingTeam(false);
+    }
+  };
+
+  const generateInviteLink = () => {
+    const liffId = process.env.NEXT_PUBLIC_LIFF_ID ?? "YOUR_LIFF_ID";
+    const link = `https://liff.line.me/${liffId}/register?team_id=${TEAM_ID}`;
+    setInviteLink(link);
+  };
+
   if (loading) {
     return (
       <ContentLayout header={<Header variant="h1">設定</Header>}>
@@ -203,13 +280,129 @@ export default function SettingsPage() {
         />
       }
       header={
-        <Header variant="h1" description="チームの交渉ポリシーを管理します">
+        <Header
+          variant="h1"
+          description="チームの設定と交渉ポリシーを管理します"
+        >
           設定
         </Header>
       }
     >
       <SpaceBetween size="l">
         <Flashbar items={flash} />
+
+        {/* Team Profile */}
+        <Container header={<Header variant="h2">チーム情報</Header>}>
+          <SpaceBetween size="l">
+            <ColumnLayout columns={2}>
+              <FormField label="チーム名">
+                <Input
+                  value={teamName}
+                  onChange={({ detail }) => setTeamName(detail.value)}
+                />
+              </FormField>
+
+              <FormField label="活動エリア">
+                <Input
+                  value={homeArea}
+                  onChange={({ detail }) => setHomeArea(detail.value)}
+                  placeholder="例: 東京都世田谷区"
+                />
+              </FormField>
+
+              <FormField label="活動曜日">
+                <Input
+                  value={activityDay}
+                  onChange={({ detail }) => setActivityDay(detail.value)}
+                  placeholder="例: 土日"
+                />
+              </FormField>
+            </ColumnLayout>
+
+            <Button
+              variant="primary"
+              loading={savingTeam}
+              onClick={handleSaveTeam}
+            >
+              チーム情報を保存
+            </Button>
+          </SpaceBetween>
+        </Container>
+
+        {/* API Integration / Team ID */}
+        <Container header={<Header variant="h2">API連携情報</Header>}>
+          <KeyValuePairs
+            items={[
+              {
+                label: "チームID",
+                value: (
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <Box fontFamily="monospace">{TEAM_ID}</Box>
+                    <Button
+                      iconName="copy"
+                      variant="icon"
+                      onClick={() => {
+                        navigator.clipboard.writeText(TEAM_ID);
+                        setFlash([
+                          {
+                            type: "success",
+                            content: "チームIDをコピーしました",
+                            dismissible: true,
+                            onDismiss: () => setFlash([]),
+                          },
+                        ]);
+                      }}
+                    />
+                  </SpaceBetween>
+                ),
+              },
+            ]}
+          />
+        </Container>
+
+        {/* Member Invitation */}
+        <Container
+          header={
+            <Header
+              variant="h2"
+              description="LINE経由でメンバーを招待するリンクを生成します"
+            >
+              メンバー招待
+            </Header>
+          }
+        >
+          <SpaceBetween size="m">
+            <Button onClick={generateInviteLink}>招待リンクを生成</Button>
+            {inviteLink && (
+              <SpaceBetween size="xs">
+                <Box variant="awsui-key-label">招待リンク</Box>
+                <SpaceBetween direction="horizontal" size="xs">
+                  <Input value={inviteLink} readOnly />
+                  <Button
+                    iconName="copy"
+                    onClick={() => {
+                      navigator.clipboard.writeText(inviteLink);
+                      setFlash([
+                        {
+                          type: "success",
+                          content: "招待リンクをコピーしました",
+                          dismissible: true,
+                          onDismiss: () => setFlash([]),
+                        },
+                      ]);
+                    }}
+                  >
+                    コピー
+                  </Button>
+                </SpaceBetween>
+                <Box variant="small" color="text-body-secondary">
+                  このリンクをLINEグループに共有してメンバーを招待してください
+                </Box>
+              </SpaceBetween>
+            )}
+          </SpaceBetween>
+        </Container>
+
         <form
           onSubmit={(e) => {
             e.preventDefault();

--- a/packages/web/src/app/api/games/[id]/pitching/route.ts
+++ b/packages/web/src/app/api/games/[id]/pitching/route.ts
@@ -1,0 +1,166 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const VALID_ROLES = ["STARTER", "RELIEVER", "CLOSER"] as const;
+
+const pitchingStatSchema = z.object({
+  member_id: z.string().uuid("member_id は有効な UUID である必要があります"),
+  role: z.enum(VALID_ROLES, {
+    errorMap: () => ({
+      message: "role は STARTER, RELIEVER, CLOSER のいずれかです",
+    }),
+  }),
+  innings_pitched: z
+    .number()
+    .min(0, "innings_pitched は 0 以上です")
+    .max(99.9, "innings_pitched は 99.9 以下です"),
+  hits_allowed: z.number().int().min(0).default(0),
+  runs_allowed: z.number().int().min(0).default(0),
+  earned_runs: z.number().int().min(0).default(0),
+  strikeouts: z.number().int().min(0).default(0),
+  walks: z.number().int().min(0).default(0),
+  hit_batters: z.number().int().min(0).default(0),
+  home_runs_allowed: z.number().int().min(0).default(0),
+  is_winning_pitcher: z.boolean().default(false),
+  is_losing_pitcher: z.boolean().default(false),
+  note: z.string().nullish(),
+});
+
+/** GET /api/games/:id/pitching — 投球成績取得 */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("pitching_stats")
+    .select("*, members:member_id(name)")
+    .eq("game_id", id)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data ?? [], []));
+}
+
+/** POST /api/games/:id/pitching — 投球成績登録 */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const body = await request.json();
+
+  // Validate game exists
+  const { error: gameError } = await supabase
+    .from("games")
+    .select("id")
+    .eq("id", id)
+    .single();
+
+  if (gameError) {
+    return NextResponse.json(apiError("NOT_FOUND", "試合が見つかりません"), {
+      status: 404,
+    });
+  }
+
+  const parsed = pitchingStatSchema.safeParse(body);
+  if (!parsed.success) {
+    const messages = parsed.error.issues.map((i) => i.message).join("; ");
+    return NextResponse.json(apiError("VALIDATION_ERROR", messages), {
+      status: 400,
+    });
+  }
+
+  const input = parsed.data;
+
+  const { data, error } = await supabase
+    .from("pitching_stats")
+    .insert({
+      game_id: id,
+      member_id: input.member_id,
+      role: input.role,
+      innings_pitched: input.innings_pitched,
+      hits_allowed: input.hits_allowed,
+      runs_allowed: input.runs_allowed,
+      earned_runs: input.earned_runs,
+      strikeouts: input.strikeouts,
+      walks: input.walks,
+      hit_batters: input.hit_batters,
+      home_runs_allowed: input.home_runs_allowed,
+      is_winning_pitcher: input.is_winning_pitcher,
+      is_losing_pitcher: input.is_losing_pitcher,
+      note: input.note ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "RECORD_PITCHING_STAT",
+    target_type: "pitching_stat",
+    target_id: data.id,
+    after_json: data,
+  });
+
+  return NextResponse.json(apiSuccess(data, []), { status: 201 });
+}
+
+/** DELETE /api/games/:id/pitching — 投球成績削除 */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const { searchParams } = new URL(request.url);
+  const statId = searchParams.get("stat_id");
+
+  if (!statId) {
+    return NextResponse.json(
+      apiError("VALIDATION_ERROR", "stat_id は必須です"),
+      { status: 400 },
+    );
+  }
+
+  const { error } = await supabase
+    .from("pitching_stats")
+    .delete()
+    .eq("id", statId)
+    .eq("game_id", id);
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(null, []));
+}

--- a/packages/web/src/app/api/teams/[id]/route.ts
+++ b/packages/web/src/app/api/teams/[id]/route.ts
@@ -1,0 +1,105 @@
+import { requireAuth, requireRole } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const updateTeamSchema = z.object({
+  name: z.string().min(1, "チーム名は必須です").optional(),
+  home_area: z.string().min(1, "活動エリアは必須です").optional(),
+  activity_day: z.string().nullish(),
+});
+
+/** GET /api/teams/:id */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("NOT_FOUND", "チームが見つかりません"), {
+      status: 404,
+    });
+  }
+
+  return NextResponse.json(apiSuccess(data, []));
+}
+
+/** PATCH /api/teams/:id — チーム情報更新 */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
+  const { id } = await params;
+  const supabase = await createClient();
+  const body = await request.json();
+
+  const parsed = updateTeamSchema.safeParse(body);
+  if (!parsed.success) {
+    const messages = parsed.error.issues.map((i) => i.message).join("; ");
+    return NextResponse.json(apiError("VALIDATION_ERROR", messages), {
+      status: 400,
+    });
+  }
+
+  const { data: before, error: fetchError } = await supabase
+    .from("teams")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (fetchError) {
+    return NextResponse.json(apiError("NOT_FOUND", "チームが見つかりません"), {
+      status: 404,
+    });
+  }
+
+  const updateFields: Record<string, unknown> = {};
+  const input = parsed.data;
+  if (input.name !== undefined) updateFields.name = input.name;
+  if (input.home_area !== undefined) updateFields.home_area = input.home_area;
+  if (input.activity_day !== undefined)
+    updateFields.activity_day = input.activity_day;
+
+  if (Object.keys(updateFields).length === 0) {
+    return NextResponse.json(apiSuccess(before, []));
+  }
+
+  const { data, error } = await supabase
+    .from("teams")
+    .update(updateFields)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(apiError("DATABASE_ERROR", error.message), {
+      status: 400,
+    });
+  }
+
+  await writeAuditLog(supabase, {
+    actor_type: "USER",
+    actor_id: authResult.id,
+    action: "UPDATE_TEAM",
+    target_type: "team",
+    target_id: id,
+    before_json: before,
+    after_json: data,
+  });
+
+  return NextResponse.json(apiSuccess(data, []));
+}


### PR DESCRIPTION
## Summary
- 投球成績入力ページ (`/games/[id]/pitching`) — 役割/イニング/被安打/奪三振等の入力・削除
- 投球API (`/api/games/[id]/pitching`) — GET/POST/DELETE + Zodバリデーション
- 試合一覧ページ (`/games`) — ステータスフィルタ、ページネーション、行クリックで詳細遷移
- チーム設定強化 — プロフィール編集、team_idコピー、LINE招待リンク生成
- チームAPI (`/api/teams/[id]`) — GET/PATCH
- サイドナビに「試合一覧」リンク追加

https://claude.ai/code/session_017ggKCsGVeUB8kcUNQzKM2n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Games list page with status filtering and pagination for improved game management
  * Pitching performance entry interface to track pitcher statistics in completed games
  * Team profile management in settings (name, home area, activity day)
  * One-click invite link generation for team membership recruitment
  * Added games list navigation link in the manager menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->