### PR TITLE
fix: restore missing CSS module breaking production build

### DIFF
--- a/packages/web/src/app/(public)/terms/page.module.css
+++ b/packages/web/src/app/(public)/terms/page.module.css
@@ -1,0 +1,59 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #fff;
+  margin-bottom: 8px;
+}
+
+.updated {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 32px;
+}
+
+.section {
+  margin-bottom: 32px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+}
+
+.section h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 12px;
+}
+
+.section p,
+.section li {
+  font-size: 14px;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.section ul {
+  padding-left: 20px;
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 32px 16px;
+  }
+
+  .title {
+    font-size: 24px;
+  }
+
+  .section {
+    padding: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- `terms/page.module.css` がCloudscape移行時に削除されたが、`contact/page.tsx` と `legal/page.tsx` が依然参照していたため、本番ビルドが `Module not found` エラーで失敗していた
- CSSモジュールファイルを復元してビルドを修正

## Test plan
- [x] `make build` 成功確認
- [x] `make check` 全パス (571テスト)

https://claude.ai/code/session_011WEuyX1zQ9pQ2LamkHPzdH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fully styled terms page with responsive design optimized for mobile and desktop viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->