### PR TITLE
refactor: コード品質改善 — 重複削減・エラー境界・catch修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ npm-debug.log*
 .vscode/
 .idea/
 .claude/worktrees/
+.last-run.json

--- a/packages/web/src/app/(manager)/games/[id]/at-bats/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/at-bats/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/attendance/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/attendance/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/expenses/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/expenses/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/helpers/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/helpers/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/negotiations/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/negotiations/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/pitching/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/pitching/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/[id]/result/error.tsx
+++ b/packages/web/src/app/(manager)/games/[id]/result/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/error.tsx
+++ b/packages/web/src/app/(manager)/games/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/games/new/error.tsx
+++ b/packages/web/src/app/(manager)/games/new/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/members/[id]/error.tsx
+++ b/packages/web/src/app/(manager)/members/[id]/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/settings/error.tsx
+++ b/packages/web/src/app/(manager)/settings/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/calendar/error.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/calendar/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/error.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/grounds/error.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/grounds/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/helpers/error.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/helpers/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/opponents/error.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/opponents/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(manager)/teams/[id]/stats/error.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/stats/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ContentLayout header={<Header variant="h1">エラーが発生しました</Header>}>
+      <Container>
+        <SpaceBetween size="l">
+          <Box variant="p">ページの読み込み中にエラーが発生しました。</Box>
+          <Box color="text-body-secondary" fontSize="body-s">
+            {error.message}
+          </Box>
+          <Button variant="primary" onClick={reset}>
+            再読み込み
+          </Button>
+        </SpaceBetween>
+      </Container>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/api/games/[id]/rsvps/route.ts
+++ b/packages/web/src/app/api/games/[id]/rsvps/route.ts
@@ -1,3 +1,4 @@
+import { requireAuth, requireRole } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import { apiError, apiSuccess, writeAuditLog } from "@match-engine/core";
 import { type NextRequest, NextResponse } from "next/server";
@@ -49,6 +50,11 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+  const roleCheck = requireRole(authResult, "ADMIN");
+  if (roleCheck) return roleCheck;
+
   const { id } = await params;
   const supabase = await createClient();
 

--- a/packages/web/src/components/DeleteConfirmModal.tsx
+++ b/packages/web/src/components/DeleteConfirmModal.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Modal from "@cloudscape-design/components/modal";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+
+interface DeleteConfirmModalProps {
+  visible: boolean;
+  onDismiss: () => void;
+  onConfirm: () => void;
+  loading: boolean;
+  itemName: string;
+  entityName: string;
+}
+
+export function DeleteConfirmModal({
+  visible,
+  onDismiss,
+  onConfirm,
+  loading,
+  itemName,
+  entityName,
+}: DeleteConfirmModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={onDismiss}
+      header={`${entityName}を削除`}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button variant="link" onClick={onDismiss}>
+              キャンセル
+            </Button>
+            <Button variant="primary" onClick={onConfirm} loading={loading}>
+              削除
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+    >
+      <strong>{itemName}</strong> を削除しますか？この操作は取り消せません。
+    </Modal>
+  );
+}

--- a/packages/web/src/components/GroundsList.tsx
+++ b/packages/web/src/components/GroundsList.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import { DeleteConfirmModal } from "@/components/DeleteConfirmModal";
 import { GroundFormModal } from "@/components/GroundFormModal";
+import { useCrudList } from "@/hooks/useCrudList";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
 import Flashbar from "@cloudscape-design/components/flashbar";
 import Header from "@cloudscape-design/components/header";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface Ground {
   id: string;
@@ -29,67 +28,21 @@ interface GroundsListProps {
 }
 
 export function GroundsList({ initialGrounds }: GroundsListProps) {
-  const router = useRouter();
-  const [showModal, setShowModal] = useState(false);
-  const [editingItem, setEditingItem] = useState<Ground | null>(null);
-  const [deletingItem, setDeletingItem] = useState<Ground | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [flash, setFlash] = useState<{ type: "success"; content: string }[]>(
-    [],
-  );
-
-  const handleDelete = async () => {
-    if (!deletingItem) return;
-    setDeleting(true);
-    try {
-      const res = await fetch(`/api/grounds/${deletingItem.id}`, {
-        method: "DELETE",
-      });
-      if (res.ok) {
-        setDeletingItem(null);
-        setFlash([{ type: "success", content: "グラウンドを削除しました" }]);
-        router.refresh();
-      }
-    } catch {
-      // ignore
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleSuccess = () => {
-    setFlash([
-      {
-        type: "success",
-        content: editingItem
-          ? "グラウンドを更新しました"
-          : "グラウンドを追加しました",
-      },
-    ]);
-    setEditingItem(null);
-    router.refresh();
-  };
+  const crud = useCrudList<Ground>({
+    deleteEndpoint: (id) => `/api/grounds/${id}`,
+    entityName: "グラウンド",
+  });
 
   return (
     <>
-      {flash.length > 0 && (
-        <Flashbar
-          items={flash.map((f) => ({
-            ...f,
-            dismissible: true,
-            onDismiss: () => setFlash([]),
-          }))}
-        />
-      )}
+      {crud.flash.length > 0 && <Flashbar items={crud.flash} />}
 
       <Cards
         header={
           <Header
             counter={`(${initialGrounds.length})`}
             actions={
-              <Button onClick={() => setShowModal(true)}>
-                グラウンドを追加
-              </Button>
+              <Button onClick={crud.openCreate}>グラウンドを追加</Button>
             }
           >
             グラウンド一覧
@@ -143,16 +96,13 @@ export function GroundsList({ initialGrounds }: GroundsListProps) {
               header: "操作",
               content: (item) => (
                 <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={() => {
-                      setEditingItem(item);
-                      setShowModal(true);
-                    }}
-                  >
+                  <Button variant="link" onClick={() => crud.openEdit(item)}>
                     編集
                   </Button>
-                  <Button variant="link" onClick={() => setDeletingItem(item)}>
+                  <Button
+                    variant="link"
+                    onClick={() => crud.setDeletingItem(item)}
+                  >
                     削除
                   </Button>
                 </SpaceBetween>
@@ -169,40 +119,20 @@ export function GroundsList({ initialGrounds }: GroundsListProps) {
       />
 
       <GroundFormModal
-        visible={showModal}
-        onDismiss={() => {
-          setShowModal(false);
-          setEditingItem(null);
-        }}
-        onSuccess={handleSuccess}
-        ground={editingItem}
+        visible={crud.showModal}
+        onDismiss={crud.closeModal}
+        onSuccess={crud.handleSuccess}
+        ground={crud.editingItem}
       />
 
-      <Modal
-        visible={!!deletingItem}
-        onDismiss={() => setDeletingItem(null)}
-        header="グラウンドを削除"
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button variant="link" onClick={() => setDeletingItem(null)}>
-                キャンセル
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleDelete}
-                loading={deleting}
-              >
-                削除
-              </Button>
-            </SpaceBetween>
-          </Box>
-        }
-      >
-        <Box>
-          <strong>{deletingItem?.name}</strong> を削除しますか？
-        </Box>
-      </Modal>
+      <DeleteConfirmModal
+        visible={!!crud.deletingItem}
+        onDismiss={() => crud.setDeletingItem(null)}
+        onConfirm={crud.handleDelete}
+        loading={crud.deleting}
+        itemName={crud.deletingItem?.name ?? ""}
+        entityName="グラウンド"
+      />
     </>
   );
 }

--- a/packages/web/src/components/HelpersList.tsx
+++ b/packages/web/src/components/HelpersList.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import { DeleteConfirmModal } from "@/components/DeleteConfirmModal";
 import { HelperFormModal } from "@/components/HelperFormModal";
+import { useCrudList } from "@/hooks/useCrudList";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
 import Flashbar from "@cloudscape-design/components/flashbar";
 import Header from "@cloudscape-design/components/header";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface Helper {
   id: string;
@@ -28,64 +27,20 @@ interface HelpersListProps {
 }
 
 export function HelpersList({ initialHelpers }: HelpersListProps) {
-  const router = useRouter();
-  const [showModal, setShowModal] = useState(false);
-  const [editingItem, setEditingItem] = useState<Helper | null>(null);
-  const [deletingItem, setDeletingItem] = useState<Helper | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [flash, setFlash] = useState<{ type: "success"; content: string }[]>(
-    [],
-  );
-
-  const handleDelete = async () => {
-    if (!deletingItem) return;
-    setDeleting(true);
-    try {
-      const res = await fetch(`/api/helpers/${deletingItem.id}`, {
-        method: "DELETE",
-      });
-      if (res.ok) {
-        setDeletingItem(null);
-        setFlash([{ type: "success", content: "助っ人を削除しました" }]);
-        router.refresh();
-      }
-    } catch {
-      // ignore
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleSuccess = () => {
-    setFlash([
-      {
-        type: "success",
-        content: editingItem ? "助っ人を更新しました" : "助っ人を追加しました",
-      },
-    ]);
-    setEditingItem(null);
-    router.refresh();
-  };
+  const crud = useCrudList<Helper>({
+    deleteEndpoint: (id) => `/api/helpers/${id}`,
+    entityName: "助っ人",
+  });
 
   return (
     <>
-      {flash.length > 0 && (
-        <Flashbar
-          items={flash.map((f) => ({
-            ...f,
-            dismissible: true,
-            onDismiss: () => setFlash([]),
-          }))}
-        />
-      )}
+      {crud.flash.length > 0 && <Flashbar items={crud.flash} />}
 
       <Cards
         header={
           <Header
             counter={`(${initialHelpers.length})`}
-            actions={
-              <Button onClick={() => setShowModal(true)}>助っ人を追加</Button>
-            }
+            actions={<Button onClick={crud.openCreate}>助っ人を追加</Button>}
           >
             助っ人一覧
           </Header>
@@ -129,16 +84,13 @@ export function HelpersList({ initialHelpers }: HelpersListProps) {
               header: "操作",
               content: (item) => (
                 <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={() => {
-                      setEditingItem(item);
-                      setShowModal(true);
-                    }}
-                  >
+                  <Button variant="link" onClick={() => crud.openEdit(item)}>
                     編集
                   </Button>
-                  <Button variant="link" onClick={() => setDeletingItem(item)}>
+                  <Button
+                    variant="link"
+                    onClick={() => crud.setDeletingItem(item)}
+                  >
                     削除
                   </Button>
                 </SpaceBetween>
@@ -155,40 +107,20 @@ export function HelpersList({ initialHelpers }: HelpersListProps) {
       />
 
       <HelperFormModal
-        visible={showModal}
-        onDismiss={() => {
-          setShowModal(false);
-          setEditingItem(null);
-        }}
-        onSuccess={handleSuccess}
-        helper={editingItem}
+        visible={crud.showModal}
+        onDismiss={crud.closeModal}
+        onSuccess={crud.handleSuccess}
+        helper={crud.editingItem}
       />
 
-      <Modal
-        visible={!!deletingItem}
-        onDismiss={() => setDeletingItem(null)}
-        header="助っ人を削除"
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button variant="link" onClick={() => setDeletingItem(null)}>
-                キャンセル
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleDelete}
-                loading={deleting}
-              >
-                削除
-              </Button>
-            </SpaceBetween>
-          </Box>
-        }
-      >
-        <Box>
-          <strong>{deletingItem?.name}</strong> を削除しますか？
-        </Box>
-      </Modal>
+      <DeleteConfirmModal
+        visible={!!crud.deletingItem}
+        onDismiss={() => crud.setDeletingItem(null)}
+        onConfirm={crud.handleDelete}
+        loading={crud.deleting}
+        itemName={crud.deletingItem?.name ?? ""}
+        entityName="助っ人"
+      />
     </>
   );
 }

--- a/packages/web/src/components/MembersList.tsx
+++ b/packages/web/src/components/MembersList.tsx
@@ -1,16 +1,15 @@
 "use client";
 
+import { DeleteConfirmModal } from "@/components/DeleteConfirmModal";
 import { MemberFormModal } from "@/components/MemberFormModal";
+import { useCrudList } from "@/hooks/useCrudList";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
 import Flashbar from "@cloudscape-design/components/flashbar";
 import Header from "@cloudscape-design/components/header";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import StatusIndicator from "@cloudscape-design/components/status-indicator";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 const ROLE_LABELS: Record<string, string> = {
   SUPER_ADMIN: "管理者(代表)",
@@ -45,67 +44,20 @@ interface MembersListProps {
 }
 
 export function MembersList({ initialMembers, teamId }: MembersListProps) {
-  const router = useRouter();
-
-  const [showModal, setShowModal] = useState(false);
-  const [editingItem, setEditingItem] = useState<Member | null>(null);
-  const [deletingItem, setDeletingItem] = useState<Member | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [flash, setFlash] = useState<{ type: "success"; content: string }[]>(
-    [],
-  );
-
-  const handleDelete = async () => {
-    if (!deletingItem) return;
-    setDeleting(true);
-    try {
-      const res = await fetch(`/api/members/${deletingItem.id}`, {
-        method: "DELETE",
-      });
-      if (res.ok) {
-        setDeletingItem(null);
-        setFlash([{ type: "success", content: "メンバーを削除しました" }]);
-        router.refresh();
-      }
-    } catch {
-      // ignore
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleSuccess = () => {
-    setFlash([
-      {
-        type: "success",
-        content: editingItem
-          ? "メンバーを更新しました"
-          : "メンバーを追加しました",
-      },
-    ]);
-    setEditingItem(null);
-    router.refresh();
-  };
+  const crud = useCrudList<Member>({
+    deleteEndpoint: (id) => `/api/members/${id}`,
+    entityName: "メンバー",
+  });
 
   return (
     <>
-      {flash.length > 0 && (
-        <Flashbar
-          items={flash.map((f) => ({
-            ...f,
-            dismissible: true,
-            onDismiss: () => setFlash([]),
-          }))}
-        />
-      )}
+      {crud.flash.length > 0 && <Flashbar items={crud.flash} />}
 
       <Cards
         header={
           <Header
             counter={`(${initialMembers.length})`}
-            actions={
-              <Button onClick={() => setShowModal(true)}>メンバーを追加</Button>
-            }
+            actions={<Button onClick={crud.openCreate}>メンバーを追加</Button>}
           >
             メンバー一覧
           </Header>
@@ -130,10 +82,8 @@ export function MembersList({ initialMembers, teamId }: MembersListProps) {
             {
               id: "positions",
               header: "ポジション",
-              content: (item) => {
-                const positions = item.positions_json as string[];
-                return positions?.join(", ") || "—";
-              },
+              content: (item) =>
+                (item.positions_json as string[])?.join(", ") || "—",
             },
             {
               id: "jersey_number",
@@ -165,16 +115,13 @@ export function MembersList({ initialMembers, teamId }: MembersListProps) {
               header: "操作",
               content: (item) => (
                 <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    variant="link"
-                    onClick={() => {
-                      setEditingItem(item);
-                      setShowModal(true);
-                    }}
-                  >
+                  <Button variant="link" onClick={() => crud.openEdit(item)}>
                     編集
                   </Button>
-                  <Button variant="link" onClick={() => setDeletingItem(item)}>
+                  <Button
+                    variant="link"
+                    onClick={() => crud.setDeletingItem(item)}
+                  >
                     削除
                   </Button>
                 </SpaceBetween>
@@ -191,41 +138,21 @@ export function MembersList({ initialMembers, teamId }: MembersListProps) {
       />
 
       <MemberFormModal
-        visible={showModal}
-        onDismiss={() => {
-          setShowModal(false);
-          setEditingItem(null);
-        }}
-        onSuccess={handleSuccess}
+        visible={crud.showModal}
+        onDismiss={crud.closeModal}
+        onSuccess={crud.handleSuccess}
         teamId={teamId}
-        member={editingItem}
+        member={crud.editingItem}
       />
 
-      <Modal
-        visible={!!deletingItem}
-        onDismiss={() => setDeletingItem(null)}
-        header="メンバーを削除"
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button variant="link" onClick={() => setDeletingItem(null)}>
-                キャンセル
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleDelete}
-                loading={deleting}
-              >
-                削除
-              </Button>
-            </SpaceBetween>
-          </Box>
-        }
-      >
-        <Box>
-          <strong>{deletingItem?.name}</strong> を削除しますか？
-        </Box>
-      </Modal>
+      <DeleteConfirmModal
+        visible={!!crud.deletingItem}
+        onDismiss={() => crud.setDeletingItem(null)}
+        onConfirm={crud.handleDelete}
+        loading={crud.deleting}
+        itemName={crud.deletingItem?.name ?? ""}
+        entityName="メンバー"
+      />
     </>
   );
 }

--- a/packages/web/src/components/OpponentsList.tsx
+++ b/packages/web/src/components/OpponentsList.tsx
@@ -1,15 +1,14 @@
 "use client";
 
+import { DeleteConfirmModal } from "@/components/DeleteConfirmModal";
 import { OpponentFormModal } from "@/components/OpponentFormModal";
+import { useCrudList } from "@/hooks/useCrudList";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Flashbar from "@cloudscape-design/components/flashbar";
 import Header from "@cloudscape-design/components/header";
-import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
 
 interface Opponent {
   id: string;
@@ -34,66 +33,20 @@ export function OpponentsList({
   initialOpponents,
   teamId,
 }: OpponentsListProps) {
-  const router = useRouter();
-  const [showModal, setShowModal] = useState(false);
-  const [editingItem, setEditingItem] = useState<Opponent | null>(null);
-  const [deletingItem, setDeletingItem] = useState<Opponent | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [flash, setFlash] = useState<{ type: "success"; content: string }[]>(
-    [],
-  );
-
-  const handleDelete = async () => {
-    if (!deletingItem) return;
-    setDeleting(true);
-    try {
-      const res = await fetch(`/api/opponents/${deletingItem.id}`, {
-        method: "DELETE",
-      });
-      if (res.ok) {
-        setDeletingItem(null);
-        setFlash([{ type: "success", content: "対戦相手を削除しました" }]);
-        router.refresh();
-      }
-    } catch {
-      // ignore
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const handleSuccess = () => {
-    setFlash([
-      {
-        type: "success",
-        content: editingItem
-          ? "対戦相手を更新しました"
-          : "対戦相手を追加しました",
-      },
-    ]);
-    setEditingItem(null);
-    router.refresh();
-  };
+  const crud = useCrudList<Opponent>({
+    deleteEndpoint: (id) => `/api/opponents/${id}`,
+    entityName: "対戦相手",
+  });
 
   return (
     <>
-      {flash.length > 0 && (
-        <Flashbar
-          items={flash.map((f) => ({
-            ...f,
-            dismissible: true,
-            onDismiss: () => setFlash([]),
-          }))}
-        />
-      )}
+      {crud.flash.length > 0 && <Flashbar items={crud.flash} />}
 
       <Table
         header={
           <Header
             counter={`(${initialOpponents.length})`}
-            actions={
-              <Button onClick={() => setShowModal(true)}>対戦相手を追加</Button>
-            }
+            actions={<Button onClick={crud.openCreate}>対戦相手を追加</Button>}
           >
             対戦相手一覧
           </Header>
@@ -136,16 +89,13 @@ export function OpponentsList({
             header: "操作",
             cell: (item) => (
               <SpaceBetween direction="horizontal" size="xs">
-                <Button
-                  variant="link"
-                  onClick={() => {
-                    setEditingItem(item);
-                    setShowModal(true);
-                  }}
-                >
+                <Button variant="link" onClick={() => crud.openEdit(item)}>
                   編集
                 </Button>
-                <Button variant="link" onClick={() => setDeletingItem(item)}>
+                <Button
+                  variant="link"
+                  onClick={() => crud.setDeletingItem(item)}
+                >
                   削除
                 </Button>
               </SpaceBetween>
@@ -163,41 +113,21 @@ export function OpponentsList({
       />
 
       <OpponentFormModal
-        visible={showModal}
-        onDismiss={() => {
-          setShowModal(false);
-          setEditingItem(null);
-        }}
-        onSuccess={handleSuccess}
+        visible={crud.showModal}
+        onDismiss={crud.closeModal}
+        onSuccess={crud.handleSuccess}
         teamId={teamId}
-        opponent={editingItem}
+        opponent={crud.editingItem}
       />
 
-      <Modal
-        visible={!!deletingItem}
-        onDismiss={() => setDeletingItem(null)}
-        header="対戦相手を削除"
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              <Button variant="link" onClick={() => setDeletingItem(null)}>
-                キャンセル
-              </Button>
-              <Button
-                variant="primary"
-                onClick={handleDelete}
-                loading={deleting}
-              >
-                削除
-              </Button>
-            </SpaceBetween>
-          </Box>
-        }
-      >
-        <Box>
-          <strong>{deletingItem?.name}</strong> を削除しますか？
-        </Box>
-      </Modal>
+      <DeleteConfirmModal
+        visible={!!crud.deletingItem}
+        onDismiss={() => crud.setDeletingItem(null)}
+        onConfirm={crud.handleDelete}
+        loading={crud.deleting}
+        itemName={crud.deletingItem?.name ?? ""}
+        entityName="対戦相手"
+      />
     </>
   );
 }

--- a/packages/web/src/hooks/useCrudList.ts
+++ b/packages/web/src/hooks/useCrudList.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import type { FlashbarProps } from "@cloudscape-design/components/flashbar";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface CrudItem {
+  id: string;
+  name: string;
+}
+
+interface UseCrudListOptions {
+  deleteEndpoint: (id: string) => string;
+  entityName: string;
+}
+
+export function useCrudList<T extends CrudItem>(options: UseCrudListOptions) {
+  const router = useRouter();
+  const [showModal, setShowModal] = useState(false);
+  const [editingItem, setEditingItem] = useState<T | null>(null);
+  const [deletingItem, setDeletingItem] = useState<T | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [flash, setFlash] = useState<FlashbarProps.MessageDefinition[]>([]);
+
+  const clearFlash = () => setFlash([]);
+
+  const showSuccess = (message: string) => {
+    setFlash([
+      {
+        type: "success",
+        content: message,
+        dismissible: true,
+        onDismiss: clearFlash,
+      },
+    ]);
+  };
+
+  const showError = (message: string) => {
+    setFlash([
+      {
+        type: "error",
+        content: message,
+        dismissible: true,
+        onDismiss: clearFlash,
+      },
+    ]);
+  };
+
+  const handleDelete = async () => {
+    if (!deletingItem) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(options.deleteEndpoint(deletingItem.id), {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setDeletingItem(null);
+        showSuccess(`${options.entityName}を削除しました`);
+        router.refresh();
+      } else {
+        const json = await res.json();
+        showError(json.error ?? "削除に失敗しました");
+      }
+    } catch (err) {
+      showError(err instanceof Error ? err.message : "削除に失敗しました");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleSuccess = () => {
+    showSuccess(
+      editingItem
+        ? `${options.entityName}を更新しました`
+        : `${options.entityName}を追加しました`,
+    );
+    setEditingItem(null);
+    router.refresh();
+  };
+
+  const openCreate = () => {
+    setEditingItem(null);
+    setShowModal(true);
+  };
+
+  const openEdit = (item: T) => {
+    setEditingItem(item);
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+    setEditingItem(null);
+  };
+
+  return {
+    showModal,
+    editingItem,
+    deletingItem,
+    deleting,
+    flash,
+    setDeletingItem,
+    handleDelete,
+    handleSuccess,
+    openCreate,
+    openEdit,
+    closeModal,
+  };
+}


### PR DESCRIPTION
## Summary

### 重複削減 (-200行)
- `useCrudList` フック: 4つのListコンポーネントの共通状態管理(modal/delete/flash)を抽出
- `DeleteConfirmModal`: 4つの削除確認ダイアログを1コンポーネントに統合
- MembersList / HelpersList / OpponentsList / GroundsList をリファクタ

### エラー境界 (+18ファイル)
- 全(manager)ページに error.tsx 追加 — サーバーエラー時のリカバリUI

### バグ修正
- サイレントcatch → エラーFlashbar表示に改善
- POST /api/games/:id/rsvps に requireAuth 追加

## Test plan
- [x] 670テスト全パス
- [x] lint通過

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)