### PR TITLE
copy: 無料プランに広告あり・成績制限を明示

### DIFF
--- a/packages/web/src/app/(public)/page.tsx
+++ b/packages/web/src/app/(public)/page.tsx
@@ -108,7 +108,7 @@ export default function LandingPage() {
               }
             >
               <Box variant="p" color="text-body-secondary">
-                1チーム・月3試合まで
+                1チーム・月3試合まで・成績は直近1年分・広告あり
               </Box>
             </Container>
 


### PR DESCRIPTION
## Summary
- 無料プランの説明に「広告あり」「成績は直近1年分」の制限を明示

## Changes
- `1チーム・月3試合まで` → `1チーム・月3試合まで・成績は直近1年分・広告あり`

🤖 Generated with [Claude Code](https://claude.com/claude-code)