### PR TITLE
fix: CI マイグレーションジョブ修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,16 +115,22 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: supabase/setup-cli@53fcbb272661e3f8efb38c5e4cd3b5e8e46f3755 # v2.2.1
+      - uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.84.2
 
       - name: Link Supabase project
+        if: ${{ secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_PROJECT_REF != '' }}
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Run migrations
+        if: ${{ secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_PROJECT_REF != '' }}
         run: supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Skip migration (secrets not configured)
+        if: ${{ secrets.SUPABASE_ACCESS_TOKEN == '' || secrets.SUPABASE_PROJECT_REF == '' }}
+        run: echo "⚠️ SUPABASE_ACCESS_TOKEN or SUPABASE_PROJECT_REF not set. Skipping migration."


### PR DESCRIPTION
## Summary
- supabase/setup-cli のSHAが存在せずCIが毎回失敗していた問題を修正
- Supabase Secrets未設定時はスキップして失敗しないように

### 本番でマイグレーションを動かすために必要
GitHub Secretsに以下を設定してください:
- `SUPABASE_ACCESS_TOKEN` — https://supabase.com/dashboard/account/tokens
- `SUPABASE_PROJECT_REF` — Supabaseプロジェクト設定 → Reference ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration tooling and dependencies
  * Improved CI/CD reliability with enhanced credential validation for deployment steps; migration tasks now skip gracefully when required configuration is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->