### PR TITLE
fix: ゲーム詳細に出欠リンク生成ボタン追加

### DIFF
--- a/packages/web/src/app/(manager)/games/[id]/page.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { RsvpLinkGenerator } from "@/components/RsvpLinkGenerator";
 import { RsvpTable } from "@/components/RsvpTable";
 import { TransitionButtons } from "@/components/TransitionButtons";
 import { createClient } from "@/lib/supabase/server";
@@ -188,7 +189,8 @@ export default async function GameDetailPage({
               <Header
                 variant="h2"
                 counter={`(${rsvps.length})`}
-                description="出欠の回答はLINEアプリから行えます"
+                description="LINEまたはWebリンクから回答できます"
+                actions={<RsvpLinkGenerator gameId={game.id} />}
               >
                 出欠状況
               </Header>

--- a/packages/web/src/components/RsvpLinkGenerator.tsx
+++ b/packages/web/src/components/RsvpLinkGenerator.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Flashbar from "@cloudscape-design/components/flashbar";
+import type { FlashbarProps } from "@cloudscape-design/components/flashbar";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
+import { useState } from "react";
+
+interface RsvpToken {
+  memberId: string;
+  memberName: string;
+  rsvpId: string;
+  token: string;
+  url: string;
+}
+
+interface RsvpLinkGeneratorProps {
+  gameId: string;
+}
+
+export function RsvpLinkGenerator({ gameId }: RsvpLinkGeneratorProps) {
+  const [visible, setVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [tokens, setTokens] = useState<RsvpToken[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [flash, setFlash] = useState<FlashbarProps.MessageDefinition[]>([]);
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/games/${gameId}/rsvp-tokens`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const json = await res.json();
+        setError(json.error ?? "トークン生成に失敗しました");
+        return;
+      }
+      const json = await res.json();
+      setTokens(json.data ?? []);
+      setVisible(true);
+    } catch {
+      setError("ネットワークエラー");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyUrl = (url: string, name: string) => {
+    navigator.clipboard.writeText(url);
+    setFlash([
+      {
+        type: "success",
+        content: `${name}さんのリンクをコピーしました`,
+        dismissible: true,
+        onDismiss: () => setFlash([]),
+      },
+    ]);
+  };
+
+  const copyAll = () => {
+    const text = tokens.map((t) => `${t.memberName}: ${t.url}`).join("\n");
+    navigator.clipboard.writeText(text);
+    setFlash([
+      {
+        type: "success",
+        content: `${tokens.length}人分のリンクをコピーしました`,
+        dismissible: true,
+        onDismiss: () => setFlash([]),
+      },
+    ]);
+  };
+
+  return (
+    <>
+      <Button onClick={handleGenerate} loading={loading}>
+        出欠リンクを生成
+      </Button>
+
+      {error && (
+        <Box color="text-status-error" fontSize="body-s">
+          {error}
+        </Box>
+      )}
+
+      <Modal
+        visible={visible}
+        onDismiss={() => setVisible(false)}
+        header="出欠回答リンク"
+        size="large"
+        footer={
+          <Box float="right">
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button onClick={copyAll}>全員分をコピー</Button>
+              <Button variant="primary" onClick={() => setVisible(false)}>
+                閉じる
+              </Button>
+            </SpaceBetween>
+          </Box>
+        }
+      >
+        <SpaceBetween size="m">
+          <Flashbar items={flash} />
+          <Box variant="p" fontSize="body-s" color="text-body-secondary">
+            各メンバーにリンクを送信してください。LINEやメールでシェアできます。
+          </Box>
+          <Table
+            columnDefinitions={[
+              {
+                id: "name",
+                header: "メンバー",
+                cell: (item) => item.memberName,
+              },
+              {
+                id: "url",
+                header: "リンク",
+                cell: (item) => (
+                  <Box fontSize="body-s" variant="code">
+                    {item.url}
+                  </Box>
+                ),
+                maxWidth: 400,
+              },
+              {
+                id: "copy",
+                header: "",
+                cell: (item) => (
+                  <Button
+                    variant="inline-link"
+                    onClick={() => copyUrl(item.url, item.memberName)}
+                  >
+                    コピー
+                  </Button>
+                ),
+                width: 80,
+              },
+            ]}
+            items={tokens}
+            variant="embedded"
+          />
+        </SpaceBetween>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- ゲーム詳細ページの出欠セクションに「出欠リンクを生成」ボタン追加
- メンバーごとのWeb RSVPリンクを一覧表示・個別コピー・全員分一括コピー
- 説明文を「LINEまたはWebリンクから回答できます」に更新

## Test plan
- [x] 670テスト全パス
- [x] lint通過

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RSVP link generation capability—users can now create and share shareable web links for team members to submit attendance responses
  * Enable bulk copying of RSVP links for easier distribution
  * Updated RSVP response instructions to reflect both LINE and web-based options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->