### PR TITLE
Improve local onboarding and member invitation flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 # .env.local にコピーして値を設定してください
 # ============================================================
 
+# --- Runtime ---
+# 開発用ログイン (/dev, /api/dev) は development 環境でのみ有効
+NODE_ENV=development
+
 # --- Supabase ---
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-anon-key

--- a/packages/web/src/app/(manager)/dashboard/page.tsx
+++ b/packages/web/src/app/(manager)/dashboard/page.tsx
@@ -170,7 +170,7 @@ export default function DashboardPage() {
   }
 
   const calendarGames = games
-    .filter((g) => g.game_date)
+    .filter((g): g is GameRow & { game_date: string } => g.game_date !== null)
     .map((g) => ({
       id: g.id,
       title: g.title,

--- a/packages/web/src/app/(manager)/dashboard/page.tsx
+++ b/packages/web/src/app/(manager)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { DashboardView } from "@/components/DashboardView";
 import { OnboardingGuard } from "@/components/OnboardingGuard";
+import { TeamSetupChecklist } from "@/components/TeamSetupChecklist";
 import { useTeam } from "@/contexts/TeamContext";
 import Box from "@cloudscape-design/components/box";
 import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
@@ -45,10 +46,17 @@ interface GameRow {
   result?: string | null;
 }
 
+interface SetupSummary {
+  memberCount: number;
+  groundCount: number;
+  opponentCount: number;
+}
+
 export default function DashboardPage() {
   const team = useTeam();
   const teamId = team?.teamId;
   const [games, setGames] = useState<GameRow[]>([]);
+  const [setupSummary, setSetupSummary] = useState<SetupSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -62,10 +70,33 @@ export default function DashboardPage() {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`/api/games?team_id=${teamId}&limit=20`);
-        if (!res.ok) throw new Error("試合データの取得に失敗しました");
-        const json = await res.json();
-        setGames(json.data ?? []);
+        const [gamesRes, membersRes, groundsRes, opponentsRes] =
+          await Promise.all([
+            fetch(`/api/games?team_id=${teamId}&limit=20`),
+            fetch(`/api/teams/${teamId}/members`),
+            fetch(`/api/grounds?team_id=${teamId}`),
+            fetch(`/api/teams/${teamId}/opponents`),
+          ]);
+
+        if (!gamesRes.ok) throw new Error("試合データの取得に失敗しました");
+
+        const [gamesJson, membersJson, groundsJson, opponentsJson] =
+          await Promise.all([
+            gamesRes.json(),
+            membersRes.ok ? membersRes.json() : Promise.resolve({ data: [] }),
+            groundsRes.ok ? groundsRes.json() : Promise.resolve({ data: [] }),
+            opponentsRes.ok
+              ? opponentsRes.json()
+              : Promise.resolve({ data: [] }),
+          ]);
+
+        const nextGames = gamesJson.data ?? [];
+        setGames(nextGames);
+        setSetupSummary({
+          memberCount: membersJson.data?.length ?? 0,
+          groundCount: groundsJson.data?.length ?? 0,
+          opponentCount: opponentsJson.data?.length ?? 0,
+        });
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "データの取得に失敗しました",
@@ -155,14 +186,25 @@ export default function DashboardPage() {
         }
       >
         <Container header={<Header variant="h2">まだ活動がありません</Header>}>
-          <SpaceBetween size="m">
-            <Box variant="p">
-              最初の活動を作成して、チーム運営を始めましょう。
-              試合・練習・イベントを作成すると、メンバーへの出欠確認が自動で始まります。
-            </Box>
-            <Button variant="primary" href="/games">
-              活動を作成する
-            </Button>
+          <SpaceBetween size="l">
+            {setupSummary && (
+              <TeamSetupChecklist
+                teamId={teamId}
+                memberCount={setupSummary.memberCount}
+                groundCount={setupSummary.groundCount}
+                opponentCount={setupSummary.opponentCount}
+                gameCount={games.length}
+              />
+            )}
+            <SpaceBetween size="m">
+              <Box variant="p">
+                最初の活動を作成して、チーム運営を始めましょう。
+                試合・練習・イベントを作成すると、メンバーへの出欠確認が自動で始まります。
+              </Box>
+              <Button variant="primary" href="/games">
+                活動を作成する
+              </Button>
+            </SpaceBetween>
           </SpaceBetween>
         </Container>
       </ContentLayout>
@@ -193,6 +235,16 @@ export default function DashboardPage() {
       }
     >
       <SpaceBetween size="l">
+        {setupSummary && (
+          <TeamSetupChecklist
+            teamId={teamId}
+            memberCount={setupSummary.memberCount}
+            groundCount={setupSummary.groundCount}
+            opponentCount={setupSummary.opponentCount}
+            gameCount={games.length}
+          />
+        )}
+
         <ColumnLayout columns={3}>
           <KpiCard label="進行中" value={active.length} />
           <KpiCard label="確定済み" value={confirmed.length} />

--- a/packages/web/src/app/(manager)/dashboard/page.tsx
+++ b/packages/web/src/app/(manager)/dashboard/page.tsx
@@ -57,6 +57,7 @@ export default function DashboardPage() {
   const teamId = team?.teamId;
   const [games, setGames] = useState<GameRow[]>([]);
   const [setupSummary, setSetupSummary] = useState<SetupSummary | null>(null);
+  const [setupWarning, setSetupWarning] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -69,6 +70,7 @@ export default function DashboardPage() {
     async function load() {
       setLoading(true);
       setError(null);
+      setSetupWarning(null);
       try {
         const [gamesRes, membersRes, groundsRes, opponentsRes] =
           await Promise.all([
@@ -80,18 +82,23 @@ export default function DashboardPage() {
 
         if (!gamesRes.ok) throw new Error("試合データの取得に失敗しました");
 
-        const [gamesJson, membersJson, groundsJson, opponentsJson] =
-          await Promise.all([
-            gamesRes.json(),
-            membersRes.ok ? membersRes.json() : Promise.resolve({ data: [] }),
-            groundsRes.ok ? groundsRes.json() : Promise.resolve({ data: [] }),
-            opponentsRes.ok
-              ? opponentsRes.json()
-              : Promise.resolve({ data: [] }),
-          ]);
+        const gamesJson = await gamesRes.json();
 
         const nextGames = gamesJson.data ?? [];
         setGames(nextGames);
+
+        if (!membersRes.ok || !groundsRes.ok || !opponentsRes.ok) {
+          setSetupSummary(null);
+          setSetupWarning("初期セットアップ状況の取得に失敗しました。");
+          return;
+        }
+
+        const [membersJson, groundsJson, opponentsJson] = await Promise.all([
+          membersRes.json(),
+          groundsRes.json(),
+          opponentsRes.json(),
+        ]);
+
         setSetupSummary({
           memberCount: membersJson.data?.length ?? 0,
           groundCount: groundsJson.data?.length ?? 0,
@@ -187,6 +194,9 @@ export default function DashboardPage() {
       >
         <Container header={<Header variant="h2">まだ活動がありません</Header>}>
           <SpaceBetween size="l">
+            {setupWarning && (
+              <Box color="text-status-warning">{setupWarning}</Box>
+            )}
             {setupSummary && (
               <TeamSetupChecklist
                 teamId={teamId}
@@ -235,6 +245,7 @@ export default function DashboardPage() {
       }
     >
       <SpaceBetween size="l">
+        {setupWarning && <Box color="text-status-warning">{setupWarning}</Box>}
         {setupSummary && (
           <TeamSetupChecklist
             teamId={teamId}

--- a/packages/web/src/app/(manager)/layout.tsx
+++ b/packages/web/src/app/(manager)/layout.tsx
@@ -150,7 +150,7 @@ export default function ManagerLayout({
                   e.preventDefault();
                   if (e.detail.href === "#create") {
                     setShowCreateModal(true);
-                  } else if (e.detail.href !== "#") {
+                  } else if (!e.detail.href.startsWith("#")) {
                     router.push(e.detail.href);
                   }
                 }}
@@ -171,32 +171,40 @@ export default function ManagerLayout({
                       {
                         type: "link",
                         text: "メンバー",
-                        href: teamId ? `/teams/${teamId}` : "#",
+                        href: teamId ? `/teams/${teamId}` : "#team-members",
                       },
                       {
                         type: "link",
                         text: "助っ人",
-                        href: teamId ? `/teams/${teamId}/helpers` : "#",
+                        href: teamId
+                          ? `/teams/${teamId}/helpers`
+                          : "#team-helpers",
                       },
                       {
                         type: "link",
                         text: "対戦相手",
-                        href: teamId ? `/teams/${teamId}/opponents` : "#",
+                        href: teamId
+                          ? `/teams/${teamId}/opponents`
+                          : "#team-opponents",
                       },
                       {
                         type: "link",
                         text: "グラウンド",
-                        href: teamId ? `/teams/${teamId}/grounds` : "#",
+                        href: teamId
+                          ? `/teams/${teamId}/grounds`
+                          : "#team-grounds",
                       },
                       {
                         type: "link",
                         text: "成績・統計",
-                        href: teamId ? `/teams/${teamId}/stats` : "#",
+                        href: teamId ? `/teams/${teamId}/stats` : "#team-stats",
                       },
                       {
                         type: "link",
                         text: "カレンダー",
-                        href: teamId ? `/teams/${teamId}/calendar` : "#",
+                        href: teamId
+                          ? `/teams/${teamId}/calendar`
+                          : "#team-calendar",
                       },
                       {
                         type: "link",

--- a/packages/web/src/app/(manager)/layout.tsx
+++ b/packages/web/src/app/(manager)/layout.tsx
@@ -141,86 +141,86 @@ export default function ManagerLayout({
           <Spinner size="large" />
         </Box>
       ) : (
-        <AppLayout
-          navigation={
-            <SideNavigation
-              activeHref={pathname}
-              onFollow={(e) => {
-                e.preventDefault();
-                if (e.detail.href === "#create") {
-                  setShowCreateModal(true);
-                } else if (e.detail.href !== "#") {
-                  router.push(e.detail.href);
-                }
-              }}
-              header={{ text: "メニュー", href: "/dashboard" }}
-              items={[
-                { type: "link", text: "ダッシュボード", href: "/dashboard" },
-                { type: "link", text: "試合一覧", href: "/games" },
-                {
-                  type: "link",
-                  text: "活動を作成",
-                  href: "#create",
-                },
-                { type: "divider" },
-                {
-                  type: "section",
-                  text: "チーム管理",
-                  items: [
-                    {
-                      type: "link",
-                      text: "メンバー",
-                      href: teamId ? `/teams/${teamId}` : "#",
-                    },
-                    {
-                      type: "link",
-                      text: "助っ人",
-                      href: teamId ? `/teams/${teamId}/helpers` : "#",
-                    },
-                    {
-                      type: "link",
-                      text: "対戦相手",
-                      href: teamId ? `/teams/${teamId}/opponents` : "#",
-                    },
-                    {
-                      type: "link",
-                      text: "グラウンド",
-                      href: teamId ? `/teams/${teamId}/grounds` : "#",
-                    },
-                    {
-                      type: "link",
-                      text: "成績・統計",
-                      href: teamId ? `/teams/${teamId}/stats` : "#",
-                    },
-                    {
-                      type: "link",
-                      text: "カレンダー",
-                      href: teamId ? `/teams/${teamId}/calendar` : "#",
-                    },
-                    {
-                      type: "link",
-                      text: "設定",
-                      href: "/settings",
-                    },
-                  ],
-                },
-              ]}
-            />
-          }
-          navigationOpen={navOpen}
-          onNavigationChange={({ detail }) => setNavOpen(detail.open)}
-          content={
-            <TeamProvider activeTeam={activeTeam}>{children}</TeamProvider>
-          }
-          toolsHide
-          headerSelector="#top-nav"
-        />
-      )}
+        <TeamProvider activeTeam={activeTeam}>
+          <AppLayout
+            navigation={
+              <SideNavigation
+                activeHref={pathname}
+                onFollow={(e) => {
+                  e.preventDefault();
+                  if (e.detail.href === "#create") {
+                    setShowCreateModal(true);
+                  } else if (e.detail.href !== "#") {
+                    router.push(e.detail.href);
+                  }
+                }}
+                header={{ text: "メニュー", href: "/dashboard" }}
+                items={[
+                  { type: "link", text: "ダッシュボード", href: "/dashboard" },
+                  { type: "link", text: "試合一覧", href: "/games" },
+                  {
+                    type: "link",
+                    text: "活動を作成",
+                    href: "#create",
+                  },
+                  { type: "divider" },
+                  {
+                    type: "section",
+                    text: "チーム管理",
+                    items: [
+                      {
+                        type: "link",
+                        text: "メンバー",
+                        href: teamId ? `/teams/${teamId}` : "#",
+                      },
+                      {
+                        type: "link",
+                        text: "助っ人",
+                        href: teamId ? `/teams/${teamId}/helpers` : "#",
+                      },
+                      {
+                        type: "link",
+                        text: "対戦相手",
+                        href: teamId ? `/teams/${teamId}/opponents` : "#",
+                      },
+                      {
+                        type: "link",
+                        text: "グラウンド",
+                        href: teamId ? `/teams/${teamId}/grounds` : "#",
+                      },
+                      {
+                        type: "link",
+                        text: "成績・統計",
+                        href: teamId ? `/teams/${teamId}/stats` : "#",
+                      },
+                      {
+                        type: "link",
+                        text: "カレンダー",
+                        href: teamId ? `/teams/${teamId}/calendar` : "#",
+                      },
+                      {
+                        type: "link",
+                        text: "設定",
+                        href: "/settings",
+                      },
+                    ],
+                  },
+                ]}
+              />
+            }
+            navigationOpen={navOpen}
+            onNavigationChange={({ detail }) => setNavOpen(detail.open)}
+            content={children}
+            toolsHide
+            headerSelector="#top-nav"
+          />
 
-      <CreateActivityModal
-        visible={showCreateModal}
-        onDismiss={() => setShowCreateModal(false)}
-      />
+          <CreateActivityModal
+            visible={showCreateModal}
+            onDismiss={() => setShowCreateModal(false)}
+          />
+        </TeamProvider>
+      )}
 
       <Modal
         visible={showLogoutConfirm}

--- a/packages/web/src/app/(manager)/settings/page.tsx
+++ b/packages/web/src/app/(manager)/settings/page.tsx
@@ -357,9 +357,7 @@ export default function SettingsPage() {
           />
         </Container>
 
-        {team?.memberId && (
-          <MemberInvitePanel teamId={TEAM_ID} memberId={team.memberId} />
-        )}
+        {team?.memberId && <MemberInvitePanel teamId={TEAM_ID} />}
 
         <form
           onSubmit={(e) => {

--- a/packages/web/src/app/(manager)/settings/page.tsx
+++ b/packages/web/src/app/(manager)/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MemberInvitePanel } from "@/components/MemberInvitePanel";
 import { useTeam } from "@/contexts/TeamContext";
 import Box from "@cloudscape-design/components/box";
 import BreadcrumbGroup from "@cloudscape-design/components/breadcrumb-group";
@@ -64,7 +65,6 @@ export default function SettingsPage() {
   const [teamName, setTeamName] = useState("");
   const [homeArea, setHomeArea] = useState("");
   const [activityDay, setActivityDay] = useState("");
-  const [inviteLink, setInviteLink] = useState("");
 
   // Policy state
   const [autoAccept, setAutoAccept] = useState(false);
@@ -256,12 +256,6 @@ export default function SettingsPage() {
     }
   };
 
-  const generateInviteLink = () => {
-    const liffId = process.env.NEXT_PUBLIC_LIFF_ID ?? "YOUR_LIFF_ID";
-    const link = `https://liff.line.me/${liffId}/register?team_id=${TEAM_ID}`;
-    setInviteLink(link);
-  };
-
   if (loading) {
     return (
       <ContentLayout header={<Header variant="h1">設定</Header>}>
@@ -363,48 +357,9 @@ export default function SettingsPage() {
           />
         </Container>
 
-        {/* Member Invitation */}
-        <Container
-          header={
-            <Header
-              variant="h2"
-              description="LINE経由でメンバーを招待するリンクを生成します"
-            >
-              メンバー招待
-            </Header>
-          }
-        >
-          <SpaceBetween size="m">
-            <Button onClick={generateInviteLink}>招待リンクを生成</Button>
-            {inviteLink && (
-              <SpaceBetween size="xs">
-                <Box variant="awsui-key-label">招待リンク</Box>
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Input value={inviteLink} readOnly />
-                  <Button
-                    iconName="copy"
-                    onClick={() => {
-                      navigator.clipboard.writeText(inviteLink);
-                      setFlash([
-                        {
-                          type: "success",
-                          content: "招待リンクをコピーしました",
-                          dismissible: true,
-                          onDismiss: () => setFlash([]),
-                        },
-                      ]);
-                    }}
-                  >
-                    コピー
-                  </Button>
-                </SpaceBetween>
-                <Box variant="small" color="text-body-secondary">
-                  このリンクをLINEグループに共有してメンバーを招待してください
-                </Box>
-              </SpaceBetween>
-            )}
-          </SpaceBetween>
-        </Container>
+        {team?.memberId && (
+          <MemberInvitePanel teamId={TEAM_ID} memberId={team.memberId} />
+        )}
 
         <form
           onSubmit={(e) => {

--- a/packages/web/src/app/(manager)/teams/[id]/grounds/page.tsx
+++ b/packages/web/src/app/(manager)/teams/[id]/grounds/page.tsx
@@ -41,7 +41,7 @@ export default async function GroundsPage({
         </Header>
       }
     >
-      <GroundsList initialGrounds={grounds ?? []} teamId={id} />
+      <GroundsList initialGrounds={grounds ?? []} />
     </ContentLayout>
   );
 }

--- a/packages/web/src/app/(public)/dev/login/page.tsx
+++ b/packages/web/src/app/(public)/dev/login/page.tsx
@@ -1,0 +1,113 @@
+import { isDevLoginEnabled } from "@/lib/dev-auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import Alert from "@cloudscape-design/components/alert";
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import ContentLayout from "@cloudscape-design/components/content-layout";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { notFound } from "next/navigation";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  missing_member: "ログイン対象のメンバーが指定されていません。",
+  member_not_found:
+    "指定されたメンバーが見つからないか、ACTIVE ではありません。",
+  member_update_failed:
+    "開発用ログインの準備に失敗しました。DB 状態を確認してください。",
+};
+
+interface SearchParams {
+  error?: string;
+}
+
+interface MemberRow {
+  id: string;
+  name: string;
+  teams: { name: string } | { name: string }[] | null;
+}
+
+function getTeamName(teams: MemberRow["teams"]) {
+  if (!teams) return "チーム不明";
+  return Array.isArray(teams) ? (teams[0]?.name ?? "チーム不明") : teams.name;
+}
+
+export default async function DevLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  if (!isDevLoginEnabled()) {
+    notFound();
+  }
+
+  const { error } = await searchParams;
+  const supabase = createAdminClient();
+  const { data: members, error: membersError } = await supabase
+    .from("members")
+    .select("id, name, teams(name)")
+    .eq("status", "ACTIVE")
+    .order("team_id", { ascending: true })
+    .order("created_at", { ascending: true });
+
+  return (
+    <ContentLayout
+      defaultPadding
+      header={
+        <Header
+          variant="h1"
+          description="ローカル開発専用。seed メンバーで疑似ログインします。"
+        >
+          Dev Login
+        </Header>
+      }
+    >
+      <SpaceBetween size="l">
+        <Container>
+          <SpaceBetween size="s">
+            <Box variant="p">
+              事前にローカル Supabase を起動し、`.env.local` にローカル API URL
+              と publishable key を設定してください。
+            </Box>
+            <Box variant="p">
+              選んだメンバーに `line_user_id` が未設定なら、開発用 ID
+              を自動で割り当てます。
+            </Box>
+          </SpaceBetween>
+        </Container>
+
+        {error && <Alert type="error">{ERROR_MESSAGES[error] ?? error}</Alert>}
+
+        {membersError ? (
+          <Alert type="error">
+            メンバー一覧を取得できませんでした: {membersError.message}
+          </Alert>
+        ) : (
+          <SpaceBetween size="m">
+            {(members as MemberRow[] | null)?.map((member) => (
+              <Container
+                key={member.id}
+                header={
+                  <Header variant="h2" description={getTeamName(member.teams)}>
+                    {member.name}
+                  </Header>
+                }
+              >
+                <Button
+                  variant="primary"
+                  href={`/api/dev/login?member_id=${member.id}&redirect=/dashboard`}
+                >
+                  このメンバーでログイン
+                </Button>
+              </Container>
+            )) ?? (
+              <Alert type="warning">
+                ACTIVE メンバーが見つかりません。seed を確認してください。
+              </Alert>
+            )}
+          </SpaceBetween>
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+}

--- a/packages/web/src/app/(public)/dev/login/page.tsx
+++ b/packages/web/src/app/(public)/dev/login/page.tsx
@@ -82,9 +82,10 @@ export default async function DevLoginPage({
           <Alert type="error">
             メンバー一覧を取得できませんでした: {membersError.message}
           </Alert>
-        ) : (
+        ) : (members as MemberRow[] | null) &&
+          (members as MemberRow[]).length > 0 ? (
           <SpaceBetween size="m">
-            {(members as MemberRow[] | null)?.map((member) => (
+            {(members as MemberRow[]).map((member) => (
               <Container
                 key={member.id}
                 header={
@@ -100,12 +101,12 @@ export default async function DevLoginPage({
                   このメンバーでログイン
                 </Button>
               </Container>
-            )) ?? (
-              <Alert type="warning">
-                ACTIVE メンバーが見つかりません。seed を確認してください。
-              </Alert>
-            )}
+            ))}
           </SpaceBetween>
+        ) : (
+          <Alert type="warning">
+            ACTIVE メンバーが見つかりません。seed を確認してください。
+          </Alert>
         )}
       </SpaceBetween>
     </ContentLayout>

--- a/packages/web/src/app/api/cron/daily/route.ts
+++ b/packages/web/src/app/api/cron/daily/route.ts
@@ -1,0 +1,201 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  apiError,
+  apiSuccess,
+  checkGrounds,
+  writeAuditLog,
+} from "@match-engine/core";
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/cron/daily — 日次 cron ジョブ (reminders + deadlines + grounds を統合)
+ *
+ * Vercel Hobby プランの cron 上限 (2件) に対応するため、
+ * 以下の 3 つのタスクをまとめて実行する:
+ * 1. reminders  — 未回答メンバーへのリマインダー通知挿入
+ * 2. deadlines  — rsvp_deadline 超過ゲームを ASSESSING に遷移
+ * 3. grounds    — watch_active なグラウンドの空き確認
+ *
+ * 認証: Bearer CRON_SECRET ヘッダー
+ */
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json(apiError("UNAUTHORIZED", "Invalid CRON_SECRET"), {
+      status: 401,
+    });
+  }
+
+  const supabase = await createClient();
+  const now = new Date();
+
+  // ── 1. Reminders ──────────────────────────────────────────────────────────
+  const cutoff = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+
+  const { data: gamesForReminder } = await supabase
+    .from("games")
+    .select("id, team_id, rsvp_deadline")
+    .eq("status", "COLLECTING")
+    .not("rsvp_deadline", "is", null)
+    .gt("rsvp_deadline", now.toISOString())
+    .lte("rsvp_deadline", cutoff.toISOString());
+
+  let totalReminders = 0;
+  const reminderResults: Array<{
+    gameId: string;
+    reminders: number;
+    error?: string;
+  }> = [];
+
+  for (const game of gamesForReminder ?? []) {
+    try {
+      const { data: responded } = await supabase
+        .from("rsvps")
+        .select("member_id")
+        .eq("game_id", game.id);
+
+      const respondedIds = (responded ?? []).map((r) => r.member_id);
+
+      const { data: members } = await supabase
+        .from("members")
+        .select("id")
+        .eq("team_id", game.team_id);
+
+      const unresponsive = (members ?? []).filter(
+        (m) => !respondedIds.includes(m.id),
+      );
+
+      let gameReminders = 0;
+      for (const member of unresponsive) {
+        const { data: existing } = await supabase
+          .from("notification_logs")
+          .select("id")
+          .eq("game_id", game.id)
+          .eq("recipient_id", member.id)
+          .eq("notification_type", "REMINDER")
+          .limit(1);
+
+        if (existing && existing.length > 0) continue;
+
+        const { error: insertError } = await supabase
+          .from("notification_logs")
+          .insert({
+            team_id: game.team_id,
+            game_id: game.id,
+            recipient_type: "MEMBER",
+            recipient_id: member.id,
+            notification_type: "REMINDER",
+            content: "出欠回答リマインダー: 締切が近づいています",
+          });
+
+        if (!insertError) gameReminders++;
+      }
+
+      totalReminders += gameReminders;
+      reminderResults.push({ gameId: game.id, reminders: gameReminders });
+    } catch (e) {
+      reminderResults.push({
+        gameId: game.id,
+        reminders: 0,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  // ── 2. Deadlines ──────────────────────────────────────────────────────────
+  const { data: overdueGames, error: deadlineError } = await supabase
+    .from("games")
+    .select("id, version")
+    .eq("status", "COLLECTING")
+    .lte("rsvp_deadline", now.toISOString());
+
+  if (deadlineError) {
+    return NextResponse.json(
+      apiError("DATABASE_ERROR", deadlineError.message),
+      {
+        status: 500,
+      },
+    );
+  }
+
+  let deadlinesProcessed = 0;
+  const deadlineErrors: Array<{ gameId: string; error: string }> = [];
+
+  for (const game of overdueGames ?? []) {
+    const { error: updateError } = await supabase
+      .from("games")
+      .update({ status: "ASSESSING", version: game.version + 1 })
+      .eq("id", game.id)
+      .eq("version", game.version);
+
+    if (updateError) {
+      deadlineErrors.push({ gameId: game.id, error: updateError.message });
+      continue;
+    }
+
+    await writeAuditLog(supabase, {
+      actor_type: "SYSTEM",
+      actor_id: "SYSTEM",
+      action: "CRON:DEADLINE_PROCESSED",
+      target_type: "game",
+      target_id: game.id,
+      after_json: {
+        previous_status: "COLLECTING",
+        new_status: "ASSESSING",
+        previous_version: game.version,
+      },
+    });
+
+    deadlinesProcessed++;
+  }
+
+  // ── 3. Grounds ────────────────────────────────────────────────────────────
+  const { data: activeGrounds, error: groundsError } = await supabase
+    .from("grounds")
+    .select("team_id")
+    .eq("watch_active", true);
+
+  if (groundsError) {
+    return NextResponse.json(apiError("DATABASE_ERROR", groundsError.message), {
+      status: 500,
+    });
+  }
+
+  const teamIds = [...new Set((activeGrounds ?? []).map((g) => g.team_id))];
+  const groundsResults = [];
+  let totalNewAvailabilities = 0;
+
+  for (const teamId of teamIds) {
+    try {
+      const result = await checkGrounds(supabase, teamId);
+      groundsResults.push(result);
+      totalNewAvailabilities += result.totalNewAvailabilities;
+    } catch (e) {
+      groundsResults.push({
+        teamId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return NextResponse.json(
+    apiSuccess({
+      processedAt: now.toISOString(),
+      reminders: {
+        gamesProcessed: (gamesForReminder ?? []).length,
+        totalReminders,
+        results: reminderResults,
+      },
+      deadlines: {
+        processedCount: deadlinesProcessed,
+        totalFound: (overdueGames ?? []).length,
+        errors: deadlineErrors.length > 0 ? deadlineErrors : undefined,
+      },
+      grounds: {
+        teamsChecked: teamIds.length,
+        totalNewAvailabilities,
+        results: groundsResults,
+      },
+    }),
+  );
+}

--- a/packages/web/src/app/api/dev/login/route.ts
+++ b/packages/web/src/app/api/dev/login/route.ts
@@ -1,0 +1,75 @@
+import { SESSION_COOKIE_NAME, createSessionToken } from "@/lib/line-auth";
+import { getDevLineUserId, isDevLoginEnabled } from "@/lib/dev-auth";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { NextResponse } from "next/server";
+
+function devLoginDisabledResponse() {
+  return new NextResponse("Not Found", { status: 404 });
+}
+
+function getSafeRedirect(input: string | null) {
+  if (!input || !input.startsWith("/") || input.startsWith("//")) {
+    return "/dashboard";
+  }
+  return input;
+}
+
+/** GET /api/dev/login — 開発用の疑似ログイン */
+export async function GET(request: Request) {
+  if (!isDevLoginEnabled()) {
+    return devLoginDisabledResponse();
+  }
+
+  const url = new URL(request.url);
+  const memberId = url.searchParams.get("member_id");
+  const redirect = getSafeRedirect(url.searchParams.get("redirect"));
+
+  if (!memberId) {
+    return NextResponse.redirect(
+      new URL("/dev/login?error=missing_member", url.origin),
+    );
+  }
+
+  const supabase = createAdminClient();
+  const { data: member, error } = await supabase
+    .from("members")
+    .select("id, name, line_user_id, status")
+    .eq("id", memberId)
+    .single();
+
+  if (error || !member || member.status !== "ACTIVE") {
+    return NextResponse.redirect(
+      new URL("/dev/login?error=member_not_found", url.origin),
+    );
+  }
+
+  const lineUserId = member.line_user_id ?? getDevLineUserId(member.id);
+
+  if (!member.line_user_id) {
+    const { error: updateError } = await supabase
+      .from("members")
+      .update({ line_user_id: lineUserId })
+      .eq("id", member.id);
+
+    if (updateError) {
+      return NextResponse.redirect(
+        new URL("/dev/login?error=member_update_failed", url.origin),
+      );
+    }
+  }
+
+  const sessionToken = await createSessionToken({
+    userId: lineUserId,
+    displayName: member.name,
+  });
+
+  const response = NextResponse.redirect(new URL(redirect, url.origin));
+  response.cookies.set(SESSION_COOKIE_NAME, sessionToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  });
+  return response;
+}

--- a/packages/web/src/app/api/dev/login/route.ts
+++ b/packages/web/src/app/api/dev/login/route.ts
@@ -1,5 +1,5 @@
-import { SESSION_COOKIE_NAME, createSessionToken } from "@/lib/line-auth";
 import { getDevLineUserId, isDevLoginEnabled } from "@/lib/dev-auth";
+import { SESSION_COOKIE_NAME, createSessionToken } from "@/lib/line-auth";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { NextResponse } from "next/server";
 

--- a/packages/web/src/app/api/liff/register/route.ts
+++ b/packages/web/src/app/api/liff/register/route.ts
@@ -43,12 +43,19 @@ export async function POST(request: Request) {
   } | null = null;
 
   if (body.invite_code) {
-    const { data: inviteData } = await supabase
+    const { data: inviteData, error: invitationFetchError } = await supabase
       .from("team_invitations")
       .select("id, team_id, use_count, max_uses, expires_at")
       .eq("invite_code", body.invite_code)
       .eq("is_active", true)
-      .single();
+      .maybeSingle();
+
+    if (invitationFetchError) {
+      return NextResponse.json(
+        { error: invitationFetchError.message },
+        { status: 500 },
+      );
+    }
 
     if (!inviteData) {
       return NextResponse.json(
@@ -130,17 +137,40 @@ export async function POST(request: Request) {
   }
 
   if (invitation) {
-    const { error: invitationError } = await supabase
+    const { data: consumedInvitations, error: invitationError } = await supabase
       .from("team_invitations")
       .update({ use_count: invitation.use_count + 1 })
-      .eq("id", invitation.id);
+      .eq("id", invitation.id)
+      .eq("use_count", invitation.use_count)
+      .select("id");
 
-    if (!invitationError) {
-      await supabase.from("invitation_uses").insert({
+    if (invitationError) {
+      return NextResponse.json(
+        { error: invitationError.message },
+        { status: 500 },
+      );
+    }
+
+    if (!consumedInvitations || consumedInvitations.length !== 1) {
+      return NextResponse.json(
+        { error: "招待コードの使用に失敗しました。もう一度お試しください。" },
+        { status: 409 },
+      );
+    }
+
+    const { error: invitationUseError } = await supabase
+      .from("invitation_uses")
+      .insert({
         invitation_id: invitation.id,
-        used_by_user_id: result.lineUserId,
+        used_by_user_id: target.id,
         used_by_team_id: target.team_id,
       });
+
+    if (invitationUseError) {
+      return NextResponse.json(
+        { error: invitationUseError.message },
+        { status: 500 },
+      );
     }
   }
 

--- a/packages/web/src/app/api/liff/register/route.ts
+++ b/packages/web/src/app/api/liff/register/route.ts
@@ -21,7 +21,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: result.error }, { status: 403 });
   }
 
-  const body = (await request.json()) as { member_id?: string };
+  const body = (await request.json()) as {
+    member_id?: string;
+    invite_code?: string | null;
+  };
   if (!body.member_id) {
     return NextResponse.json(
       { error: "member_id is required" },
@@ -30,6 +33,49 @@ export async function POST(request: Request) {
   }
 
   const supabase = await createClient();
+
+  let invitation: {
+    id: string;
+    team_id: string;
+    use_count: number;
+    max_uses: number | null;
+    expires_at: string | null;
+  } | null = null;
+
+  if (body.invite_code) {
+    const { data: inviteData } = await supabase
+      .from("team_invitations")
+      .select("id, team_id, use_count, max_uses, expires_at")
+      .eq("invite_code", body.invite_code)
+      .eq("is_active", true)
+      .single();
+
+    if (!inviteData) {
+      return NextResponse.json(
+        { error: "招待コードが無効です" },
+        { status: 404 },
+      );
+    }
+
+    if (inviteData.expires_at && new Date(inviteData.expires_at) < new Date()) {
+      return NextResponse.json(
+        { error: "招待コードの有効期限が切れています" },
+        { status: 400 },
+      );
+    }
+
+    if (
+      inviteData.max_uses !== null &&
+      inviteData.use_count >= inviteData.max_uses
+    ) {
+      return NextResponse.json(
+        { error: "招待コードの使用回数上限に達しています" },
+        { status: 400 },
+      );
+    }
+
+    invitation = inviteData;
+  }
 
   // 既に他のメンバーに紐付いていないか確認
   const { data: existing } = await supabase
@@ -51,12 +97,19 @@ export async function POST(request: Request) {
   // 対象メンバーが既に別のLINE IDを持っていないか確認
   const { data: target } = await supabase
     .from("members")
-    .select("id, name, line_user_id")
+    .select("id, name, line_user_id, team_id")
     .eq("id", body.member_id)
     .single();
 
   if (!target) {
     return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+
+  if (invitation && invitation.team_id !== target.team_id) {
+    return NextResponse.json(
+      { error: "招待されたチームのメンバーのみ登録できます" },
+      { status: 403 },
+    );
   }
 
   if (target.line_user_id) {
@@ -74,6 +127,21 @@ export async function POST(request: Request) {
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  if (invitation) {
+    const { error: invitationError } = await supabase
+      .from("team_invitations")
+      .update({ use_count: invitation.use_count + 1 })
+      .eq("id", invitation.id);
+
+    if (!invitationError) {
+      await supabase.from("invitation_uses").insert({
+        invitation_id: invitation.id,
+        used_by_user_id: result.lineUserId,
+        used_by_team_id: target.team_id,
+      });
+    }
   }
 
   return NextResponse.json({

--- a/packages/web/src/app/api/teams/[id]/invitations/route.ts
+++ b/packages/web/src/app/api/teams/[id]/invitations/route.ts
@@ -20,12 +20,20 @@ export async function POST(
   if (roleCheck) return roleCheck;
 
   const { id: teamId } = await params;
+  if (authResult.team_id !== teamId) {
+    return NextResponse.json(
+      apiError("FORBIDDEN", "アクセス権限がありません"),
+      { status: 403 },
+    );
+  }
+
   const supabase = await createClient();
   const body = await request.json();
 
   const parsed = createInvitationSchema.safeParse({
     ...body,
     team_id: teamId,
+    created_by: authResult.id,
   });
   if (!parsed.success) {
     const ve = zodToValidationError(parsed.error);
@@ -63,7 +71,17 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
+  const authResult = await requireAuth();
+  if (authResult instanceof NextResponse) return authResult;
+
   const { id: teamId } = await params;
+  if (authResult.team_id !== teamId) {
+    return NextResponse.json(
+      apiError("FORBIDDEN", "アクセス権限がありません"),
+      { status: 403 },
+    );
+  }
+
   const supabase = await createClient();
 
   const { data, error } = await supabase

--- a/packages/web/src/app/liff/register/page.tsx
+++ b/packages/web/src/app/liff/register/page.tsx
@@ -46,6 +46,7 @@ function ErrorDisplay({
 export default function LiffRegisterPage() {
   const { accessToken, profile } = useLiffContext();
   const searchParams = useSearchParams();
+  const inviteCode = searchParams.get("code");
   const teamId = searchParams.get("team_id");
 
   const [members, setMembers] = useState<Member[]>([]);
@@ -59,12 +60,37 @@ export default function LiffRegisterPage() {
   } | null>(null);
 
   const fetchMembers = useCallback(async () => {
-    if (!teamId) {
+    setLoading(true);
+    setFetchError(null);
+
+    const resolvedTeamId = inviteCode
+      ? await (async () => {
+          const inviteRes = await fetch(`/api/invitations/${inviteCode}`);
+          if (!inviteRes.ok) {
+            if (inviteRes.status === 404) {
+              setFetchError("招待コードが見つかりません。");
+            } else {
+              const inviteJson = await inviteRes.json().catch(() => null);
+              setFetchError(
+                inviteJson?.error?.message ??
+                  "招待リンクの検証に失敗しました。",
+              );
+            }
+            return null;
+          }
+
+          const inviteJson = (await inviteRes.json()) as {
+            data?: { team_id?: string };
+          };
+          return inviteJson.data?.team_id ?? null;
+        })()
+      : teamId;
+
+    if (!resolvedTeamId) {
       setLoading(false);
       return;
     }
-    setLoading(true);
-    setFetchError(null);
+
     try {
       const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const supabaseKey =
@@ -77,7 +103,7 @@ export default function LiffRegisterPage() {
       }
 
       const membersRes = await fetch(
-        `${supabaseUrl}/rest/v1/members?team_id=eq.${teamId}&status=eq.ACTIVE&select=id,name,line_user_id&order=name`,
+        `${supabaseUrl}/rest/v1/members?team_id=eq.${resolvedTeamId}&status=eq.ACTIVE&select=id,name,line_user_id&order=name`,
         {
           headers: {
             apikey: supabaseKey,
@@ -99,7 +125,7 @@ export default function LiffRegisterPage() {
     } finally {
       setLoading(false);
     }
-  }, [teamId]);
+  }, [inviteCode, teamId]);
 
   useEffect(() => {
     fetchMembers();
@@ -118,7 +144,10 @@ export default function LiffRegisterPage() {
           "Content-Type": "application/json",
           Authorization: `Bearer ${accessToken}`,
         },
-        body: JSON.stringify({ member_id: memberId }),
+        body: JSON.stringify({
+          member_id: memberId,
+          invite_code: inviteCode,
+        }),
       });
 
       const json = (await res.json()) as {
@@ -146,9 +175,9 @@ export default function LiffRegisterPage() {
     }
   };
 
-  if (!teamId) {
+  if (!teamId && !inviteCode) {
     return (
-      <ErrorDisplay message="チーム ID が指定されていません。正しいリンクからアクセスしてください。" />
+      <ErrorDisplay message="招待コードが指定されていません。正しいリンクからアクセスしてください。" />
     );
   }
 

--- a/packages/web/src/app/liff/register/page.tsx
+++ b/packages/web/src/app/liff/register/page.tsx
@@ -3,6 +3,20 @@
 import { useLiffContext } from "@/components/liff/LiffProvider";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { z } from "zod/v4";
+
+const InviteParamsSchema = z
+  .object({
+    inviteCode: z
+      .string()
+      .regex(/^[A-Za-z0-9]{8}$/, "招待コードの形式が不正です")
+      .nullable(),
+    teamId: z.string().uuid("チーム ID の形式が不正です").nullable(),
+  })
+  .refine((value) => value.inviteCode || value.teamId, {
+    message:
+      "招待コードまたはチーム ID が指定されていません。正しいリンクからアクセスしてください。",
+  });
 
 interface Member {
   id: string;
@@ -46,8 +60,10 @@ function ErrorDisplay({
 export default function LiffRegisterPage() {
   const { accessToken, profile } = useLiffContext();
   const searchParams = useSearchParams();
-  const inviteCode = searchParams.get("code");
-  const teamId = searchParams.get("team_id");
+  const parsedParams = InviteParamsSchema.safeParse({
+    inviteCode: searchParams.get("code"),
+    teamId: searchParams.get("team_id"),
+  });
 
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
@@ -58,40 +74,51 @@ export default function LiffRegisterPage() {
     success: boolean;
     message: string;
   } | null>(null);
+  const parsedParamsErrorMessage = parsedParams.success
+    ? null
+    : (parsedParams.error.issues[0]?.message ?? "リンクが不正です");
+  const inviteCode = parsedParams.success ? parsedParams.data.inviteCode : null;
+  const teamId = parsedParams.success ? parsedParams.data.teamId : null;
 
   const fetchMembers = useCallback(async () => {
-    setLoading(true);
-    setFetchError(null);
-
-    const resolvedTeamId = inviteCode
-      ? await (async () => {
-          const inviteRes = await fetch(`/api/invitations/${inviteCode}`);
-          if (!inviteRes.ok) {
-            if (inviteRes.status === 404) {
-              setFetchError("招待コードが見つかりません。");
-            } else {
-              const inviteJson = await inviteRes.json().catch(() => null);
-              setFetchError(
-                inviteJson?.error?.message ??
-                  "招待リンクの検証に失敗しました。",
-              );
-            }
-            return null;
-          }
-
-          const inviteJson = (await inviteRes.json()) as {
-            data?: { team_id?: string };
-          };
-          return inviteJson.data?.team_id ?? null;
-        })()
-      : teamId;
-
-    if (!resolvedTeamId) {
+    if (!parsedParams.success) {
       setLoading(false);
+      setFetchError(parsedParamsErrorMessage);
       return;
     }
 
+    setLoading(true);
+    setFetchError(null);
+
     try {
+      let resolvedTeamId = teamId;
+      if (inviteCode) {
+        const inviteRes = await fetch(
+          `/api/invitations/${encodeURIComponent(inviteCode)}`,
+        );
+        const inviteJson = (await inviteRes.json()) as {
+          data?: { team_id?: string };
+          error?: { message?: string };
+        };
+
+        if (!inviteRes.ok) {
+          setFetchError(
+            inviteJson.error?.message ??
+              (inviteRes.status === 404
+                ? "招待コードが見つかりません。"
+                : "招待リンクの検証に失敗しました。"),
+          );
+          return;
+        }
+
+        resolvedTeamId = inviteJson.data?.team_id ?? null;
+      }
+
+      if (!resolvedTeamId) {
+        setFetchError("チームが特定できませんでした。");
+        return;
+      }
+
       const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const supabaseKey =
         process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
@@ -102,15 +129,18 @@ export default function LiffRegisterPage() {
         return;
       }
 
-      const membersRes = await fetch(
-        `${supabaseUrl}/rest/v1/members?team_id=eq.${resolvedTeamId}&status=eq.ACTIVE&select=id,name,line_user_id&order=name`,
-        {
-          headers: {
-            apikey: supabaseKey,
-            Authorization: `Bearer ${supabaseKey}`,
-          },
+      const membersUrl = new URL("/rest/v1/members", supabaseUrl);
+      membersUrl.searchParams.set("team_id", `eq.${resolvedTeamId}`);
+      membersUrl.searchParams.set("status", "eq.ACTIVE");
+      membersUrl.searchParams.set("select", "id,name,line_user_id");
+      membersUrl.searchParams.set("order", "name");
+
+      const membersRes = await fetch(membersUrl.toString(), {
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
         },
-      );
+      });
       if (!membersRes.ok) {
         if (membersRes.status === 404) {
           setFetchError("指定されたチームが見つかりません。");
@@ -125,7 +155,7 @@ export default function LiffRegisterPage() {
     } finally {
       setLoading(false);
     }
-  }, [inviteCode, teamId]);
+  }, [inviteCode, parsedParams.success, parsedParamsErrorMessage, teamId]);
 
   useEffect(() => {
     fetchMembers();
@@ -175,10 +205,8 @@ export default function LiffRegisterPage() {
     }
   };
 
-  if (!teamId && !inviteCode) {
-    return (
-      <ErrorDisplay message="招待コードが指定されていません。正しいリンクからアクセスしてください。" />
-    );
+  if (parsedParamsErrorMessage) {
+    return <ErrorDisplay message={parsedParamsErrorMessage} />;
   }
 
   if (loading) {

--- a/packages/web/src/components/MemberInvitePanel.tsx
+++ b/packages/web/src/components/MemberInvitePanel.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import { useState } from "react";
+
+interface MemberInvitePanelProps {
+  teamId: string;
+  memberId: string;
+  title?: string;
+  description?: string;
+}
+
+export function MemberInvitePanel({
+  teamId,
+  memberId,
+  title = "メンバー招待",
+  description = "LINE グループに共有する招待リンクを発行します",
+}: MemberInvitePanelProps) {
+  const [inviteLink, setInviteLink] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  const generateInviteLink = async () => {
+    const liffId = process.env.NEXT_PUBLIC_LIFF_ID;
+    if (!liffId) {
+      setMessage({
+        type: "error",
+        text: "LIFF ID が未設定です。環境変数を確認してください。",
+      });
+      return;
+    }
+
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const expiresAt = new Date(
+        Date.now() + 1000 * 60 * 60 * 24 * 14,
+      ).toISOString();
+
+      const res = await fetch(`/api/teams/${teamId}/invitations`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          invite_type: "MEMBER",
+          created_by: memberId,
+          expires_at: expiresAt,
+          max_uses: 50,
+        }),
+      });
+      const json = await res.json();
+
+      if (!res.ok) {
+        setMessage({
+          type: "error",
+          text: json?.error?.message ?? "招待リンクの生成に失敗しました",
+        });
+        return;
+      }
+
+      const code = json?.data?.invite_code as string | undefined;
+      if (!code) {
+        setMessage({
+          type: "error",
+          text: "招待コードの生成に失敗しました",
+        });
+        return;
+      }
+
+      setInviteLink(`https://liff.line.me/${liffId}/register?code=${code}`);
+      setMessage({
+        type: "success",
+        text: "招待リンクを生成しました。LINE グループで共有できます。",
+      });
+    } catch {
+      setMessage({
+        type: "error",
+        text: "通信エラーが発生しました。もう一度お試しください。",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyInviteLink = async () => {
+    if (!inviteLink) return;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setMessage({
+        type: "success",
+        text: "招待リンクをコピーしました",
+      });
+    } catch {
+      setMessage({
+        type: "error",
+        text: "クリップボードへのコピーに失敗しました",
+      });
+    }
+  };
+
+  return (
+    <Container
+      header={
+        <Header variant="h2" description={description}>
+          {title}
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        {message && (
+          <Box
+            color={
+              message.type === "success"
+                ? "text-status-success"
+                : "text-status-error"
+            }
+          >
+            {message.text}
+          </Box>
+        )}
+
+        <SpaceBetween direction="horizontal" size="xs">
+          <Button loading={loading} onClick={generateInviteLink}>
+            招待リンクを生成
+          </Button>
+          <Button disabled={!inviteLink} onClick={copyInviteLink}>
+            コピー
+          </Button>
+        </SpaceBetween>
+
+        {inviteLink && (
+          <SpaceBetween size="xs">
+            <Box variant="awsui-key-label">招待リンク</Box>
+            <Input value={inviteLink} readOnly />
+            <Box variant="small" color="text-body-secondary">
+              有効期限は 14 日、最大 50 回まで利用できます。
+            </Box>
+          </SpaceBetween>
+        )}
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/packages/web/src/components/MemberInvitePanel.tsx
+++ b/packages/web/src/components/MemberInvitePanel.tsx
@@ -3,26 +3,31 @@
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
+import Flashbar from "@cloudscape-design/components/flashbar";
 import Header from "@cloudscape-design/components/header";
 import Input from "@cloudscape-design/components/input";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useState } from "react";
+import { z } from "zod/v4";
+
+const MemberInvitePanelSchema = z.object({
+  teamId: z.string().uuid("チーム ID の形式が不正です"),
+});
 
 interface MemberInvitePanelProps {
   teamId: string;
-  memberId: string;
   title?: string;
   description?: string;
 }
 
 export function MemberInvitePanel({
   teamId,
-  memberId,
   title = "メンバー招待",
   description = "LINE グループに共有する招待リンクを発行します",
 }: MemberInvitePanelProps) {
   const [inviteLink, setInviteLink] = useState("");
   const [loading, setLoading] = useState(false);
+  const [copyLoading, setCopyLoading] = useState(false);
   const [message, setMessage] = useState<{
     type: "success" | "error";
     text: string;
@@ -42,20 +47,31 @@ export function MemberInvitePanel({
     setMessage(null);
 
     try {
+      const parsed = MemberInvitePanelSchema.safeParse({ teamId });
+      if (!parsed.success) {
+        setMessage({
+          type: "error",
+          text: parsed.error.issues[0]?.message ?? "チーム ID が不正です。",
+        });
+        return;
+      }
+
       const expiresAt = new Date(
         Date.now() + 1000 * 60 * 60 * 24 * 14,
       ).toISOString();
 
-      const res = await fetch(`/api/teams/${teamId}/invitations`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          invite_type: "MEMBER",
-          created_by: memberId,
-          expires_at: expiresAt,
-          max_uses: 50,
-        }),
-      });
+      const res = await fetch(
+        `/api/teams/${encodeURIComponent(parsed.data.teamId)}/invitations`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            invite_type: "MEMBER",
+            expires_at: expiresAt,
+            max_uses: 50,
+          }),
+        },
+      );
       const json = await res.json();
 
       if (!res.ok) {
@@ -91,7 +107,8 @@ export function MemberInvitePanel({
   };
 
   const copyInviteLink = async () => {
-    if (!inviteLink) return;
+    if (!inviteLink || copyLoading) return;
+    setCopyLoading(true);
     try {
       await navigator.clipboard.writeText(inviteLink);
       setMessage({
@@ -103,6 +120,8 @@ export function MemberInvitePanel({
         type: "error",
         text: "クリップボードへのコピーに失敗しました",
       });
+    } finally {
+      setCopyLoading(false);
     }
   };
 
@@ -116,22 +135,27 @@ export function MemberInvitePanel({
     >
       <SpaceBetween size="m">
         {message && (
-          <Box
-            color={
-              message.type === "success"
-                ? "text-status-success"
-                : "text-status-error"
-            }
-          >
-            {message.text}
-          </Box>
+          <Flashbar
+            items={[
+              {
+                type: message.type === "success" ? "success" : "error",
+                content: message.text,
+                dismissible: true,
+                onDismiss: () => setMessage(null),
+              },
+            ]}
+          />
         )}
 
         <SpaceBetween direction="horizontal" size="xs">
           <Button loading={loading} onClick={generateInviteLink}>
             招待リンクを生成
           </Button>
-          <Button disabled={!inviteLink} onClick={copyInviteLink}>
+          <Button
+            loading={copyLoading}
+            disabled={!inviteLink || copyLoading}
+            onClick={copyInviteLink}
+          >
             コピー
           </Button>
         </SpaceBetween>

--- a/packages/web/src/components/MembersList.tsx
+++ b/packages/web/src/components/MembersList.tsx
@@ -2,6 +2,8 @@
 
 import { DeleteConfirmModal } from "@/components/DeleteConfirmModal";
 import { MemberFormModal } from "@/components/MemberFormModal";
+import { MemberInvitePanel } from "@/components/MemberInvitePanel";
+import { useTeam } from "@/contexts/TeamContext";
 import { useCrudList } from "@/hooks/useCrudList";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
@@ -44,6 +46,7 @@ interface MembersListProps {
 }
 
 export function MembersList({ initialMembers, teamId }: MembersListProps) {
+  const team = useTeam();
   const crud = useCrudList<Member>({
     deleteEndpoint: (id) => `/api/members/${id}`,
     entityName: "メンバー",
@@ -52,6 +55,15 @@ export function MembersList({ initialMembers, teamId }: MembersListProps) {
   return (
     <>
       {crud.flash.length > 0 && <Flashbar items={crud.flash} />}
+
+      {team?.memberId && (
+        <MemberInvitePanel
+          teamId={teamId}
+          memberId={team.memberId}
+          title="メンバー招待"
+          description="LINE 連携用の招待リンクを発行して、チームメンバーを追加します"
+        />
+      )}
 
       <Cards
         header={

--- a/packages/web/src/components/MembersList.tsx
+++ b/packages/web/src/components/MembersList.tsx
@@ -59,7 +59,6 @@ export function MembersList({ initialMembers, teamId }: MembersListProps) {
       {team?.memberId && (
         <MemberInvitePanel
           teamId={teamId}
-          memberId={team.memberId}
           title="メンバー招待"
           description="LINE 連携用の招待リンクを発行して、チームメンバーを追加します"
         />
@@ -143,7 +142,15 @@ export function MembersList({ initialMembers, teamId }: MembersListProps) {
         items={initialMembers}
         empty={
           <Box textAlign="center" color="text-body-secondary" padding="xxl">
-            メンバーがいません
+            <SpaceBetween size="m">
+              <Box>メンバーがいません</Box>
+              <Box variant="small">
+                最初のメンバーを追加して運営を始めてください。
+              </Box>
+              <Button variant="primary" onClick={crud.openCreate}>
+                メンバーを追加
+              </Button>
+            </SpaceBetween>
           </Box>
         }
       />

--- a/packages/web/src/components/TeamSetupChecklist.tsx
+++ b/packages/web/src/components/TeamSetupChecklist.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Box from "@cloudscape-design/components/box";
+import Button from "@cloudscape-design/components/button";
+import Container from "@cloudscape-design/components/container";
+import Header from "@cloudscape-design/components/header";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import StatusIndicator from "@cloudscape-design/components/status-indicator";
+
+interface TeamSetupChecklistProps {
+  teamId: string;
+  memberCount: number;
+  groundCount: number;
+  opponentCount: number;
+  gameCount: number;
+}
+
+interface ChecklistItem {
+  id: string;
+  label: string;
+  helpText: string;
+  complete: boolean;
+  href: string;
+  actionLabel: string;
+}
+
+export function TeamSetupChecklist({
+  teamId,
+  memberCount,
+  groundCount,
+  opponentCount,
+  gameCount,
+}: TeamSetupChecklistProps) {
+  const items: ChecklistItem[] = [
+    {
+      id: "members",
+      label: "メンバーを集める",
+      helpText:
+        memberCount >= 9
+          ? `${memberCount}人登録済み`
+          : `${memberCount}人登録済み。試合には最低9人を目安に準備します。`,
+      complete: memberCount >= 9,
+      href: `/teams/${teamId}`,
+      actionLabel: "メンバー管理",
+    },
+    {
+      id: "grounds",
+      label: "グラウンドを登録する",
+      helpText:
+        groundCount > 0
+          ? `${groundCount}件登録済み`
+          : "まずは候補の球場を1件以上登録します。",
+      complete: groundCount > 0,
+      href: `/teams/${teamId}/grounds`,
+      actionLabel: "グラウンド管理",
+    },
+    {
+      id: "opponents",
+      label: "対戦相手を登録する",
+      helpText:
+        opponentCount > 0
+          ? `${opponentCount}件登録済み`
+          : "練習試合の打診先を登録しておくと日程調整が早くなります。",
+      complete: opponentCount > 0,
+      href: `/teams/${teamId}/opponents`,
+      actionLabel: "対戦相手を追加",
+    },
+    {
+      id: "games",
+      label: "最初の活動を作成する",
+      helpText:
+        gameCount > 0
+          ? `${gameCount}件の活動あり`
+          : "試合または練習を作ると出欠確認が始まります。",
+      complete: gameCount > 0,
+      href: "/games/new",
+      actionLabel: "活動を作成",
+    },
+  ];
+
+  const completedCount = items.filter((item) => item.complete).length;
+
+  if (completedCount === items.length) {
+    return null;
+  }
+
+  return (
+    <Container
+      header={
+        <Header
+          variant="h2"
+          description={`${completedCount}/${items.length} 完了`}
+        >
+          初期セットアップ
+        </Header>
+      }
+    >
+      <SpaceBetween size="m">
+        <Box variant="p">
+          草野球の運営を回し始めるために必要な準備を並べています。
+          未完了の項目から進めてください。
+        </Box>
+
+        {items.map((item) => (
+          <div key={item.id}>
+            <SpaceBetween size="xs" direction="horizontal">
+              <StatusIndicator type={item.complete ? "success" : "pending"}>
+                {item.complete ? "完了" : "未完了"}
+              </StatusIndicator>
+              <Box fontWeight="bold">{item.label}</Box>
+            </SpaceBetween>
+            <Box color="text-body-secondary">{item.helpText}</Box>
+            {!item.complete && (
+              <Box padding={{ top: "xs" }}>
+                <Button href={item.href}>{item.actionLabel}</Button>
+              </Box>
+            )}
+          </div>
+        ))}
+      </SpaceBetween>
+    </Container>
+  );
+}

--- a/packages/web/src/lib/dev-auth.ts
+++ b/packages/web/src/lib/dev-auth.ts
@@ -1,0 +1,9 @@
+export const DEV_LOGIN_PREFIX = "dev-login:";
+
+export function isDevLoginEnabled() {
+  return process.env.NODE_ENV !== "production";
+}
+
+export function getDevLineUserId(memberId: string) {
+  return `${DEV_LOGIN_PREFIX}${memberId}`;
+}

--- a/packages/web/src/lib/supabase/admin.ts
+++ b/packages/web/src/lib/supabase/admin.ts
@@ -5,7 +5,9 @@ const supabaseSecret = process.env.SUPABASE_SECRET_KEY;
 
 export function createAdminClient() {
   if (!supabaseUrl || !supabaseSecret) {
-    throw new Error("SUPABASE_SECRET_KEY is not configured");
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SECRET_KEY is not configured",
+    );
   }
 
   return createClient(supabaseUrl, supabaseSecret, {

--- a/packages/web/src/lib/supabase/admin.ts
+++ b/packages/web/src/lib/supabase/admin.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseSecret = process.env.SUPABASE_SECRET_KEY;
+
+export function createAdminClient() {
+  if (!supabaseUrl || !supabaseSecret) {
+    throw new Error("SUPABASE_SECRET_KEY is not configured");
+  }
+
+  return createClient(supabaseUrl, supabaseSecret, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}

--- a/packages/web/src/lib/supabase/server.ts
+++ b/packages/web/src/lib/supabase/server.ts
@@ -2,7 +2,9 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+const supabaseKey =
+  process.env.SUPABASE_SECRET_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
 
 export const createClient = async () => {
   const cookieStore = await cookies();

--- a/packages/web/src/lib/supabase/server.ts
+++ b/packages/web/src/lib/supabase/server.ts
@@ -2,13 +2,17 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseKey =
-  process.env.SUPABASE_SECRET_KEY ??
-  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+const supabaseKey = process.env.SUPABASE_SECRET_KEY;
 
 export const createClient = async () => {
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SECRET_KEY is not configured",
+    );
+  }
+
   const cookieStore = await cookies();
-  return createServerClient(supabaseUrl!, supabaseKey!, {
+  return createServerClient(supabaseUrl, supabaseKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll();

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -4,6 +4,7 @@ import { SESSION_COOKIE_NAME } from "./lib/line-auth";
 // 認証不要のパス
 const PUBLIC_PATHS = [
   "/login",
+  "/dev",
   "/api/auth",
   "/auth/callback",
   "/api/liff",

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,10 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { isDevLoginEnabled } from "./lib/dev-auth";
 import { SESSION_COOKIE_NAME } from "./lib/line-auth";
 
 // 認証不要のパス
 const PUBLIC_PATHS = [
   "/login",
-  "/dev",
   "/api/auth",
   "/auth/callback",
   "/api/liff",
@@ -21,6 +21,11 @@ const PUBLIC_PATHS = [
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const isDevPath =
+    pathname === "/dev" ||
+    pathname.startsWith("/dev/") ||
+    pathname === "/api/dev" ||
+    pathname.startsWith("/api/dev/");
 
   // CSRF: ミューテーション系リクエストの Origin ヘッダー検証
   if (["POST", "PATCH", "PUT", "DELETE"].includes(request.method)) {
@@ -29,6 +34,13 @@ export async function middleware(request: NextRequest) {
     if (origin && host && !origin.includes(host)) {
       return NextResponse.json({ error: "Invalid origin" }, { status: 403 });
     }
+  }
+
+  if (isDevPath) {
+    if (process.env.NODE_ENV !== "development" || !isDevLoginEnabled()) {
+      return new NextResponse("Not Found", { status: 404 });
+    }
+    return NextResponse.next();
   }
 
   // 公開パスはスキップ（完全一致 or パス区切り付き前方一致）

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -1,8 +1,6 @@
 {
   "crons": [
     { "path": "/api/cron/orchestrate", "schedule": "0 8,12,18,21 * * *" },
-    { "path": "/api/cron/reminders", "schedule": "0 9 * * *" },
-    { "path": "/api/cron/deadlines", "schedule": "0 0 * * *" },
-    { "path": "/api/cron/grounds", "schedule": "0 6 * * *" }
+    { "path": "/api/cron/daily", "schedule": "0 0 * * *" }
   ]
 }

--- a/supabase/migrations/00007_leagues.sql
+++ b/supabase/migrations/00007_leagues.sql
@@ -75,20 +75,11 @@ CREATE INDEX idx_league_matches_league ON league_matches(league_id);
 CREATE INDEX idx_league_matches_round ON league_matches(league_id, round);
 CREATE INDEX idx_league_standings_league ON league_standings(league_id);
 
--- updated_at 自動更新トリガー
-CREATE OR REPLACE FUNCTION update_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE TRIGGER set_leagues_updated_at
-  BEFORE UPDATE ON leagues FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  BEFORE UPDATE ON leagues FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER set_league_teams_updated_at
-  BEFORE UPDATE ON league_teams FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  BEFORE UPDATE ON league_teams FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER set_league_matches_updated_at
-  BEFORE UPDATE ON league_matches FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  BEFORE UPDATE ON league_matches FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER set_league_standings_updated_at
-  BEFORE UPDATE ON league_standings FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  BEFORE UPDATE ON league_standings FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/00007_leagues.sql
+++ b/supabase/migrations/00007_leagues.sql
@@ -76,6 +76,14 @@ CREATE INDEX idx_league_matches_round ON league_matches(league_id, round);
 CREATE INDEX idx_league_standings_league ON league_standings(league_id);
 
 -- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE TRIGGER set_leagues_updated_at
   BEFORE UPDATE ON leagues FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 CREATE TRIGGER set_league_teams_updated_at

--- a/supabase/migrations/00008_viral_features.sql
+++ b/supabase/migrations/00008_viral_features.sql
@@ -57,6 +57,6 @@ CREATE INDEX idx_invitation_uses_invitation ON invitation_uses(invitation_id);
 
 -- updated_at 自動更新トリガー
 CREATE TRIGGER set_team_invitations_updated_at
-  BEFORE UPDATE ON team_invitations FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  BEFORE UPDATE ON team_invitations FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER set_team_profiles_updated_at
-  BEFORE UPDATE ON team_profiles FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  BEFORE UPDATE ON team_profiles FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -105,15 +105,15 @@ INSERT INTO negotiations (id, game_id, opponent_team_id, status, proposed_dates_
 
 -- ===== 助っ人リクエスト =====
 INSERT INTO helper_requests (id, game_id, helper_id, status, message, sent_at, responded_at) VALUES
-  ('hhhhhhhh-0001-4001-8001-hhhhhhhhhhhh', 'bbbbbbbb-0005-4005-8005-bbbbbbbbbbbb', 'ff000000-0001-4001-8001-ff0000000001', 'ACCEPTED', '5/10の試合、助っ人お願いできますか？', now(), now()),
-  ('hhhhhhhh-0002-4002-8002-hhhhhhhhhhhh', 'bbbbbbbb-0005-4005-8005-bbbbbbbbbbbb', 'ff000000-0002-4002-8002-ff0000000002', 'PENDING',  '5/10の試合、助っ人お願いできますか？', now(), NULL);
+  ('abababab-0001-4001-8001-abababababab', 'bbbbbbbb-0005-4005-8005-bbbbbbbbbbbb', 'ff000000-0001-4001-8001-ff0000000001', 'ACCEPTED', '5/10の試合、助っ人お願いできますか？', now(), now()),
+  ('abababab-0002-4002-8002-abababababab', 'bbbbbbbb-0005-4005-8005-bbbbbbbbbbbb', 'ff000000-0002-4002-8002-ff0000000002', 'PENDING',  '5/10の試合、助っ人お願いできますか？', now(), NULL);
 
 -- ===== 試合結果 =====
 INSERT INTO game_results (id, game_id, our_score, opponent_score, result, innings, note) VALUES
-  ('rrrrrrrr-0001-4001-8001-rrrrrrrrrrrr', 'bbbbbbbb-0001-4001-8001-bbbbbbbbbbbb', 8,  3, 'WIN',  7, '田中が完投。打線も好調'),
-  ('rrrrrrrr-0002-4002-8002-rrrrrrrrrrrr', 'bbbbbbbb-0002-4002-8002-bbbbbbbbbbbb', 4,  6, 'LOSE', 7, '中盤に逆転を許した'),
-  ('rrrrrrrr-0003-4003-8003-rrrrrrrrrrrr', 'bbbbbbbb-0003-4003-8003-bbbbbbbbbbbb', 5,  5, 'DRAW', 7, '延長なしの規定により引き分け'),
-  ('rrrrrrrr-0004-4004-8004-rrrrrrrrrrrr', 'bbbbbbbb-0008-4008-8008-bbbbbbbbbbbb', 7,  2, 'WIN',  7, 'リーグ戦初勝利');
+  ('cdcdcdcd-0001-4001-8001-cdcdcdcdcdcd', 'bbbbbbbb-0001-4001-8001-bbbbbbbbbbbb', 8,  3, 'WIN',  7, '田中が完投。打線も好調'),
+  ('cdcdcdcd-0002-4002-8002-cdcdcdcdcdcd', 'bbbbbbbb-0002-4002-8002-bbbbbbbbbbbb', 4,  6, 'LOSE', 7, '中盤に逆転を許した'),
+  ('cdcdcdcd-0003-4003-8003-cdcdcdcdcdcd', 'bbbbbbbb-0003-4003-8003-bbbbbbbbbbbb', 5,  5, 'DRAW', 7, '延長なしの規定により引き分け'),
+  ('cdcdcdcd-0004-4004-8004-cdcdcdcdcdcd', 'bbbbbbbb-0008-4008-8008-bbbbbbbbbbbb', 7,  2, 'WIN',  7, 'リーグ戦初勝利');
 
 -- ===== 出席記録 =====
 INSERT INTO attendances (game_id, person_type, person_id, status, recorded_by) VALUES


### PR DESCRIPTION
## Summary
- add local dev login flow for smoke testing and fix related regressions
- replace ad-hoc member invite links with invitation-code based LIFF registration
- add setup checklist and member invite entry points to improve first-time team operations

## Verification
- `bun run check`
- verified invitation creation API returns `201` with an invite code on local dev
- spot-checked app routes with `agent-browser` and local dev login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team setup checklist on the dashboard showing onboarding progress.
  * Generate and copy shareable LINE invitation links via a new invite panel.
  * Development-only dev-login page for quick dev sign-in (visible only in dev).

* **Improvements**
  * Settings and members pages surface invitation management and clearer empty states.
  * Navigation behavior refined to avoid accidental fragment-triggered navigation.
  * Dashboard shows setup warnings when supporting data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->