### PR TITLE
fix: MakefileのテストコマンドをVitest対応に修正 (CI修復)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,14 @@ format: ## Biome フォーマット
 typecheck: ## TypeScript 型チェック
 	$(BUN) run --filter '*' typecheck
 
-test: ## テスト実行
-	$(BUN) test
+test: ## テスト実行 (Vitest)
+	$(BUN) run test
 
 test-watch: ## テスト (watch モード)
-	$(BUN) test --watch
+	bunx vitest
 
 test-coverage: ## テスト + カバレッジ
-	$(BUN) test --coverage
+	bunx vitest run --coverage
 
 check: lint typecheck test ## lint + typecheck + test 一括実行
 	@echo "✅ All checks passed"


### PR DESCRIPTION
## 問題
CIが全failしていた原因:
- Makefile の `test:` が `bun test` のまま → E2Eファイルを拾ってPlaywrightエラー
- Vitest移行時にMakefileの更新を漏らしていた

## 修正
- `$(BUN) test` → `$(BUN) run test` (package.jsonの `vitest run` を実行)
- test-watch/test-coverage も vitest に統一

## Test plan
- [x] `make test` → 674テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)