### PR TITLE
refactor: CLI-first pivot with Clean Architecture + Homebrew distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
-# only one can run at a time
 concurrency:
-  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -16,7 +14,6 @@ on:
       - "docs/**"
   workflow_dispatch:
 
-# Supply chain security: Minimal permissions
 permissions:
   contents: read
   packages: read
@@ -27,17 +24,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      # Supply chain security: SHA pinning
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
 
-      # Supply chain security: Safe Chain for malicious package detection
       - name: Setup safe-chain
         run: |
           npm i -g @aikidosec/safe-chain
           safe-chain setup-ci
 
-      # Supply chain security: Disable lifecycle scripts (handled by make install-ci)
       - name: Install dependencies
         run: make install-ci
 
@@ -47,17 +43,16 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      # Supply chain security: SHA pinning
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
 
-      # Supply chain security: Safe Chain for malicious package detection
       - name: Setup safe-chain
         run: |
           npm i -g @aikidosec/safe-chain
           safe-chain setup-ci
 
-      # Supply chain security: Disable lifecycle scripts (handled by make install-ci)
       - name: Install dependencies
         run: make install-ci
 
@@ -67,70 +62,53 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      # Supply chain security: SHA pinning
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
 
-      # Supply chain security: Safe Chain for malicious package detection
       - name: Setup safe-chain
         run: |
           npm i -g @aikidosec/safe-chain
           safe-chain setup-ci
 
-      # Supply chain security: Disable lifecycle scripts (handled by make install-ci)
       - name: Install dependencies
         run: make install-ci
 
       - run: make test
 
+  shellcheck:
+    name: Shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: bash -n (syntax)
+        run: bash -n scripts/generate-formula.sh
+      - name: shellcheck
+        run: shellcheck scripts/generate-formula.sh
+
   build:
-    name: Build
+    name: Build CLI binary (smoke)
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:
-      # Supply chain security: SHA pinning
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
 
-      # Supply chain security: Safe Chain for malicious package detection
       - name: Setup safe-chain
         run: |
           npm i -g @aikidosec/safe-chain
           safe-chain setup-ci
 
-      # Supply chain security: Disable lifecycle scripts (handled by make install-ci)
       - name: Install dependencies
         run: make install-ci
 
-      - run: make build
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      - name: Build CLI binary
+        run: make cli-build
 
-  migrate:
-    name: Database Migration
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: [build]
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: supabase/setup-cli@v2
-        with:
-          version: 2.84.2
-
-      - name: Link Supabase project
-        if: ${{ secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_PROJECT_REF != '' }}
-        run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-
-      - name: Run migrations
-        if: ${{ secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_PROJECT_REF != '' }}
-        run: supabase db push
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-
-      - name: Skip migration (secrets not configured)
-        if: ${{ secrets.SUPABASE_ACCESS_TOKEN == '' || secrets.SUPABASE_PROJECT_REF == '' }}
-        run: echo "⚠️ SUPABASE_ACCESS_TOKEN or SUPABASE_PROJECT_REF not set. Skipping migration."
+      - name: Smoke test binary
+        run: |
+          ./bin/mound --version
+          ./bin/mound --help | head -5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release-build:
+    name: Cross-compile (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-darwin-arm64
+            platform: macos-arm64
+          - target: bun-darwin-x64
+            platform: macos-x86_64
+          - target: bun-linux-arm64
+            platform: linux-arm64
+          - target: bun-linux-x64
+            platform: linux-x86_64
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      - name: Resolve version
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: make install-ci
+
+      - name: Build ${{ matrix.platform }}
+        env:
+          TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          mkdir -p dist
+          bun build --compile --minify \
+            --target="$TARGET" \
+            packages/cli/src/index.ts \
+            --outfile "dist/mound-$PLATFORM"
+          cd dist
+          tar -czf "mound-$VERSION-$PLATFORM.tar.gz" "mound-$PLATFORM"
+          rm "mound-$PLATFORM"
+          shasum -a 256 "mound-$VERSION-$PLATFORM.tar.gz" \
+            > "mound-$VERSION-$PLATFORM.tar.gz.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: mound-${{ matrix.platform }}
+          path: dist/*
+          retention-days: 7
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: release-build
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Resolve version
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate combined checksums.txt
+        working-directory: dist
+        run: |
+          cat *.sha256 > checksums.txt
+          echo "--- checksums.txt ---"
+          cat checksums.txt
+
+      - name: Generate Homebrew formula
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          bash scripts/generate-formula.sh "$VERSION" "$REPO" dist > dist/mound.rb
+          echo "--- generated formula ---"
+          cat dist/mound.rb
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        with:
+          tag_name: ${{ steps.meta.outputs.version }}
+          name: ${{ steps.meta.outputs.version }}
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.sha256
+            dist/checksums.txt
+            dist/mound.rb

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ out/
 
 # build
 build/
+bin/
 dist/
 
 # env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## プロジェクト概要
 
-草野球チーム向け試合成立エンジン SaaS。仕様は [SPEC.md](./SPEC.md) を参照。
+草野球チーム向け試合成立 CLI。試合希望・出欠・状態遷移・監査ログを libSQL (SQLite/Turso) に保存し、`mound` コマンドで操作する。GUI は CodexBar 風 macOS メニューバーアプリのみ(CLI を spawn ラップ)。詳細は [SPEC.md](./SPEC.md)。
 
 ## コマンド
 
@@ -10,13 +10,60 @@
 make check          # lint + typecheck + test (変更後に必ず実行)
 make lint-fix       # 自動修正
 make test           # テスト実行
-make start          # 開発サーバー起動
+make mound ARGS="--help"  # CLI 実行
+make cli-build      # bin/mound にバイナリを生成
+make install-local  # bin/mound を $HOME/.local/bin に symlink
+make release-build  # 4 ターゲット tarball を dist/ に生成
 make help           # 全コマンド一覧
 ```
 
+## アーキテクチャ (Clean Architecture)
+
+依存方向は常に内向き(domain ← usecases ← adapters):
+
+```
+packages/cli/src/
+├── domain/              # 内側: 純粋な型 + 不変ルール (I/O 非依存)
+│   ├── types.ts         # エンティティ・値型・状態列挙
+│   ├── guards.ts        # isGameStatus / assertGameStatus 等
+│   └── state-machine.ts # 状態遷移 + ガード条件
+├── ports.ts             # アプリケーション境界: Repository インターフェイス + UseCaseContext
+├── usecases/            # ビジネスルール: ports.ts のみ依存。DB も CLI も知らない
+│   ├── team.ts          # createTeam / listTeams
+│   ├── member.ts        # addMember / listMembers
+│   ├── game.ts          # createGame / listGames / showGame / transitionGame
+│   ├── rsvp.ts          # setRsvp / listRsvpsWithMembers / summarizeRsvps
+│   ├── audit.ts         # writeAuditLog / listAuditLogs
+│   ├── agenda.ts        # computeAgenda
+│   └── errors.ts        # ドメイン例外
+└── adapters/            # 外側: ports.ts を実装、または駆動する
+    ├── libsql/          # libSQL 実装
+    │   ├── client.ts    # DB 接続 + lazy migration (PRAGMA user_version)
+    │   ├── schema.ts    # DDL + SCHEMA_VERSION
+    │   ├── row-mappers.ts
+    │   └── repositories.ts  # buildRepositories(db): Repositories
+    └── cli/             # CLI 駆動層: argv → usecase → 出力
+        ├── args.ts      # フラグパーサ
+        ├── output.ts    # JSON / TSV レンダラ
+        ├── help.ts
+        ├── zod-helper.ts
+        ├── compose.ts   # DI ワイヤリング
+        ├── cli.ts       # ディスパッチャ
+        └── commands/    # 各サブコマンドの薄いアダプタ
+```
+
+新機能を作るときの順序:
+
+1. `domain/` に必要な型・ルールを足す
+2. `ports.ts` を見て足りない repository メソッドがあれば追加
+3. `usecases/<feature>.ts` にビジネスロジックを書く(ports.ts と domain/ のみ import)
+4. `adapters/libsql/repositories.ts` に SQL 実装を足す
+5. `adapters/cli/commands/<feature>.ts` で usecase を呼ぶ
+6. usecase の単体テスト(in-memory ポートで)+ e2e テストを追加
+
 ## 開発ルール
 
-### 変更後は必ず `make before-commit` を通す
+### 変更後は必ず `make check` を通す
 
 lint・型チェック・テストが全て通ることを確認してからコミットする。
 
@@ -25,122 +72,45 @@ lint・型チェック・テストが全て通ることを確認してからコ�
 日本語の `describe` / `it` で振る舞いを記述する。テスト名は「〜のとき」「〜する」形式。
 
 ```ts
-describe("canConfirm", () => {
-  describe("すべての条件を満たしているとき", () => {
-    it("確定を許可する", () => { ... });
+describe("transitionGame", () => {
+  describe("人数不足のとき", () => {
+    it("CONFIRMED への遷移を拒否する", () => { ... });
   });
 });
 ```
 
-- Arrange-Act-Assert パターンを守る
-- 1つの `it` で1つの振る舞いのみテストする
-- ファクトリ関数 (`createMatchRequest()` など) でデフォルト値付きテストデータを用意し、差分だけ `overrides` で渡す
-- テストファイルは `src/__tests__/*.test.ts` に配置する
+- Arrange-Act-Assert
+- 1 つの `it` で 1 振る舞い
+- ファクトリ関数(`createTeam()` 等)でデフォルト値、差分だけ `overrides` で渡す
+- ユースケース層は **in-memory な port 実装(fake)** に対してテストする(`__tests__/usecases/`)
+- 統合は `e2e-binary.test.ts` でコンパイル済みバイナリ越しに踏む
+
+### 依存方向の禁則
+
+- `domain/` から `adapters/` や `usecases/` を import するな
+- `usecases/` から `adapters/` を import するな(逆はOK)
+- `adapters/libsql/` から `adapters/cli/` を import するな(逆もNG)
 
 ### 禁止事項
 
-- 認証情報・秘密鍵のハードコード禁止 → `.env` を使用
+- 認証情報・秘密鍵のハードコード禁止 → 環境変数 (`MOUND_DB_AUTH_TOKEN` 等)
 - TypeScript strict mode の無効化禁止
-- ユーザー入力の無検証での使用禁止 (必ず Zod スキーマで検証)
+- ユーザー入力の無検証使用禁止(必ず Zod スキーマで検証)
+- DB-row 値を `as` で union 型へ無検査キャスト禁止(`domain/guards.ts` の assert\* を使う)
 
 ### Git コミット
 
-`feat:` / `fix:` / `refactor:` / `docs:` / `test:` / `chore:` のプレフィックスを使用する。
+`feat:` / `fix:` / `refactor:` / `docs:` / `test:` / `chore:` のプレフィックスを使用。
 
-## ドキュメント
+## 配布
 
-| ファイル | 内容 |
-| --- | --- |
-| [SPEC.md](./SPEC.md) | 機能仕様・ドメインモデル |
-| [docs/architecture.md](./docs/architecture.md) | アーキテクチャ設計・通知戦略 |
-| [docs/data-model.md](./docs/data-model.md) | データモデル・ER図・DFD |
-| [docs/agent-protocol.md](./docs/agent-protocol.md) | AI エージェントプロトコル |
-| [docs/diagrams.md](./docs/diagrams.md) | システム図 |
-| [docs/migration-strategy.md](./docs/migration-strategy.md) | v1→v2 マイグレーション戦略 |
-| [docs/operations-reality.md](./docs/operations-reality.md) | 運用上の現実・制約 |
+- ローカル: `make install-local` で `~/.local/bin/mound` に symlink
+- リリース: `git tag v0.X.Y && git push origin v0.X.Y` で `.github/workflows/release.yml` が走り、4 プラットフォーム tarball + Homebrew formula を Release に添付
+- Homebrew: `Formula/mound.rb` (テンプレ) を `scripts/generate-formula.sh` が値埋め生成。`susumutomita/homebrew-tap` リポジトリにコピーして配布
 
-## 設計思想
+## 商用品質基準
 
-- AI は **提案** する (Planner) — AI が勝手に確定・実行しない
-- システムは **状態を持つ** (State Machine) — 状態遷移は `packages/core/lib/state-machine.ts` が正本
-- ルールエンジンが **暴走を防ぐ** (Governor) — `packages/core/lib/governor.ts` で成立条件を判定
-- 人が **最後に承認する** — CONFIRMED 遷移は必ず人間のアクションを要求する
-
-## 自律改善エージェント ガイドライン
-
-スケジュール実行やIssueドリブンで自律的にプロダクトを改善するエージェント向けのルール。
-
-### 実行フロー
-
-```
-1. GitHub Issues を確認 (open, ラベル: enhancement/bug/chore)
-2. 優先度判定 (bug > enhancement > chore)
-3. ブランチ作成 (claude/<issue-slug>-<number>)
-4. 実装 + テスト追加
-5. make check 通過を確認
-6. コミット + プッシュ
-7. PR 作成 (Closes #<number> をbodyに含める)
-```
-
-### 制約
-
-- **破壊的変更禁止**: 既存のAPIシグネチャ・型定義を壊さない
-- **テスト必須**: 新機能には必ずテストを追加する。既存テストを壊さない
-- **1 Issue = 1 PR**: Issue ごとにブランチを分ける
-- **スコープ厳守**: Issue に書かれた範囲のみ実装する。関連する改善を見つけても別 Issue にする
-- **ドキュメント不要**: README/CLAUDE.md の更新はユーザーが明示的に依頼した場合のみ
-- **依存追加は慎重に**: 新しい npm パッケージの追加は最小限に
-
-### コード品質チェックリスト
-
-- [ ] `make check` (lint + typecheck + test) が通る
-- [ ] 新しいエクスポートは `packages/core/src/index.ts` に追加済み
-- [ ] Zod バリデーションを使っている (ユーザー入力)
-- [ ] `Result<T, E>` パターンでエラーハンドリングしている
-- [ ] BDD スタイルのテストを書いている (日本語 describe/it)
-- [ ] ファクトリ関数でテストデータを用意している
-
-## 商用品質基準 (Production Quality Standard)
-
-**このプロダクトは「出荷できる品質」を常に維持する。妥協しない。**
-
-### フロントエンド必須要件
-
-#### エラーハンドリング
-- **全ページに `error.tsx` を配置**: サーバーコンポーネントのクラッシュをキャッチする
-- **全ページに `loading.tsx` を配置**: データ取得中のスケルトン/スピナーを表示する
-- **API呼び出しは全て try/catch**: `.catch(() => {})` で握り潰さない。ユーザーに何が起きたか伝える
-- **空状態 (Empty State)**: データがゼロ件のとき「データがありません」だけでなく、次のアクションを提示する
-
-#### メタ情報
-- **OGP タグ必須**: og:title, og:description, og:image, og:url — SNS でシェアされたとき正しく表示
-- **favicon 必須**: `/app/icon.svg` または `/public/favicon.ico`
-- **viewport, charset**: Next.js のデフォルトに任せず明示する
-
-#### UI/UX
-- **ローディング状態**: ボタンクリック後、処理中は `loading` prop でボタンを無効化 + スピナー表示
-- **確認ダイアログ**: 破壊的操作 (ログアウト、削除、キャンセル) は確認を挟む
-- **フィードバック**: 操作成功時は Flashbar/Toast で結果を伝える
-- **レスポンシブ**: モバイルファーストで設計。Cloudscape の ColumnLayout は画面幅に応じて列数を変える
-
-#### セキュリティ
-- **全APIルートに認証チェック**: 公開エンドポイント以外は `requireAuth()` 必須
-- **認可チェック**: 自分のチームのデータだけアクセスできる (team_id の所有権検証)
-- **入力検証**: Zod スキーマで全入力をバリデーション。未検証データを DB に渡さない
-
-### API ルート必須要件
-- Supabase クエリの `{ data, error }` は **必ず error をチェック** する
-- レスポンスは常に `apiSuccess()` / `apiError()` ヘルパーで返す
-- `data` が null/undefined の可能性がある場合は明示的にハンドリングする
-
-### パッケージ構造の理解
-
-```
-packages/core/   → ビジネスロジック (純粋関数・型定義・バリデーション)
-packages/web/    → Next.js フロントエンド + API Routes
-packages/mcp/    → Claude MCP サーバー (エージェント向けツール)
-supabase/        → DB マイグレーション・シードデータ
-scripts/         → ユーティリティスクリプト
-```
-
-core パッケージのモジュールを変更した場合、web/mcp で利用する場合は `index.ts` からエクスポートすること。
+- 全コマンド `--json` を受け付ける(エージェント / GUI 連携)
+- ドメイン例外は `usecases/errors.ts` に分類し、CLI 層で exit code に翻訳
+- libSQL クエリは必ずパラメータ化(`?` プレースホルダ)
+- DB 接続は `ensureSchemaUpToDate` で lazy migration(`PRAGMA user_version`)

--- a/Formula/mound.rb
+++ b/Formula/mound.rb
@@ -1,0 +1,56 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for mound — 草野球チーム向け試合成立 CLI
+#
+# This file is a TEMPLATE. On every release, the GitHub Actions release
+# workflow regenerates it via scripts/generate-formula.sh and attaches it
+# to the GitHub Release as `mound.rb`. Copy the released `mound.rb` to your
+# Homebrew tap repository (e.g. susumutomita/homebrew-tap) to publish.
+#
+# The placeholder values below are intentionally invalid so that they fail
+# loudly if you forget to regenerate them.
+class Mound < Formula
+  desc "草野球チーム向け試合成立 CLI"
+  homepage "https://github.com/susumutomita/mound"
+  version "0.0.0"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://example.invalid/mound-vX.Y.Z-macos-arm64.tar.gz"
+      sha256 "REPLACE_ME"
+    end
+    on_intel do
+      url "https://example.invalid/mound-vX.Y.Z-macos-x86_64.tar.gz"
+      sha256 "REPLACE_ME"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://example.invalid/mound-vX.Y.Z-linux-arm64.tar.gz"
+      sha256 "REPLACE_ME"
+    end
+    on_intel do
+      url "https://example.invalid/mound-vX.Y.Z-linux-x86_64.tar.gz"
+      sha256 "REPLACE_ME"
+    end
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.arm?
+      bin.install "mound-macos-arm64" => "mound"
+    elsif OS.mac?
+      bin.install "mound-macos-x86_64" => "mound"
+    elsif OS.linux? && Hardware::CPU.arm?
+      bin.install "mound-linux-arm64" => "mound"
+    else
+      bin.install "mound-linux-x86_64" => "mound"
+    end
+  end
+
+  test do
+    assert_match "mound", shell_output("#{bin}/mound --version")
+  end
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Susumu Tomita
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,64 @@
-.PHONY: start dev build lint lint-fix lint-check format typecheck test test-watch test-coverage check before-commit clean install install-ci
+.PHONY: start mound build cli-build release-build cli-clean install-local uninstall-local \
+        lint lint-fix lint-check format typecheck test test-watch test-coverage \
+        check before-commit clean install install-ci help
 
 BUN := $(or $(shell command -v bun 2>/dev/null),$(HOME)/.bun/bin/bun)
 BIOME := ./node_modules/.bin/biome
+ENTRY := packages/cli/src/index.ts
+DIST := dist
+VERSION := $(shell git describe --tags --always 2>/dev/null || echo 0.0.0)
 
 # ===================================================
 # 試合成立エンジン — Makefile
 # ===================================================
 
-## 起動
-start: install dev ## ローカル開発サーバーを起動
+## CLI 起動
+start: install mound ## CLI を起動 (引数は ARGS で渡す: make start ARGS="team list")
 
-dev: ## Next.js 開発サーバーを起動
-	$(BUN) run dev
+mound: ## CLI を実行 (例: make mound ARGS="team list")
+	$(BUN) run $(ENTRY) $(ARGS)
 
-build: ## プロダクションビルド
-	$(BUN) run build
+## バイナリビルド
+build: cli-build ## 現プラットフォーム向けバイナリ (bin/mound)
+
+cli-build: ## 現プラットフォーム向け単一バイナリ (bin/mound)
+	@mkdir -p bin
+	$(BUN) build --compile --minify $(ENTRY) --outfile bin/mound
+	@echo "✅ bin/mound built"
+
+release-build: ## 4 ターゲット (macOS arm64/x86_64, Linux arm64/x86_64) tarball を dist/ に生成
+	@rm -rf $(DIST)
+	@mkdir -p $(DIST)
+	@$(MAKE) _release-target TARGET=bun-darwin-arm64  PLATFORM=macos-arm64
+	@$(MAKE) _release-target TARGET=bun-darwin-x64    PLATFORM=macos-x86_64
+	@$(MAKE) _release-target TARGET=bun-linux-arm64   PLATFORM=linux-arm64
+	@$(MAKE) _release-target TARGET=bun-linux-x64     PLATFORM=linux-x86_64
+	@cd $(DIST) && shasum -a 256 *.tar.gz > checksums.txt
+	@echo "✅ release artifacts:"
+	@ls -lh $(DIST)
+
+_release-target:
+	@echo "→ building $(PLATFORM) ($(TARGET))"
+	@$(BUN) build --compile --minify --target=$(TARGET) $(ENTRY) --outfile $(DIST)/mound-$(PLATFORM)
+	@cd $(DIST) && tar -czf mound-$(VERSION)-$(PLATFORM).tar.gz mound-$(PLATFORM)
+	@rm -f $(DIST)/mound-$(PLATFORM)
+
+cli-clean: ## ビルド成果物を削除
+	rm -rf bin $(DIST)
+
+INSTALL_DIR ?= $(HOME)/.local/bin
+install-local: cli-build ## bin/mound を $(INSTALL_DIR) に symlink (デフォルト ~/.local/bin)
+	@mkdir -p $(INSTALL_DIR)
+	@ln -sf $(abspath bin/mound) $(INSTALL_DIR)/mound
+	@echo "✅ $(INSTALL_DIR)/mound -> $(abspath bin/mound)"
+	@case ":$$PATH:" in \
+	  *":$(INSTALL_DIR):"*) ;; \
+	  *) echo "⚠  $(INSTALL_DIR) は PATH に入っていません。~/.zshrc に export PATH=\"$(INSTALL_DIR):\$$PATH\" を追記してください" ;; \
+	esac
+
+uninstall-local: ## $(INSTALL_DIR)/mound の symlink を削除
+	@rm -f $(INSTALL_DIR)/mound
+	@echo "✅ removed $(INSTALL_DIR)/mound"
 
 ## 品質チェック
 lint: ## Biome lint チェック
@@ -56,10 +100,8 @@ install-ci: ## CI用インストール (install後にlockfile差分チェック)
 	$(BUN) install
 	git diff --exit-code bun.lock || (echo "ERROR: bun.lock is out of date. Run 'bun install' locally and commit bun.lock." && exit 1)
 
-clean: ## ビルド成果物を削除
-	rm -rf packages/web/.next
-	rm -rf packages/core/tsconfig.tsbuildinfo
-	rm -rf packages/web/tsconfig.tsbuildinfo
+clean: cli-clean ## ビルド成果物・キャッシュを削除
+	rm -rf packages/cli/tsconfig.tsbuildinfo
 	rm -rf tsconfig.tsbuildinfo
 
 ## ヘルプ

--- a/README.md
+++ b/README.md
@@ -1,32 +1,114 @@
 # mound
 
-草野球チーム向け試合成立エンジン SaaS。
-試合の日程調整・出欠確認・グラウンド確保を状態管理付きで自動化する。
+草野球チーム向け試合成立 CLI。試合希望・出欠・状態遷移・監査ログを SQLite (libSQL) に保存し、エージェントからも操作できる単一バイナリで提供する。
 
 > AI は提案する。システムは状態を持つ。人が最後に決める。
+
+## インストール
+
+### Homebrew (推奨)
+
+```bash
+brew install susumutomita/tap/mound
+```
+
+### GitHub Releases から直接
+
+```bash
+# macOS arm64 の例
+curl -L -o mound.tar.gz \
+  https://github.com/susumutomita/mound/releases/latest/download/mound-vX.Y.Z-macos-arm64.tar.gz
+tar -xzf mound.tar.gz
+sudo mv mound-macos-arm64 /usr/local/bin/mound
+mound --help
+```
+
+ターゲット: `macos-arm64` / `macos-x86_64` / `linux-arm64` / `linux-x86_64`。SHA256 はリリースの `checksums.txt` を参照。
+
+### ソースから(開発者向け)
+
+```bash
+git clone https://github.com/susumutomita/mound.git
+cd mound
+make install        # 依存インストール
+make install-local  # bin/mound を $HOME/.local/bin に symlink (PATH 通すだけ)
+mound --version
+```
+
+別の場所に置きたいなら `make install-local INSTALL_DIR=/opt/homebrew/bin` のように上書き。`make uninstall-local` で symlink を削除できる。`make cli-build` 単体だと `bin/mound` のみで PATH には乗らない。
 
 ## クイックスタート
 
 ```bash
-cp .env.example .env   # NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY を設定
-make start
+mound init                                                # DB を初期化 (~/.mound/mound.db)
+mound team create --name 横浜BB --area 横浜
+mound member add --team <TEAM_ID> --name 山田太郎
+mound game create --team <TEAM_ID> --title 練習試合 --date 2026-06-01 --min-players 9
+mound game transition <GAME_ID> --to COLLECTING
+mound rsvp set --game <GAME_ID> --member <MEMBER_ID> --response AVAILABLE
+mound agenda --team <TEAM_ID> --json   # メニューバーアプリが叩く想定
 ```
 
-## 主要コマンド
+`--json` を付ければ全コマンドが機械可読 JSON を返す(エージェント・GUI 連携)。
+
+### DB の保存先
+
+```bash
+export MOUND_DB_URL="file:./mound.db"           # ローカルファイル
+export MOUND_DB_URL="libsql://xxx.turso.io"     # Turso クラウド
+export MOUND_DB_AUTH_TOKEN="..."                # Turso 認証
+```
+
+未指定なら `~/.mound/mound.db` を使う。
+
+## CI/Release の仕組み
+
+| Workflow | トリガ | 内容 |
+| --- | --- | --- |
+| [`ci.yml`](.github/workflows/ci.yml) | push / PR | lint + typecheck + test + バイナリ smoke |
+| [`release.yml`](.github/workflows/release.yml) | `v*` タグ push | 4 ターゲット tarball + checksums + Homebrew formula を GitHub Release に添付 |
+
+リリース手順:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0   # → release.yml が走る
+```
+
+リリースが完了したら、Release ページに `mound.rb` が添付されている。これを `susumutomita/homebrew-tap` リポジトリの `Formula/mound.rb` にコピー・コミット・push すれば `brew install susumutomita/tap/mound` で配布できる。
+
+tap リポジトリの最小構成:
+
+```
+homebrew-tap/
+└── Formula/
+    └── mound.rb
+```
+
+## 開発
+
+```bash
+make check          # lint + typecheck + test
+make mound ARGS="--help"
+make release-build  # ローカルで 4 ターゲット tarball を生成 (Bun が必要)
+```
+
+## 主要コマンド一覧
 
 | コマンド | 用途 |
 | --- | --- |
 | `make check` | lint + typecheck + test (コミット前に必須) |
-| `make test` | テスト実行 |
-| `make lint-fix` | 自動修正 |
+| `make cli-build` | 現プラットフォーム向け単一バイナリ (`bin/mound`) |
+| `make release-build` | 4 ターゲット tarball + SHA256 を `dist/` に生成 |
 | `make help` | 全コマンド一覧 |
 
-## 仕様・設計ドキュメント
+## アーキテクチャ
 
-- [SPEC.md](./SPEC.md) — 機能仕様・ドメインモデル
-- [docs/architecture.md](./docs/architecture.md) — アーキテクチャ設計
-- [docs/data-model.md](./docs/data-model.md) — データモデル・ER図
-- [docs/agent-protocol.md](./docs/agent-protocol.md) — AI エージェントプロトコル
+- `packages/cli/` — CLI 本体 (Bun + `@libsql/client` + zod)
+- `Formula/` — Homebrew formula テンプレート (リリース時に上書き)
+- `scripts/generate-formula.sh` — リリース成果物から formula を組み立てる
+
+GUI は **macOS メニューバーアプリ (Swift / SwiftPM, CodexBar 面取り)** が `mound` CLI を spawn して利用する想定。Web UI は作らない。
 
 ## 禁止事項
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,27 @@
     "": {
       "name": "mound",
       "dependencies": {
-        "zod": "^4.3.6",
+        "@libsql/client": "^0.17.3",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
         "vitest": "^4.1.2",
+      },
+    },
+    "packages/cli": {
+      "name": "@match-engine/cli",
+      "version": "0.1.0",
+      "bin": {
+        "mound": "./src/index.ts",
+      },
+      "dependencies": {
+        "@libsql/client": "^0.17.3",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -43,7 +59,37 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@libsql/client": ["@libsql/client@0.17.3", "", { "dependencies": { "@libsql/core": "^0.17.3", "@libsql/hrana-client": "^0.10.0", "js-base64": "^3.7.5", "libsql": "^0.5.28", "promise-limit": "^2.7.0" } }, "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA=="],
+
+    "@libsql/core": ["@libsql/core@0.17.3", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-2UjK1i7JBkMduJo4WdvvBxMMvVJ31pArBZNONyz/GCJJAH+1UHat2X6vn10S/WpY5fKzIT98WqYFl2vzWRLOfg=="],
+
+    "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.5.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A=="],
+
+    "@libsql/darwin-x64": ["@libsql/darwin-x64@0.5.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ=="],
+
+    "@libsql/hrana-client": ["@libsql/hrana-client@0.10.0", "", { "dependencies": { "@libsql/isomorphic-ws": "^0.1.5", "js-base64": "^3.7.5" } }, "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw=="],
+
+    "@libsql/isomorphic-ws": ["@libsql/isomorphic-ws@0.1.5", "", { "dependencies": { "@types/ws": "^8.5.4", "ws": "^8.13.0" } }, "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg=="],
+
+    "@libsql/linux-arm-gnueabihf": ["@libsql/linux-arm-gnueabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ=="],
+
+    "@libsql/linux-arm-musleabihf": ["@libsql/linux-arm-musleabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg=="],
+
+    "@libsql/linux-arm64-gnu": ["@libsql/linux-arm64-gnu@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w=="],
+
+    "@libsql/linux-arm64-musl": ["@libsql/linux-arm64-musl@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg=="],
+
+    "@libsql/linux-x64-gnu": ["@libsql/linux-x64-gnu@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg=="],
+
+    "@libsql/linux-x64-musl": ["@libsql/linux-x64-musl@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w=="],
+
+    "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.29", "", { "os": "win32", "cpu": "x64" }, "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg=="],
+
+    "@match-engine/cli": ["@match-engine/cli@workspace:packages/cli"],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
+
+    "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
 
@@ -83,6 +129,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -90,6 +138,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ=="],
 
@@ -107,11 +157,13 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+    "detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
@@ -124,6 +176,10 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+
+    "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -163,6 +219,8 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
+
     "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
@@ -183,6 +241,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
@@ -191,6 +251,10 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@biomejs/biome"
   ],
   "dependencies": {
-    "zod": "^4.3.6"
+    "@libsql/client": "^0.17.3",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@match-engine/cli",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "bin": {
+    "mound": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@libsql/client": "^0.17.3",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/cli/src/__tests__/adapters/cli/args.test.ts
+++ b/packages/cli/src/__tests__/adapters/cli/args.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  UsageError,
+  boolFlag,
+  optionalFlag,
+  parseArgs,
+  requireFlag,
+} from "../../../adapters/cli/args";
+
+describe("parseArgs", () => {
+  describe("--key value 形式のとき", () => {
+    it("値を取り込む", () => {
+      const r = parseArgs(["--name", "Mound"]);
+      expect(r.flags.name).toBe("Mound");
+      expect(r.positional).toEqual([]);
+    });
+  });
+
+  describe("--key=value 形式のとき", () => {
+    it("= 区切りで値を取る", () => {
+      const r = parseArgs(["--name=Mound"]);
+      expect(r.flags.name).toBe("Mound");
+    });
+
+    it("= の右に空文字を渡せる", () => {
+      const r = parseArgs(["--note="]);
+      expect(r.flags.note).toBe("");
+    });
+  });
+
+  describe("値を取らないブールフラグのとき", () => {
+    it("末尾にあれば true", () => {
+      const r = parseArgs(["--json"]);
+      expect(r.flags.json).toBe(true);
+    });
+
+    it("次が別フラグなら true (--key --next)", () => {
+      const r = parseArgs(["--json", "--verbose"]);
+      expect(r.flags.json).toBe(true);
+      expect(r.flags.verbose).toBe(true);
+    });
+  });
+
+  describe("positional 引数のとき", () => {
+    it("非フラグはすべて positional に積む", () => {
+      const r = parseArgs(["team", "create", "--name", "X"]);
+      expect(r.positional).toEqual(["team", "create"]);
+      expect(r.flags.name).toBe("X");
+    });
+  });
+
+  describe("requireFlag のとき", () => {
+    it("値があれば返す", () => {
+      const r = parseArgs(["--name", "Mound"]);
+      expect(requireFlag(r.flags, "name")).toBe("Mound");
+    });
+
+    it("欠落 / ブール / 空文字なら UsageError", () => {
+      const empty = parseArgs([]);
+      expect(() => requireFlag(empty.flags, "name")).toThrow(UsageError);
+
+      const bool = parseArgs(["--name"]);
+      expect(() => requireFlag(bool.flags, "name")).toThrow(UsageError);
+
+      const blank = parseArgs(["--name="]);
+      expect(() => requireFlag(blank.flags, "name")).toThrow(UsageError);
+    });
+  });
+
+  describe("optionalFlag / boolFlag のとき", () => {
+    it("文字列値だけを optionalFlag が返す", () => {
+      const r = parseArgs(["--name", "Mound", "--json"]);
+      expect(optionalFlag(r.flags, "name")).toBe("Mound");
+      expect(optionalFlag(r.flags, "json")).toBe(undefined);
+      expect(optionalFlag(r.flags, "missing")).toBe(undefined);
+    });
+
+    it('boolFlag は true / "true" 両方を真と扱う', () => {
+      const r = parseArgs(["--json"]);
+      expect(boolFlag(r.flags, "json")).toBe(true);
+      expect(boolFlag({ a: "true" }, "a")).toBe(true);
+      expect(boolFlag({ a: "false" }, "a")).toBe(false);
+      expect(boolFlag({}, "missing")).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/agenda.test.ts
+++ b/packages/cli/src/__tests__/agenda.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { run } from "../adapters/cli/cli";
+import { type DbClient, migrate, openDb } from "../adapters/libsql/client";
+
+interface Agenda {
+  needs_publish: Array<{ id: string; title: string }>;
+  collecting: Array<{
+    game: { id: string; title: string };
+    rsvp: { available: number };
+    ready_to_confirm: boolean;
+    shortage: number;
+  }>;
+  upcoming: Array<{ game: { id: string }; days_until: number }>;
+  needs_completion: Array<{ id: string }>;
+  needs_settlement: Array<{ id: string }>;
+}
+
+interface Harness {
+  db: DbClient;
+  outputs: string[];
+  exec(line: string): Promise<number>;
+  setNow(d: Date): void;
+  lastJson<T>(): T;
+}
+
+function buildHarness(): Harness {
+  const outputs: string[] = [];
+  const db = openDb({ url: ":memory:" });
+  let counter = 0;
+  const ids = () => {
+    counter += 1;
+    return `id-${counter.toString().padStart(4, "0")}`;
+  };
+  let frozenNow = new Date("2026-05-20T09:00:00.000Z");
+  const exec = (line: string) => {
+    const tokens = line.split(/\s+/).filter(Boolean);
+    tokens.push("--json");
+    return run({
+      argv: tokens,
+      env: {},
+      stdout: { write: (l) => outputs.push(l) },
+      stderr: { write: () => {} },
+      db,
+      now: () => frozenNow,
+      newId: ids,
+    });
+  };
+  return {
+    db,
+    outputs,
+    exec,
+    setNow(d: Date) {
+      frozenNow = d;
+    },
+    lastJson<T>(): T {
+      const last = outputs[outputs.length - 1];
+      if (!last) throw new Error("no output");
+      return JSON.parse(last) as T;
+    },
+  };
+}
+
+describe("mound agenda", () => {
+  let h: Harness;
+  let teamId: string;
+
+  beforeEach(async () => {
+    h = buildHarness();
+    await migrate(h.db);
+    await h.exec("team create --name Mound");
+    teamId = h.lastJson<{ id: string }>().id;
+    for (let i = 0; i < 12; i++) {
+      await h.exec(`member add --team ${teamId} --name メンバー${i}`);
+    }
+  });
+
+  describe("DRAFT のままの試合があるとき", () => {
+    it("needs_publish に並ぶ", async () => {
+      await h.exec(
+        `game create --team ${teamId} --title 公開忘れ --date 2026-06-15`,
+      );
+      await h.exec(`agenda --team ${teamId}`);
+      const agenda = h.lastJson<Agenda>();
+      expect(agenda.needs_publish.length).toBe(1);
+      expect(agenda.needs_publish[0]?.title).toBe("公開忘れ");
+    });
+  });
+
+  describe("COLLECTING で人数集まっているとき", () => {
+    it("ready_to_confirm=true で並ぶ", async () => {
+      await h.exec(
+        `game create --team ${teamId} --title 締切前 --date 2026-06-15 --min-players 9`,
+      );
+      const gameId = h.lastJson<{ id: string }>().id;
+      await h.exec(`game transition ${gameId} --to COLLECTING`);
+
+      await h.exec(`member list --team ${teamId}`);
+      const members = h.lastJson<Array<{ id: string }>>();
+      for (let i = 0; i < 9; i++) {
+        await h.exec(
+          `rsvp set --game ${gameId} --member ${members[i]?.id} --response AVAILABLE`,
+        );
+      }
+
+      await h.exec(`agenda --team ${teamId}`);
+      const agenda = h.lastJson<Agenda>();
+      expect(agenda.collecting.length).toBe(1);
+      expect(agenda.collecting[0]?.ready_to_confirm).toBe(true);
+      expect(agenda.collecting[0]?.shortage).toBe(0);
+    });
+
+    it("人数不足のとき shortage を返す", async () => {
+      await h.exec(
+        `game create --team ${teamId} --title 集まってない --min-players 9`,
+      );
+      const gameId = h.lastJson<{ id: string }>().id;
+      await h.exec(`game transition ${gameId} --to COLLECTING`);
+      await h.exec(`agenda --team ${teamId}`);
+      const agenda = h.lastJson<Agenda>();
+      expect(agenda.collecting[0]?.shortage).toBe(9);
+      expect(agenda.collecting[0]?.ready_to_confirm).toBe(false);
+    });
+  });
+
+  describe("CONFIRMED の試合があるとき", () => {
+    it("試合日が horizon 内なら upcoming に並ぶ", async () => {
+      h.setNow(new Date("2026-05-20T09:00:00.000Z"));
+      await h.exec(
+        `game create --team ${teamId} --title 今週開催 --date 2026-05-23 --min-players 1`,
+      );
+      const gameId = h.lastJson<{ id: string }>().id;
+      await h.exec(`game transition ${gameId} --to COLLECTING`);
+      await h.exec(`member list --team ${teamId}`);
+      const members = h.lastJson<Array<{ id: string }>>();
+      await h.exec(
+        `rsvp set --game ${gameId} --member ${members[0]?.id} --response AVAILABLE`,
+      );
+      await h.exec(`game transition ${gameId} --to CONFIRMED`);
+
+      await h.exec(`agenda --team ${teamId} --horizon-days 7`);
+      const agenda = h.lastJson<Agenda>();
+      expect(agenda.upcoming.length).toBe(1);
+      expect(agenda.upcoming[0]?.days_until).toBe(3);
+    });
+
+    it("試合日を過ぎていれば needs_completion に並ぶ", async () => {
+      h.setNow(new Date("2026-05-20T09:00:00.000Z"));
+      await h.exec(
+        `game create --team ${teamId} --title 完了忘れ --date 2026-05-19 --min-players 1`,
+      );
+      const gameId = h.lastJson<{ id: string }>().id;
+      await h.exec(`game transition ${gameId} --to COLLECTING`);
+      await h.exec(`member list --team ${teamId}`);
+      const members = h.lastJson<Array<{ id: string }>>();
+      await h.exec(
+        `rsvp set --game ${gameId} --member ${members[0]?.id} --response AVAILABLE`,
+      );
+      await h.exec(`game transition ${gameId} --to CONFIRMED`);
+
+      await h.exec(`agenda --team ${teamId}`);
+      const agenda = h.lastJson<Agenda>();
+      expect(agenda.needs_completion.length).toBe(1);
+      expect(agenda.upcoming.length).toBe(0);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/domain-guards.test.ts
+++ b/packages/cli/src/__tests__/domain-guards.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  DomainInvariantError,
+  assertGameStatus,
+  assertMemberRole,
+  assertRsvpResponse,
+  isGameStatus,
+  isMemberRole,
+  isRsvpResponse,
+} from "../domain/guards";
+
+describe("type guards", () => {
+  describe("isGameStatus のとき", () => {
+    it("既知の状態値で true", () => {
+      expect(isGameStatus("DRAFT")).toBe(true);
+      expect(isGameStatus("CONFIRMED")).toBe(true);
+    });
+
+    it("未知の値で false", () => {
+      expect(isGameStatus("UNKNOWN")).toBe(false);
+      expect(isGameStatus(undefined)).toBe(false);
+      expect(isGameStatus(null)).toBe(false);
+      expect(isGameStatus(42)).toBe(false);
+    });
+  });
+
+  describe("assertGameStatus のとき", () => {
+    it("既知値はそのまま返す", () => {
+      expect(assertGameStatus("DRAFT")).toBe("DRAFT");
+    });
+
+    it("不正値で DomainInvariantError", () => {
+      expect(() => assertGameStatus("OOPS")).toThrow(DomainInvariantError);
+    });
+  });
+
+  describe("isRsvpResponse のとき", () => {
+    it("AVAILABLE/UNAVAILABLE/MAYBE/NO_RESPONSE で true、それ以外で false", () => {
+      expect(isRsvpResponse("AVAILABLE")).toBe(true);
+      expect(isRsvpResponse("MAYBE")).toBe(true);
+      expect(isRsvpResponse("MAYBE_LATER")).toBe(false);
+    });
+  });
+
+  describe("assertRsvpResponse のとき", () => {
+    it("不正値で DomainInvariantError", () => {
+      expect(() => assertRsvpResponse("idk")).toThrow(DomainInvariantError);
+    });
+  });
+
+  describe("isMemberRole のとき", () => {
+    it("ADMIN/MEMBER で true", () => {
+      expect(isMemberRole("ADMIN")).toBe(true);
+      expect(isMemberRole("MEMBER")).toBe(true);
+      expect(isMemberRole("ROOT")).toBe(false);
+    });
+  });
+
+  describe("assertMemberRole のとき", () => {
+    it("不正値で DomainInvariantError", () => {
+      expect(() => assertMemberRole("ROOT")).toThrow(DomainInvariantError);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -1,0 +1,288 @@
+// 実バイナリを spawn して Phase 1 ループを最初から最後まで走らせる e2e シナリオテスト。
+// bin/mound が無いときは `make cli-build` で生成する。
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(__dirname, "../../../..");
+const binary = resolve(repoRoot, "bin/mound");
+
+function ensureBinary(): void {
+  if (existsSync(binary)) return;
+  // ローカルで一度ビルドしておく
+  execFileSync("make", ["cli-build"], { cwd: repoRoot, stdio: "inherit" });
+  if (!existsSync(binary)) {
+    throw new Error(`bin/mound build failed: ${binary} not found`);
+  }
+}
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runMound(
+  args: string[],
+  env: Record<string, string>,
+  opts: { timeout?: number } = {},
+): RunResult {
+  const r = spawnSync(binary, args, {
+    env: { ...process.env, ...env },
+    encoding: "utf-8",
+    timeout: opts.timeout ?? 15000,
+  });
+  return {
+    code: r.status ?? -1,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+  };
+}
+
+function parseJson<T>(out: string): T {
+  const trimmed = out.trim();
+  if (!trimmed) throw new Error("empty stdout");
+  return JSON.parse(trimmed) as T;
+}
+
+describe("e2e: bin/mound を実際に spawn する Phase 1 シナリオ", () => {
+  let dbDir: string;
+  let env: Record<string, string>;
+
+  beforeAll(() => {
+    ensureBinary();
+    dbDir = mkdtempSync(join(tmpdir(), "mound-e2e-"));
+    env = { MOUND_DB_URL: `file:${join(dbDir, "deep", "mound.db")}` };
+  });
+
+  describe("セットアップのとき", () => {
+    it("--version で 0 終了する", () => {
+      const r = runMound(["--version", "--json"], env);
+      expect(r.code).toBe(0);
+      expect(parseJson<{ version: string }>(r.stdout).version).toMatch(
+        /^\d+\.\d+\.\d+$/,
+      );
+    });
+
+    it("init で DB が作られる (親 dir が存在しなくても通る)", () => {
+      const r = runMound(["init", "--json"], env);
+      expect(r.stderr).toBe("");
+      expect(r.code).toBe(0);
+      const file = env.MOUND_DB_URL.slice("file:".length);
+      expect(existsSync(file)).toBe(true);
+      expect(existsSync(dirname(file))).toBe(true);
+    });
+  });
+
+  describe("試合希望 → 出欠 → 確定 の Phase 1 ループのとき", () => {
+    it("CONFIRMED まで実バイナリで完走する", () => {
+      // チーム作成
+      const teamR = runMound(
+        ["team", "create", "--name", "横浜BB", "--area", "横浜", "--json"],
+        env,
+      );
+      expect(teamR.code).toBe(0);
+      const team = parseJson<{ id: string; name: string }>(teamR.stdout);
+      expect(team.name).toBe("横浜BB");
+
+      // メンバー 10 人追加
+      const memberIds: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        const r = runMound(
+          [
+            "member",
+            "add",
+            "--team",
+            team.id,
+            "--name",
+            `メンバー${i}`,
+            "--json",
+          ],
+          env,
+        );
+        expect(r.code).toBe(0);
+        memberIds.push(parseJson<{ id: string }>(r.stdout).id);
+      }
+      const listR = runMound(
+        ["member", "list", "--team", team.id, "--json"],
+        env,
+      );
+      expect(parseJson<unknown[]>(listR.stdout)).toHaveLength(10);
+
+      // 試合を DRAFT で作成
+      const gameR = runMound(
+        [
+          "game",
+          "create",
+          "--team",
+          team.id,
+          "--title",
+          "練習試合",
+          "--date",
+          "2026-06-01",
+          "--ground",
+          "公園グラウンド",
+          "--min-players",
+          "9",
+          "--json",
+        ],
+        env,
+      );
+      expect(gameR.code).toBe(0);
+      const game = parseJson<{ id: string; status: string }>(gameR.stdout);
+      expect(game.status).toBe("DRAFT");
+
+      // COLLECTING に遷移
+      const t1 = runMound(
+        ["game", "transition", game.id, "--to", "COLLECTING", "--json"],
+        env,
+      );
+      expect(t1.code).toBe(0);
+      expect(parseJson<{ status: string }>(t1.stdout).status).toBe(
+        "COLLECTING",
+      );
+
+      // 9 人が AVAILABLE で回答
+      for (let i = 0; i < 9; i++) {
+        const r = runMound(
+          [
+            "rsvp",
+            "set",
+            "--game",
+            game.id,
+            "--member",
+            memberIds[i] as string,
+            "--response",
+            "AVAILABLE",
+            "--json",
+          ],
+          env,
+        );
+        expect(r.code).toBe(0);
+      }
+      // 残り 1 人は不参加
+      const lastR = runMound(
+        [
+          "rsvp",
+          "set",
+          "--game",
+          game.id,
+          "--member",
+          memberIds[9] as string,
+          "--response",
+          "UNAVAILABLE",
+          "--json",
+        ],
+        env,
+      );
+      expect(lastR.code).toBe(0);
+
+      // summary 確認
+      const sR = runMound(
+        ["rsvp", "summary", "--game", game.id, "--json"],
+        env,
+      );
+      const summary = parseJson<{
+        available: number;
+        unavailable: number;
+        no_response: number;
+      }>(sR.stdout);
+      expect(summary.available).toBe(9);
+      expect(summary.unavailable).toBe(1);
+      expect(summary.no_response).toBe(0);
+
+      // CONFIRMED に遷移できる
+      const t2 = runMound(
+        ["game", "transition", game.id, "--to", "CONFIRMED", "--json"],
+        env,
+      );
+      expect(t2.code).toBe(0);
+      expect(parseJson<{ status: string }>(t2.stdout).status).toBe("CONFIRMED");
+
+      // agenda が upcoming にこの試合を含む
+      const aR = runMound(
+        ["agenda", "--team", team.id, "--horizon-days", "60", "--json"],
+        env,
+      );
+      expect(aR.code).toBe(0);
+      const agenda = parseJson<{
+        upcoming: Array<{ game: { id: string } }>;
+      }>(aR.stdout);
+      expect(agenda.upcoming.some((u) => u.game.id === game.id)).toBe(true);
+
+      // audit ログに全イベントが残っている
+      const auditR = runMound(["audit", "--target", game.id, "--json"], env);
+      expect(auditR.code).toBe(0);
+      const actions = parseJson<Array<{ action: string }>>(auditR.stdout).map(
+        (l) => l.action,
+      );
+      expect(actions).toContain("GAME_CREATED");
+      expect(actions).toContain("GAME_TRANSITION:DRAFT->COLLECTING");
+      expect(actions).toContain("GAME_TRANSITION:COLLECTING->CONFIRMED");
+    });
+  });
+
+  describe("不正な操作のとき", () => {
+    it("人数不足で CONFIRMED に直接遷移しようとすると exit 2 + 日本語エラー", () => {
+      // 別チームを建てる
+      const tR = runMound(
+        ["team", "create", "--name", "別チーム", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+
+      const gR = runMound(
+        [
+          "game",
+          "create",
+          "--team",
+          team.id,
+          "--title",
+          "人数不足の試合",
+          "--min-players",
+          "9",
+          "--json",
+        ],
+        env,
+      );
+      const game = parseJson<{ id: string }>(gR.stdout);
+
+      // メンバーは 0 人。COLLECTING に進めてから CONFIRMED を試みる
+      runMound(
+        ["game", "transition", game.id, "--to", "COLLECTING", "--json"],
+        env,
+      );
+      const r = runMound(
+        ["game", "transition", game.id, "--to", "CONFIRMED", "--json"],
+        env,
+      );
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("最低人数");
+    });
+
+    it("不正な状態への遷移は拒否する", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "テストC", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+      const gR = runMound(
+        ["game", "create", "--team", team.id, "--title", "テスト", "--json"],
+        env,
+      );
+      const game = parseJson<{ id: string }>(gR.stdout);
+      const r = runMound(
+        ["game", "transition", game.id, "--to", "SETTLED", "--json"],
+        env,
+      );
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("状態遷移が不正です");
+    });
+  });
+
+  afterAll(() => {
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/src/__tests__/state-machine.test.ts
+++ b/packages/cli/src/__tests__/state-machine.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  canTransition,
+  checkGuard,
+  getAvailableTransitions,
+} from "../domain/state-machine";
+import type { RsvpSummary } from "../domain/types";
+
+function createRsvpSummary(overrides?: Partial<RsvpSummary>): RsvpSummary {
+  return {
+    available: 0,
+    unavailable: 0,
+    maybe: 0,
+    no_response: 0,
+    ...overrides,
+  };
+}
+
+describe("canTransition", () => {
+  describe("DRAFT からのとき", () => {
+    it("COLLECTING / CONFIRMED / CANCELLED を許可する", () => {
+      expect(canTransition("DRAFT", "COLLECTING")).toBe(true);
+      expect(canTransition("DRAFT", "CONFIRMED")).toBe(true);
+      expect(canTransition("DRAFT", "CANCELLED")).toBe(true);
+    });
+
+    it("COMPLETED や SETTLED への直接遷移は拒否する", () => {
+      expect(canTransition("DRAFT", "COMPLETED")).toBe(false);
+      expect(canTransition("DRAFT", "SETTLED")).toBe(false);
+    });
+  });
+
+  describe("終端状態のとき", () => {
+    it("CANCELLED からはどこにも遷移できない", () => {
+      expect(getAvailableTransitions("CANCELLED")).toEqual([]);
+    });
+
+    it("SETTLED からはどこにも遷移できない", () => {
+      expect(getAvailableTransitions("SETTLED")).toEqual([]);
+    });
+  });
+});
+
+describe("checkGuard", () => {
+  describe("COLLECTING → CONFIRMED のとき", () => {
+    it("参加可が最低人数以上なら許可する", () => {
+      const result = checkGuard("COLLECTING", "CONFIRMED", {
+        rsvp: createRsvpSummary({ available: 9 }),
+        minPlayers: 9,
+        gameDate: "2026-06-01",
+        now: new Date("2026-05-20"),
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("参加可が最低人数に満たないとき拒否する", () => {
+      const result = checkGuard("COLLECTING", "CONFIRMED", {
+        rsvp: createRsvpSummary({ available: 5 }),
+        minPlayers: 9,
+        gameDate: "2026-06-01",
+        now: new Date("2026-05-20"),
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("最低人数");
+    });
+  });
+
+  describe("CONFIRMED → COMPLETED のとき", () => {
+    it("試合日が過ぎていれば許可する", () => {
+      const result = checkGuard("CONFIRMED", "COMPLETED", {
+        rsvp: createRsvpSummary({ available: 9 }),
+        minPlayers: 9,
+        gameDate: "2026-05-19",
+        now: new Date("2026-05-20T10:00:00Z"),
+      });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("試合日が未到来なら拒否する", () => {
+      const result = checkGuard("CONFIRMED", "COMPLETED", {
+        rsvp: createRsvpSummary({ available: 9 }),
+        minPlayers: 9,
+        gameDate: "2026-06-01",
+        now: new Date("2026-05-20"),
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("試合日");
+    });
+  });
+
+  describe("不正な遷移のとき", () => {
+    it("理由を返して拒否する", () => {
+      const result = checkGuard("DRAFT", "SETTLED", {
+        rsvp: createRsvpSummary(),
+        minPlayers: 9,
+        gameDate: null,
+        now: new Date(),
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("DRAFT → SETTLED");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/storage.test.ts
+++ b/packages/cli/src/__tests__/storage.test.ts
@@ -1,0 +1,164 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { type DbClient, migrate, openDb } from "../adapters/libsql/client";
+import { buildRepositories } from "../adapters/libsql/repositories";
+import type { Game, Member, Rsvp, Team } from "../domain/types";
+import type { Repositories } from "../ports";
+
+function createTeam(overrides: Partial<Team> = {}): Team {
+  return {
+    id: "team-1",
+    name: "Mound BB",
+    home_area: "横浜",
+    created_at: "2026-05-20T00:00:00.000Z",
+    updated_at: "2026-05-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createMember(overrides: Partial<Member> = {}): Member {
+  return {
+    id: "member-1",
+    team_id: "team-1",
+    name: "山田",
+    email: null,
+    role: "MEMBER",
+    created_at: "2026-05-20T00:00:00.000Z",
+    updated_at: "2026-05-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "game-1",
+    team_id: "team-1",
+    title: "練習試合",
+    status: "DRAFT",
+    game_date: "2026-06-01",
+    ground_name: null,
+    min_players: 9,
+    note: null,
+    created_at: "2026-05-20T00:00:00.000Z",
+    updated_at: "2026-05-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function createRsvp(overrides: Partial<Rsvp> = {}): Rsvp {
+  return {
+    id: "rsvp-1",
+    game_id: "game-1",
+    member_id: "member-1",
+    response: "AVAILABLE",
+    responded_at: "2026-05-20T00:00:00.000Z",
+    created_at: "2026-05-20T00:00:00.000Z",
+    updated_at: "2026-05-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("openDb", () => {
+  describe("存在しないネスト dir の file: URL を渡したとき", () => {
+    it("親ディレクトリを作成して接続できる", async () => {
+      const root = mkdtempSync(join(tmpdir(), "mound-openDb-"));
+      try {
+        const nested = join(root, "deep", "nested", "mound.db");
+        const db = openDb({ url: `file:${nested}` });
+        await migrate(db);
+        const repo = buildRepositories(db);
+        await repo.teams.insert(createTeam());
+        const t = await repo.teams.get("team-1");
+        expect(t?.name).toBe("Mound BB");
+        expect(existsSync(nested)).toBe(true);
+        db.close();
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+describe("Repositories", () => {
+  let db: DbClient;
+  let repo: Repositories;
+
+  beforeEach(async () => {
+    db = openDb({ url: ":memory:" });
+    await migrate(db);
+    repo = buildRepositories(db);
+  });
+
+  describe("Team を作って取得するとき", () => {
+    it("挿入した内容で取得できる", async () => {
+      const team = createTeam();
+      await repo.teams.insert(team);
+      const fetched = await repo.teams.get("team-1");
+      expect(fetched).toEqual(team);
+    });
+  });
+
+  describe("RSVP を upsert するとき", () => {
+    beforeEach(async () => {
+      await repo.teams.insert(createTeam());
+      await repo.members.insert(createMember());
+      await repo.games.insert(createGame());
+    });
+
+    it("同じ (game, member) なら更新される", async () => {
+      await repo.rsvps.upsert(createRsvp({ response: "MAYBE" }));
+      await repo.rsvps.upsert(
+        createRsvp({
+          id: "rsvp-2",
+          response: "AVAILABLE",
+          responded_at: "2026-05-21T00:00:00.000Z",
+          updated_at: "2026-05-21T00:00:00.000Z",
+        }),
+      );
+      const rsvps = await repo.rsvps.list("game-1");
+      expect(rsvps.length).toBe(1);
+      expect(rsvps[0]?.response).toBe("AVAILABLE");
+    });
+  });
+
+  describe("RSVP サマリを集計するとき", () => {
+    beforeEach(async () => {
+      await repo.teams.insert(createTeam());
+      await repo.games.insert(createGame());
+      for (let i = 0; i < 12; i++) {
+        await repo.members.insert(
+          createMember({ id: `member-${i}`, name: `メンバー${i}` }),
+        );
+      }
+    });
+
+    it("回答済み・未回答を正しく数える", async () => {
+      await repo.rsvps.upsert(
+        createRsvp({ id: "r1", member_id: "member-0", response: "AVAILABLE" }),
+      );
+      await repo.rsvps.upsert(
+        createRsvp({ id: "r2", member_id: "member-1", response: "AVAILABLE" }),
+      );
+      await repo.rsvps.upsert(
+        createRsvp({
+          id: "r3",
+          member_id: "member-2",
+          response: "UNAVAILABLE",
+        }),
+      );
+      await repo.rsvps.upsert(
+        createRsvp({ id: "r4", member_id: "member-3", response: "MAYBE" }),
+      );
+
+      const summary = await repo.rsvps.summarize("game-1", "team-1");
+      expect(summary).toEqual({
+        available: 2,
+        unavailable: 1,
+        maybe: 1,
+        no_response: 8,
+      });
+    });
+  });
+});

--- a/packages/cli/src/__tests__/use-case.test.ts
+++ b/packages/cli/src/__tests__/use-case.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { run } from "../adapters/cli/cli";
+import { type DbClient, migrate, openDb } from "../adapters/libsql/client";
+
+interface Capture {
+  out: string[];
+  err: string[];
+}
+
+function createCapture(): Capture {
+  return { out: [], err: [] };
+}
+
+interface Harness {
+  capture: Capture;
+  db: DbClient;
+  nextId: () => string;
+  exec(line: string, opts?: { json?: boolean }): Promise<number>;
+  lastJson<T>(): T;
+  outText(): string;
+  errText(): string;
+}
+
+function buildHarness(): Harness {
+  const capture = createCapture();
+  const db = openDb({ url: ":memory:" });
+  let counter = 0;
+  const ids = () => {
+    counter += 1;
+    return `id-${counter.toString().padStart(4, "0")}`;
+  };
+  const frozenNow = new Date("2026-05-20T09:00:00.000Z");
+  const exec = async (line: string, opts: { json?: boolean } = {}) => {
+    const tokens = line.split(/\s+/).filter(Boolean);
+    if (opts.json !== false) tokens.push("--json");
+    const code = await run({
+      argv: tokens,
+      env: {},
+      stdout: { write: (l) => capture.out.push(l) },
+      stderr: { write: (l) => capture.err.push(l) },
+      db,
+      now: () => frozenNow,
+      newId: ids,
+    });
+    return code;
+  };
+  return {
+    capture,
+    db,
+    nextId: ids,
+    exec,
+    lastJson<T>() {
+      const last = capture.out[capture.out.length - 1];
+      if (!last) throw new Error("no output");
+      return JSON.parse(last) as T;
+    },
+    outText() {
+      return capture.out.join("\n");
+    },
+    errText() {
+      return capture.err.join("\n");
+    },
+  };
+}
+
+describe("Phase 1 ユースケース (CLI)", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = buildHarness();
+    await migrate(h.db);
+  });
+
+  describe("試合希望 → 出欠 → 確定 の一連の流れのとき", () => {
+    it("DRAFT → COLLECTING → CONFIRMED まで CLI で完走できる", async () => {
+      expect(await h.exec("team create --name Mound --area 横浜")).toBe(0);
+      const team = h.lastJson<{ id: string }>();
+
+      for (let i = 0; i < 10; i++) {
+        expect(
+          await h.exec(`member add --team ${team.id} --name メンバー${i}`),
+        ).toBe(0);
+      }
+      const membersResult = await h.exec(`member list --team ${team.id}`);
+      expect(membersResult).toBe(0);
+      const members = h.lastJson<Array<{ id: string }>>();
+      expect(members.length).toBe(10);
+
+      expect(
+        await h.exec(
+          `game create --team ${team.id} --title 練習試合 --date 2026-06-01 --min-players 9`,
+        ),
+      ).toBe(0);
+      const game = h.lastJson<{ id: string; status: string }>();
+      expect(game.status).toBe("DRAFT");
+
+      expect(await h.exec(`game transition ${game.id} --to COLLECTING`)).toBe(
+        0,
+      );
+
+      for (let i = 0; i < 9; i++) {
+        expect(
+          await h.exec(
+            `rsvp set --game ${game.id} --member ${members[i]?.id} --response AVAILABLE`,
+          ),
+        ).toBe(0);
+      }
+
+      const summaryExit = await h.exec(`rsvp summary --game ${game.id}`);
+      expect(summaryExit).toBe(0);
+      expect(h.lastJson<{ available: number }>().available).toBe(9);
+
+      expect(await h.exec(`game transition ${game.id} --to CONFIRMED`)).toBe(0);
+      expect(h.lastJson<{ status: string }>().status).toBe("CONFIRMED");
+    });
+
+    it("最低人数に満たないとき CONFIRMED への遷移を拒否する", async () => {
+      expect(await h.exec("team create --name Mound")).toBe(0);
+      const team = h.lastJson<{ id: string }>();
+      for (let i = 0; i < 9; i++) {
+        await h.exec(`member add --team ${team.id} --name メンバー${i}`);
+      }
+      const membersExit = await h.exec(`member list --team ${team.id}`);
+      expect(membersExit).toBe(0);
+      const members = h.lastJson<Array<{ id: string }>>();
+
+      await h.exec(
+        `game create --team ${team.id} --title 練習試合 --min-players 9`,
+      );
+      const game = h.lastJson<{ id: string }>();
+
+      await h.exec(`game transition ${game.id} --to COLLECTING`);
+      for (let i = 0; i < 5; i++) {
+        await h.exec(
+          `rsvp set --game ${game.id} --member ${members[i]?.id} --response AVAILABLE`,
+        );
+      }
+      const code = await h.exec(`game transition ${game.id} --to CONFIRMED`);
+      expect(code).toBe(2);
+      expect(h.errText()).toContain("最低人数");
+    });
+  });
+
+  describe("監査ログのとき", () => {
+    it("チーム作成・メンバー追加・試合作成・遷移が記録される", async () => {
+      await h.exec("team create --name Mound");
+      const team = h.lastJson<{ id: string }>();
+      await h.exec(
+        `game create --team ${team.id} --title 練習試合 --min-players 9`,
+      );
+      const game = h.lastJson<{ id: string }>();
+      await h.exec(`game transition ${game.id} --to CANCELLED`);
+
+      const exit = await h.exec(`audit --target ${game.id}`);
+      expect(exit).toBe(0);
+      const logs = h.lastJson<Array<{ action: string }>>();
+      const actions = logs.map((l) => l.action);
+      expect(actions).toContain("GAME_CREATED");
+      expect(actions).toContain("GAME_TRANSITION:DRAFT->CANCELLED");
+    });
+  });
+
+  describe("RSVP upsert のとき", () => {
+    it("同じメンバーの再回答は上書きされる", async () => {
+      await h.exec("team create --name Mound");
+      const team = h.lastJson<{ id: string }>();
+      await h.exec(`member add --team ${team.id} --name 山田`);
+      const member = h.lastJson<{ id: string }>();
+      await h.exec(`game create --team ${team.id} --title 練習試合`);
+      const game = h.lastJson<{ id: string }>();
+
+      await h.exec(
+        `rsvp set --game ${game.id} --member ${member.id} --response MAYBE`,
+      );
+      await h.exec(
+        `rsvp set --game ${game.id} --member ${member.id} --response AVAILABLE`,
+      );
+
+      await h.exec(`rsvp list --game ${game.id}`);
+      const list = h.lastJson<Array<{ response: string }>>();
+      expect(list.length).toBe(1);
+      expect(list[0]?.response).toBe("AVAILABLE");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -1,0 +1,241 @@
+// Clean Architecture の境界を確かめるテスト: usecase は DB に触れず、in-memory な
+// ポート実装に対して同じ振る舞いをする。
+import { describe, expect, it } from "vitest";
+import type {
+  AuditLog,
+  Game,
+  Member,
+  MemberRsvp,
+  Rsvp,
+  RsvpBreakdown,
+  RsvpSummary,
+  Team,
+} from "../../domain/types";
+import type {
+  AuditRepository,
+  GameRepository,
+  MemberRepository,
+  Repositories,
+  RsvpRepository,
+  TeamRepository,
+  UseCaseContext,
+} from "../../ports";
+
+import { createGame, transitionGame } from "../../usecases/game";
+
+interface Fake {
+  teamStore: Map<string, Team>;
+  memberStore: Map<string, Member>;
+  gameStore: Map<string, Game>;
+  rsvpStore: Map<string, Rsvp>;
+  auditStore: AuditLog[];
+  repo: Repositories;
+}
+
+function buildFake(): Fake {
+  const teamStore = new Map<string, Team>();
+  const memberStore = new Map<string, Member>();
+  const gameStore = new Map<string, Game>();
+  const rsvpStore = new Map<string, Rsvp>();
+  const auditStore: AuditLog[] = [];
+
+  const teams: TeamRepository = {
+    insert: async (t) => {
+      teamStore.set(t.id, t);
+      return t;
+    },
+    list: async () => Array.from(teamStore.values()),
+    get: async (id) => teamStore.get(id) ?? null,
+  };
+
+  const members: MemberRepository = {
+    insert: async (m) => {
+      memberStore.set(m.id, m);
+      return m;
+    },
+    list: async (teamId) =>
+      Array.from(memberStore.values()).filter((m) => m.team_id === teamId),
+    get: async (id) => memberStore.get(id) ?? null,
+  };
+
+  const games: GameRepository = {
+    insert: async (g) => {
+      gameStore.set(g.id, g);
+      return g;
+    },
+    list: async (filter) =>
+      Array.from(gameStore.values()).filter(
+        (g) =>
+          (!filter.teamId || g.team_id === filter.teamId) &&
+          (!filter.status || g.status === filter.status),
+      ),
+    get: async (id) => gameStore.get(id) ?? null,
+    updateStatus: async (id, status, updatedAt) => {
+      const g = gameStore.get(id);
+      if (g) gameStore.set(id, { ...g, status, updated_at: updatedAt });
+    },
+  };
+
+  const listWithMembers = async (
+    gameId: string,
+    teamId: string,
+  ): Promise<MemberRsvp[]> => {
+    const teamMembers = Array.from(memberStore.values()).filter(
+      (m) => m.team_id === teamId,
+    );
+    return teamMembers.map((m) => {
+      const r = rsvpStore.get(`${gameId}:${m.id}`);
+      return {
+        member_id: m.id,
+        member_name: m.name,
+        member_role: m.role,
+        response: r?.response ?? "NO_RESPONSE",
+        responded_at: r?.responded_at ?? null,
+      };
+    });
+  };
+
+  const breakdown = async (
+    gameId: string,
+    teamId: string,
+  ): Promise<RsvpBreakdown> => {
+    const rows = await listWithMembers(gameId, teamId);
+    const out: RsvpBreakdown = {
+      available: [],
+      unavailable: [],
+      maybe: [],
+      no_response: [],
+    };
+    for (const r of rows) {
+      if (r.response === "AVAILABLE") out.available.push(r);
+      else if (r.response === "UNAVAILABLE") out.unavailable.push(r);
+      else if (r.response === "MAYBE") out.maybe.push(r);
+      else out.no_response.push(r);
+    }
+    return out;
+  };
+
+  const rsvps: RsvpRepository = {
+    upsert: async (r) => {
+      rsvpStore.set(`${r.game_id}:${r.member_id}`, r);
+      return r;
+    },
+    list: async (gameId) =>
+      Array.from(rsvpStore.values()).filter((r) => r.game_id === gameId),
+    listWithMembers,
+    breakdown,
+    summarize: async (gameId, teamId): Promise<RsvpSummary> => {
+      const b = await breakdown(gameId, teamId);
+      return {
+        available: b.available.length,
+        unavailable: b.unavailable.length,
+        maybe: b.maybe.length,
+        no_response: b.no_response.length,
+      };
+    },
+  };
+
+  const audit: AuditRepository = {
+    insert: async (l) => {
+      auditStore.push(l);
+      return l;
+    },
+    list: async (targetType, targetId) =>
+      auditStore.filter(
+        (l) => l.target_type === targetType && l.target_id === targetId,
+      ),
+  };
+
+  return {
+    teamStore,
+    memberStore,
+    gameStore,
+    rsvpStore,
+    auditStore,
+    repo: { teams, members, games, rsvps, audit },
+  };
+}
+
+function createCtx(): { ctx: UseCaseContext; fake: Fake } {
+  const fake = buildFake();
+  let counter = 0;
+  const ctx: UseCaseContext = {
+    repo: fake.repo,
+    now: () => new Date("2026-05-20T09:00:00.000Z"),
+    newId: () => `id-${++counter}`,
+  };
+  return { ctx, fake };
+}
+
+describe("createGame use case", () => {
+  describe("チームが存在しないとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const { ctx } = createCtx();
+      await expect(
+        createGame(ctx, {
+          teamId: "nonexistent",
+          title: "練習試合",
+          date: null,
+          ground: null,
+          minPlayers: 9,
+          note: null,
+        }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+
+  describe("チームが存在するとき", () => {
+    it("DRAFT で保存して監査ログを残す", async () => {
+      const { ctx, fake } = createCtx();
+      await fake.repo.teams.insert({
+        id: "team-1",
+        name: "Mound",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const game = await createGame(ctx, {
+        teamId: "team-1",
+        title: "練習試合",
+        date: null,
+        ground: null,
+        minPlayers: 9,
+        note: null,
+      });
+      expect(game.status).toBe("DRAFT");
+      expect(
+        fake.auditStore.find((l) => l.action === "GAME_CREATED"),
+      ).toBeTruthy();
+    });
+  });
+});
+
+describe("transitionGame use case", () => {
+  describe("人数不足のとき", () => {
+    it("CONFIRMED への遷移を拒否する", async () => {
+      const { ctx, fake } = createCtx();
+      await fake.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await fake.repo.games.insert({
+        id: "g",
+        team_id: "t",
+        title: "x",
+        status: "COLLECTING",
+        game_date: null,
+        ground_name: null,
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await expect(transitionGame(ctx, "g", "CONFIRMED")).rejects.toThrow(
+        /最低人数/,
+      );
+    });
+  });
+});

--- a/packages/cli/src/adapters/cli/args.ts
+++ b/packages/cli/src/adapters/cli/args.ts
@@ -1,0 +1,65 @@
+export interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === undefined) continue;
+    if (token.startsWith("--")) {
+      const eq = token.indexOf("=");
+      if (eq > 0) {
+        flags[token.slice(2, eq)] = token.slice(eq + 1);
+      } else {
+        const key = token.slice(2);
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith("--")) {
+          flags[key] = next;
+          i++;
+        } else {
+          flags[key] = true;
+        }
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { positional, flags };
+}
+
+export function requireFlag(
+  flags: Record<string, string | boolean>,
+  name: string,
+): string {
+  const v = flags[name];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new UsageError(`--${name} は必須です`);
+  }
+  return v;
+}
+
+export function optionalFlag(
+  flags: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const v = flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+export function boolFlag(
+  flags: Record<string, string | boolean>,
+  name: string,
+): boolean {
+  const v = flags[name];
+  return v === true || v === "true";
+}
+
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -1,0 +1,122 @@
+import {
+  type DbClient,
+  buildDbConfig,
+  ensureSchemaUpToDate,
+  openDb,
+} from "../libsql/client";
+import { type ParsedArgs, UsageError, boolFlag, parseArgs } from "./args";
+
+const USER_ERROR_NAMES = new Set([
+  "UsageError",
+  "TransitionDeniedError",
+  "NotFoundError",
+  "TeamNotFoundError",
+  "GameNotFoundError",
+  "MemberNotFoundError",
+  "CrossTeamRsvpError",
+]);
+
+function isUserError(e: unknown): boolean {
+  if (e instanceof UsageError) return true;
+  if (e instanceof Error && USER_ERROR_NAMES.has(e.name)) return true;
+  return false;
+}
+import { runAgenda } from "./commands/agenda";
+import { runAudit } from "./commands/audit";
+import { runGame } from "./commands/game";
+import { runInit } from "./commands/init";
+import { runMember } from "./commands/member";
+import { runRsvp } from "./commands/rsvp";
+import { runTeam } from "./commands/team";
+import { composeContext } from "./compose";
+import { HELP, VERSION } from "./help";
+import {
+  type OutputSink,
+  emit,
+  emitError,
+  stderrSink,
+  stdoutSink,
+} from "./output";
+
+export interface RunOptions {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  stdout?: OutputSink;
+  stderr?: OutputSink;
+  db?: DbClient;
+  now?: () => Date;
+  newId?: () => string;
+}
+
+export async function run(options: RunOptions): Promise<number> {
+  const stdout = options.stdout ?? stdoutSink;
+  const stderr = options.stderr ?? stderrSink;
+  const parsed = parseArgs(options.argv);
+  const json = boolFlag(parsed.flags, "json");
+  const renderOpts = { json, sink: stdout };
+
+  if (boolFlag(parsed.flags, "version")) {
+    emit({ version: VERSION }, `mound ${VERSION}`, renderOpts);
+    return 0;
+  }
+  if (boolFlag(parsed.flags, "help") || parsed.positional.length === 0) {
+    stdout.write(HELP);
+    return 0;
+  }
+
+  const [command, ...rest] = parsed.positional;
+  const subArgs: ParsedArgs = { positional: rest, flags: parsed.flags };
+  const ownsDb = !options.db;
+  let db: DbClient | null = null;
+
+  try {
+    db = options.db ?? openDb(buildDbConfig(options.env));
+    if (command !== "init") {
+      await ensureSchemaUpToDate(db);
+    }
+    const ctx = composeContext({
+      db,
+      now: options.now ?? (() => new Date()),
+      newId: options.newId ?? (() => crypto.randomUUID()),
+    });
+
+    switch (command) {
+      case "init":
+        await runInit(db, renderOpts);
+        return 0;
+      case "team":
+        await runTeam(subArgs, ctx, renderOpts);
+        return 0;
+      case "member":
+        await runMember(subArgs, ctx, renderOpts);
+        return 0;
+      case "game":
+        await runGame(subArgs, ctx, renderOpts);
+        return 0;
+      case "rsvp":
+        await runRsvp(subArgs, ctx, renderOpts);
+        return 0;
+      case "audit":
+        await runAudit(subArgs, ctx, renderOpts);
+        return 0;
+      case "agenda":
+        await runAgenda(subArgs, ctx, renderOpts);
+        return 0;
+      default:
+        emitError(`未知のコマンド: ${command}`, { json, sink: stderr });
+        return 2;
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    emitError(message, { json, sink: stderr });
+    return isUserError(e) ? 2 : 1;
+  } finally {
+    if (ownsDb && db) {
+      try {
+        db.close();
+      } catch {
+        // libSQL clients may already be closed
+      }
+    }
+  }
+}

--- a/packages/cli/src/adapters/cli/commands/agenda.ts
+++ b/packages/cli/src/adapters/cli/commands/agenda.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import type { UseCaseContext } from "../../../ports";
+import { type Agenda, computeAgenda } from "../../../usecases/agenda";
+import { type ParsedArgs, optionalFlag } from "../args";
+import { type RenderOptions, emit } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const horizonInput = z.coerce.number().int().min(0).max(365).default(7);
+
+export async function runAgenda(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const horizonDays = parseOrUsage(
+    horizonInput,
+    optionalFlag(args.flags, "horizon-days"),
+  );
+  const agenda = await computeAgenda(ctx, {
+    teamId: optionalFlag(args.flags, "team"),
+    horizonDays,
+  });
+  emit(agenda, renderAgendaText(agenda), opts);
+}
+
+function renderAgendaText(a: Agenda): string {
+  const lines: string[] = [`# 草野球 mound アジェンダ (${a.generated_at})`];
+  if (a.team_id) lines.push(`team: ${a.team_id}`);
+
+  lines.push("", `## 公開待ち (DRAFT): ${a.needs_publish.length}`);
+  for (const g of a.needs_publish) lines.push(`  - ${g.title} (${g.id})`);
+
+  lines.push("", `## 出欠集計中 (COLLECTING): ${a.collecting.length}`);
+  for (const c of a.collecting) {
+    const ready = c.ready_to_confirm ? "✅ 確定可" : `あと ${c.shortage} 人`;
+    lines.push(
+      `  - ${c.game.title} [${c.rsvp.available}/${c.game.min_players}] ${ready}`,
+    );
+  }
+
+  lines.push(
+    "",
+    `## 開催間近 (CONFIRMED, ≤${a.horizon_days} 日先): ${a.upcoming.length}`,
+  );
+  for (const u of a.upcoming) {
+    lines.push(
+      `  - ${u.game.title} (${u.game.game_date}) — あと ${u.days_until} 日`,
+    );
+  }
+
+  lines.push("", `## 完了入力待ち (試合日経過): ${a.needs_completion.length}`);
+  for (const g of a.needs_completion)
+    lines.push(`  - ${g.title} (${g.game_date})`);
+
+  lines.push("", `## 精算待ち (COMPLETED): ${a.needs_settlement.length}`);
+  for (const g of a.needs_settlement) lines.push(`  - ${g.title} (${g.id})`);
+
+  return lines.join("\n");
+}

--- a/packages/cli/src/adapters/cli/commands/audit.ts
+++ b/packages/cli/src/adapters/cli/commands/audit.ts
@@ -1,0 +1,23 @@
+import type { UseCaseContext } from "../../../ports";
+import { listAuditLogs } from "../../../usecases/audit";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+
+export async function runAudit(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  if (args.positional.length > 0) {
+    throw new UsageError(`未知の引数: ${args.positional.join(" ")}`);
+  }
+  const targetType = optionalFlag(args.flags, "type") ?? "game";
+  const targetId = requireFlag(args.flags, "target");
+  const logs = await listAuditLogs(ctx, targetType, targetId);
+  emit(logs, formatRows(logs, ["created_at", "action", "actor"]), opts);
+}

--- a/packages/cli/src/adapters/cli/commands/game.ts
+++ b/packages/cli/src/adapters/cli/commands/game.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import { assertGameStatus } from "../../../domain/guards";
+import { GAME_STATUSES, type GameStatus } from "../../../domain/types";
+import type { UseCaseContext } from "../../../ports";
+import {
+  createGame,
+  listGames,
+  showGame,
+  transitionGame,
+} from "../../../usecases/game";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const createInput = z.object({
+  teamId: z.string().min(1),
+  title: z.string().min(1).max(120),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "date は YYYY-MM-DD 形式")
+    .optional(),
+  ground: z.string().max(80).optional(),
+  minPlayers: z.coerce.number().int().min(1).max(30).default(9),
+  note: z.string().max(500).optional(),
+});
+
+const statusFilterInput = z
+  .enum(GAME_STATUSES)
+  .optional()
+  .or(z.literal("").transform(() => undefined));
+
+export async function runGame(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub)
+    throw new UsageError("使い方: mound game <create|list|show|transition>");
+  if (sub === "create") return create(args, ctx, opts);
+  if (sub === "list") return list(args, ctx, opts);
+  if (sub === "show") return show(args, ctx, opts);
+  if (sub === "transition") return transition(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: game ${sub}`);
+}
+
+async function create(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(createInput, {
+    teamId: requireFlag(args.flags, "team"),
+    title: requireFlag(args.flags, "title"),
+    date: optionalFlag(args.flags, "date"),
+    ground: optionalFlag(args.flags, "ground"),
+    minPlayers: optionalFlag(args.flags, "min-players"),
+    note: optionalFlag(args.flags, "note"),
+  });
+  const game = await createGame(ctx, {
+    teamId: data.teamId,
+    title: data.title,
+    date: data.date ?? null,
+    ground: data.ground ?? null,
+    minPlayers: data.minPlayers,
+    note: data.note ?? null,
+  });
+  emit(game, `試合を作成しました: ${game.id} (${game.title}) [DRAFT]`, opts);
+}
+
+async function list(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const statusFlag = optionalFlag(args.flags, "status");
+  const status = parseOrUsage(statusFilterInput, statusFlag);
+  const games = await listGames(ctx, {
+    teamId: optionalFlag(args.flags, "team"),
+    status,
+  });
+  emit(
+    games,
+    formatRows(games, ["id", "title", "status", "game_date", "ground_name"]),
+    opts,
+  );
+}
+
+async function show(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id) throw new UsageError("使い方: mound game show <id>");
+  const detail = await showGame(ctx, id);
+  const { game, rsvp_summary: s, rsvp_breakdown: b } = detail;
+  const names = (rows: { member_name: string }[]) =>
+    rows.length === 0 ? "(なし)" : rows.map((r) => r.member_name).join(", ");
+  const text = [
+    `${game.title} [${game.status}]`,
+    `id: ${game.id}`,
+    `team: ${game.team_id}`,
+    `date: ${game.game_date ?? "(未定)"}`,
+    `ground: ${game.ground_name ?? "(未定)"}`,
+    `min_players: ${game.min_players}`,
+    `note: ${game.note ?? ""}`,
+    `RSVP: available=${s.available} unavailable=${s.unavailable} maybe=${s.maybe} no_response=${s.no_response}`,
+    `  参加可:   ${names(b.available)}`,
+    `  欠席:     ${names(b.unavailable)}`,
+    `  未定:     ${names(b.maybe)}`,
+    `  未回答:   ${names(b.no_response)}`,
+  ].join("\n");
+  emit(detail, text, opts);
+}
+
+function toGameStatusOrUsage(input: string): GameStatus {
+  try {
+    return assertGameStatus(input);
+  } catch {
+    throw new UsageError(`未知のステータス: ${input}`);
+  }
+}
+
+async function transition(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id)
+    throw new UsageError("使い方: mound game transition <id> --to <STATUS>");
+  const to = toGameStatusOrUsage(requireFlag(args.flags, "to"));
+  const after = await transitionGame(ctx, id, to);
+  emit(after, `状態を遷移しました: → ${to}`, opts);
+}

--- a/packages/cli/src/adapters/cli/commands/init.ts
+++ b/packages/cli/src/adapters/cli/commands/init.ts
@@ -1,0 +1,11 @@
+import { migrate } from "../../libsql/client";
+import type { DbClient } from "../../libsql/client";
+import { type RenderOptions, emit } from "../output";
+
+export async function runInit(
+  db: DbClient,
+  opts: RenderOptions,
+): Promise<void> {
+  await migrate(db);
+  emit({ ok: true }, "DB を初期化しました", opts);
+}

--- a/packages/cli/src/adapters/cli/commands/member.ts
+++ b/packages/cli/src/adapters/cli/commands/member.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { MEMBER_ROLES } from "../../../domain/types";
+import type { UseCaseContext } from "../../../ports";
+import { addMember, listMembers } from "../../../usecases/member";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const addInput = z.object({
+  teamId: z.string().min(1),
+  name: z.string().min(1, "name は必須です").max(80),
+  email: z.string().email().optional(),
+  role: z.enum(MEMBER_ROLES).default("MEMBER"),
+});
+
+export async function runMember(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound member <add|list>");
+  if (sub === "add") return add(args, ctx, opts);
+  if (sub === "list") return list(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: member ${sub}`);
+}
+
+async function add(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(addInput, {
+    teamId: requireFlag(args.flags, "team"),
+    name: requireFlag(args.flags, "name"),
+    email: optionalFlag(args.flags, "email"),
+    role: optionalFlag(args.flags, "role") ?? "MEMBER",
+  });
+  const member = await addMember(ctx, {
+    teamId: data.teamId,
+    name: data.name,
+    email: data.email ?? null,
+    role: data.role,
+  });
+  emit(member, `メンバーを追加しました: ${member.id} (${member.name})`, opts);
+}
+
+async function list(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const members = await listMembers(ctx, teamId);
+  emit(members, formatRows(members, ["id", "name", "role", "email"]), opts);
+}

--- a/packages/cli/src/adapters/cli/commands/rsvp.ts
+++ b/packages/cli/src/adapters/cli/commands/rsvp.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { RSVP_RESPONSES } from "../../../domain/types";
+import type { UseCaseContext } from "../../../ports";
+import {
+  listRsvpsWithMembers,
+  setRsvp,
+  summarizeRsvps,
+} from "../../../usecases/rsvp";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const setInput = z.object({
+  gameId: z.string().min(1),
+  memberId: z.string().min(1),
+  response: z.enum(RSVP_RESPONSES),
+});
+
+export async function runRsvp(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound rsvp <set|list|summary>");
+  if (sub === "set") return set(args, ctx, opts);
+  if (sub === "list") return list(args, ctx, opts);
+  if (sub === "summary") return summary(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: rsvp ${sub}`);
+}
+
+async function set(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(setInput, {
+    gameId: requireFlag(args.flags, "game"),
+    memberId: requireFlag(args.flags, "member"),
+    response: requireFlag(args.flags, "response"),
+  });
+  const saved = await setRsvp(ctx, data);
+  emit(saved, `RSVP を記録しました: → ${data.response}`, opts);
+}
+
+async function list(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const gameId = requireFlag(args.flags, "game");
+  const rows = await listRsvpsWithMembers(ctx, gameId);
+  emit(
+    rows,
+    formatRows(rows, [
+      "member_name",
+      "member_role",
+      "response",
+      "responded_at",
+    ]),
+    opts,
+  );
+}
+
+async function summary(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const gameId = requireFlag(args.flags, "game");
+  const teamId = optionalFlag(args.flags, "team");
+  const s = await summarizeRsvps(ctx, gameId, teamId);
+  const text = `available=${s.available} unavailable=${s.unavailable} maybe=${s.maybe} no_response=${s.no_response}`;
+  emit(s, text, opts);
+}

--- a/packages/cli/src/adapters/cli/commands/team.ts
+++ b/packages/cli/src/adapters/cli/commands/team.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { UseCaseContext } from "../../../ports";
+import { createTeam, listTeams } from "../../../usecases/team";
+import {
+  type ParsedArgs,
+  UsageError,
+  boolFlag,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const createInput = z.object({
+  name: z.string().min(1, "name は必須です").max(80),
+  area: z.string().max(80).optional(),
+});
+
+export async function runTeam(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound team <create|list>");
+  if (sub === "create") return create(args, ctx, opts);
+  if (sub === "list") return list(ctx, opts);
+  throw new UsageError(`未知のサブコマンド: team ${sub}`);
+}
+
+async function create(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(createInput, {
+    name: requireFlag(args.flags, "name"),
+    area: optionalFlag(args.flags, "area"),
+  });
+  const team = await createTeam(ctx, {
+    name: data.name,
+    homeArea: data.area ?? null,
+  });
+  emit(team, `チームを作成しました: ${team.id} (${team.name})`, opts);
+  if (boolFlag(args.flags, "verbose") && !opts.json) {
+    opts.sink.write(`home_area: ${team.home_area ?? "(未設定)"}`);
+  }
+}
+
+async function list(ctx: UseCaseContext, opts: RenderOptions): Promise<void> {
+  const teams = await listTeams(ctx);
+  emit(
+    teams,
+    formatRows(teams, ["id", "name", "home_area", "created_at"]),
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/compose.ts
+++ b/packages/cli/src/adapters/cli/compose.ts
@@ -1,0 +1,17 @@
+import type { UseCaseContext } from "../../ports";
+import type { DbClient } from "../libsql/client";
+import { buildRepositories } from "../libsql/repositories";
+
+export interface ComposeOptions {
+  db: DbClient;
+  now: () => Date;
+  newId: () => string;
+}
+
+export function composeContext(options: ComposeOptions): UseCaseContext {
+  return {
+    repo: buildRepositories(options.db),
+    now: options.now,
+    newId: options.newId,
+  };
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -1,0 +1,32 @@
+export const HELP = `mound — 草野球チーム向け試合成立 CLI
+
+使い方:
+  mound <command> [subcommand] [--flags]
+
+コマンド:
+  init                                       DB を初期化する
+  team create --name <N> [--area <A>]        チームを作成
+  team list                                  チーム一覧
+  member add --team <ID> --name <N> [--email <E>] [--role ADMIN|MEMBER]
+  member list --team <ID>
+  game create --team <ID> --title <T> [--date YYYY-MM-DD] [--ground <G>] [--min-players <N>] [--note <NOTE>]
+  game list [--team <ID>] [--status DRAFT|COLLECTING|CONFIRMED|...]
+  game show <ID>
+  game transition <ID> --to COLLECTING|CONFIRMED|COMPLETED|SETTLED|CANCELLED
+  rsvp set --game <ID> --member <ID> --response AVAILABLE|UNAVAILABLE|MAYBE
+  rsvp list --game <ID>
+  rsvp summary --game <ID>
+  audit --target <ID> [--type game|team|member]
+  agenda [--team <ID>] [--horizon-days N]    いま注意すべき試合 (メニューバー向け)
+
+グローバルフラグ:
+  --json       JSON 出力 (エージェント連携向け)
+  --help       このヘルプ
+  --version    バージョン
+
+環境変数:
+  MOUND_DB_URL          libSQL URL (例: file:./mound.db, libsql://...turso.io)
+  MOUND_DB_AUTH_TOKEN   Turso 認証トークン
+`;
+
+export const VERSION = "0.1.0";

--- a/packages/cli/src/adapters/cli/output.ts
+++ b/packages/cli/src/adapters/cli/output.ts
@@ -1,0 +1,51 @@
+export interface OutputSink {
+  write(line: string): void;
+}
+
+export const stdoutSink: OutputSink = {
+  write(line) {
+    process.stdout.write(`${line}\n`);
+  },
+};
+
+export const stderrSink: OutputSink = {
+  write(line) {
+    process.stderr.write(`${line}\n`);
+  },
+};
+
+export interface RenderOptions {
+  json: boolean;
+  sink: OutputSink;
+}
+
+export function emit<T>(value: T, text: string, opts: RenderOptions): void {
+  if (opts.json) {
+    opts.sink.write(JSON.stringify(value));
+  } else {
+    opts.sink.write(text);
+  }
+}
+
+export function emitError(
+  message: string,
+  opts: { json: boolean; sink: OutputSink },
+): void {
+  if (opts.json) {
+    opts.sink.write(JSON.stringify({ ok: false, error: message }));
+  } else {
+    opts.sink.write(`エラー: ${message}`);
+  }
+}
+
+export function formatRows<T>(
+  rows: readonly T[],
+  columns: ReadonlyArray<keyof T & string>,
+): string {
+  if (rows.length === 0) return "(該当なし)";
+  const header = columns.join("\t");
+  const lines = rows.map((row) =>
+    columns.map((c) => String(row[c] ?? "")).join("\t"),
+  );
+  return [header, ...lines].join("\n");
+}

--- a/packages/cli/src/adapters/cli/zod-helper.ts
+++ b/packages/cli/src/adapters/cli/zod-helper.ts
@@ -1,0 +1,13 @@
+import type { z } from "zod";
+import { UsageError } from "./args";
+
+export function parseOrUsage<T extends z.ZodTypeAny>(
+  schema: T,
+  input: unknown,
+): z.infer<T> {
+  const parsed = schema.safeParse(input);
+  if (!parsed.success) {
+    throw new UsageError(parsed.error.issues[0]?.message ?? "入力が不正です");
+  }
+  return parsed.data;
+}

--- a/packages/cli/src/adapters/libsql/client.ts
+++ b/packages/cli/src/adapters/libsql/client.ts
@@ -1,0 +1,55 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { type Client, createClient } from "@libsql/client";
+import { SCHEMA_SQL, SCHEMA_VERSION } from "./schema";
+
+export type DbClient = Client;
+
+export interface DbConfig {
+  url: string;
+  authToken?: string;
+}
+
+export function buildDbConfig(
+  env: Record<string, string | undefined>,
+): DbConfig {
+  const url =
+    env.MOUND_DB_URL ??
+    env.TURSO_DATABASE_URL ??
+    `file:${env.HOME ?? "."}/.mound/mound.db`;
+  const authToken = env.MOUND_DB_AUTH_TOKEN ?? env.TURSO_AUTH_TOKEN;
+  return { url, authToken };
+}
+
+export function ensureDbParentDir(url: string): void {
+  if (!url.startsWith("file:")) return;
+  const path = url.slice("file:".length);
+  if (path.startsWith(":memory:") || path.length === 0) return;
+  const dir = dirname(path);
+  if (dir && dir !== ".") {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function openDb(config: DbConfig): DbClient {
+  ensureDbParentDir(config.url);
+  return createClient({ url: config.url, authToken: config.authToken });
+}
+
+export async function readSchemaVersion(db: DbClient): Promise<number> {
+  const r = await db.execute("PRAGMA user_version");
+  const v = r.rows[0]?.user_version;
+  return typeof v === "number" ? v : Number(v ?? 0);
+}
+
+export async function migrate(db: DbClient): Promise<void> {
+  await db.executeMultiple(SCHEMA_SQL);
+  await db.execute(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+}
+
+export async function ensureSchemaUpToDate(db: DbClient): Promise<void> {
+  const current = await readSchemaVersion(db);
+  if (current < SCHEMA_VERSION) {
+    await migrate(db);
+  }
+}

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -1,0 +1,309 @@
+import type { InValue } from "@libsql/client";
+import type {
+  AuditLog,
+  Game,
+  GameStatus,
+  Member,
+  MemberRsvp,
+  Rsvp,
+  RsvpBreakdown,
+  RsvpSummary,
+  Team,
+} from "../../domain/types";
+import type {
+  AuditRepository,
+  GameRepository,
+  MemberRepository,
+  Repositories,
+  RsvpRepository,
+  TeamRepository,
+} from "../../ports";
+import type { DbClient } from "./client";
+import {
+  rowToAuditLog,
+  rowToGame,
+  rowToMember,
+  rowToMemberRsvp,
+  rowToRsvp,
+  rowToTeam,
+} from "./row-mappers";
+
+class LibsqlTeamRepository implements TeamRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(team: Team): Promise<Team> {
+    await this.db.execute({
+      sql: `INSERT INTO teams (id, name, home_area, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)`,
+      args: [
+        team.id,
+        team.name,
+        team.home_area,
+        team.created_at,
+        team.updated_at,
+      ],
+    });
+    return team;
+  }
+
+  async list(): Promise<Team[]> {
+    const r = await this.db.execute(
+      "SELECT * FROM teams ORDER BY created_at ASC",
+    );
+    return r.rows.map(rowToTeam);
+  }
+
+  async get(id: string): Promise<Team | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM teams WHERE id = ?",
+      args: [id],
+    });
+    return r.rows[0] ? rowToTeam(r.rows[0]) : null;
+  }
+}
+
+class LibsqlMemberRepository implements MemberRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(member: Member): Promise<Member> {
+    await this.db.execute({
+      sql: `INSERT INTO members (id, team_id, name, email, role, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        member.id,
+        member.team_id,
+        member.name,
+        member.email,
+        member.role,
+        member.created_at,
+        member.updated_at,
+      ],
+    });
+    return member;
+  }
+
+  async list(teamId: string): Promise<Member[]> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM members WHERE team_id = ? ORDER BY created_at ASC",
+      args: [teamId],
+    });
+    return r.rows.map(rowToMember);
+  }
+
+  async get(id: string): Promise<Member | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM members WHERE id = ?",
+      args: [id],
+    });
+    return r.rows[0] ? rowToMember(r.rows[0]) : null;
+  }
+}
+
+class LibsqlGameRepository implements GameRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(game: Game): Promise<Game> {
+    await this.db.execute({
+      sql: `INSERT INTO games (
+              id, team_id, title, status, game_date, ground_name,
+              min_players, note, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        game.id,
+        game.team_id,
+        game.title,
+        game.status,
+        game.game_date,
+        game.ground_name,
+        game.min_players,
+        game.note,
+        game.created_at,
+        game.updated_at,
+      ],
+    });
+    return game;
+  }
+
+  async list(filter: {
+    teamId?: string;
+    status?: GameStatus;
+  }): Promise<Game[]> {
+    const where: string[] = [];
+    const args: InValue[] = [];
+    if (filter.teamId) {
+      where.push("team_id = ?");
+      args.push(filter.teamId);
+    }
+    if (filter.status) {
+      where.push("status = ?");
+      args.push(filter.status);
+    }
+    const sql = `SELECT * FROM games${
+      where.length ? ` WHERE ${where.join(" AND ")}` : ""
+    } ORDER BY created_at DESC`;
+    const r = await this.db.execute({ sql, args });
+    return r.rows.map(rowToGame);
+  }
+
+  async get(id: string): Promise<Game | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM games WHERE id = ?",
+      args: [id],
+    });
+    return r.rows[0] ? rowToGame(r.rows[0]) : null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: GameStatus,
+    updatedAt: string,
+  ): Promise<void> {
+    await this.db.execute({
+      sql: "UPDATE games SET status = ?, updated_at = ? WHERE id = ?",
+      args: [status, updatedAt, id],
+    });
+  }
+}
+
+class LibsqlRsvpRepository implements RsvpRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async upsert(rsvp: Rsvp): Promise<Rsvp> {
+    await this.db.execute({
+      sql: `INSERT INTO rsvps (id, game_id, member_id, response, responded_at, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(game_id, member_id) DO UPDATE SET
+              response = excluded.response,
+              responded_at = excluded.responded_at,
+              updated_at = excluded.updated_at`,
+      args: [
+        rsvp.id,
+        rsvp.game_id,
+        rsvp.member_id,
+        rsvp.response,
+        rsvp.responded_at,
+        rsvp.created_at,
+        rsvp.updated_at,
+      ],
+    });
+    const r = await this.db.execute({
+      sql: "SELECT * FROM rsvps WHERE game_id = ? AND member_id = ?",
+      args: [rsvp.game_id, rsvp.member_id],
+    });
+    if (!r.rows[0]) throw new Error("rsvp upsert failed");
+    return rowToRsvp(r.rows[0]);
+  }
+
+  async list(gameId: string): Promise<Rsvp[]> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM rsvps WHERE game_id = ? ORDER BY responded_at ASC",
+      args: [gameId],
+    });
+    return r.rows.map(rowToRsvp);
+  }
+
+  async listWithMembers(gameId: string, teamId: string): Promise<MemberRsvp[]> {
+    const r = await this.db.execute({
+      sql: `SELECT
+              m.id AS member_id,
+              m.name AS member_name,
+              m.role AS member_role,
+              COALESCE(rs.response, 'NO_RESPONSE') AS response,
+              rs.responded_at AS responded_at
+            FROM members m
+            LEFT JOIN rsvps rs
+              ON rs.member_id = m.id AND rs.game_id = ?
+            WHERE m.team_id = ?
+            ORDER BY m.created_at ASC`,
+      args: [gameId, teamId],
+    });
+    return r.rows.map(rowToMemberRsvp);
+  }
+
+  async breakdown(gameId: string, teamId: string): Promise<RsvpBreakdown> {
+    const rows = await this.listWithMembers(gameId, teamId);
+    const out: RsvpBreakdown = {
+      available: [],
+      unavailable: [],
+      maybe: [],
+      no_response: [],
+    };
+    for (const row of rows) {
+      if (row.response === "AVAILABLE") out.available.push(row);
+      else if (row.response === "UNAVAILABLE") out.unavailable.push(row);
+      else if (row.response === "MAYBE") out.maybe.push(row);
+      else out.no_response.push(row);
+    }
+    return out;
+  }
+
+  async summarize(gameId: string, teamId: string): Promise<RsvpSummary> {
+    const r = await this.db.execute({
+      sql: `SELECT
+              SUM(CASE WHEN r.response = 'AVAILABLE'   THEN 1 ELSE 0 END) AS available,
+              SUM(CASE WHEN r.response = 'UNAVAILABLE' THEN 1 ELSE 0 END) AS unavailable,
+              SUM(CASE WHEN r.response = 'MAYBE'       THEN 1 ELSE 0 END) AS maybe,
+              (SELECT COUNT(*) FROM members WHERE team_id = ?) AS total,
+              COUNT(r.id) AS recorded
+            FROM rsvps r
+            WHERE r.game_id = ?`,
+      args: [teamId, gameId],
+    });
+    const row = r.rows[0];
+    const available = Number(row?.available ?? 0);
+    const unavailable = Number(row?.unavailable ?? 0);
+    const maybe = Number(row?.maybe ?? 0);
+    const total = Number(row?.total ?? 0);
+    const recorded = Number(row?.recorded ?? 0);
+    return {
+      available,
+      unavailable,
+      maybe,
+      no_response: Math.max(0, total - recorded),
+    };
+  }
+}
+
+class LibsqlAuditRepository implements AuditRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(log: AuditLog): Promise<AuditLog> {
+    await this.db.execute({
+      sql: `INSERT INTO audit_logs (
+              id, actor, action, target_type, target_id,
+              before_json, after_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        log.id,
+        log.actor,
+        log.action,
+        log.target_type,
+        log.target_id,
+        log.before_json,
+        log.after_json,
+        log.created_at,
+      ],
+    });
+    return log;
+  }
+
+  async list(targetType: string, targetId: string): Promise<AuditLog[]> {
+    const r = await this.db.execute({
+      sql: `SELECT * FROM audit_logs
+            WHERE target_type = ? AND target_id = ?
+            ORDER BY created_at ASC`,
+      args: [targetType, targetId],
+    });
+    return r.rows.map(rowToAuditLog);
+  }
+}
+
+export function buildRepositories(db: DbClient): Repositories {
+  return {
+    teams: new LibsqlTeamRepository(db),
+    members: new LibsqlMemberRepository(db),
+    games: new LibsqlGameRepository(db),
+    rsvps: new LibsqlRsvpRepository(db),
+    audit: new LibsqlAuditRepository(db),
+  };
+}

--- a/packages/cli/src/adapters/libsql/row-mappers.ts
+++ b/packages/cli/src/adapters/libsql/row-mappers.ts
@@ -1,0 +1,90 @@
+import type { InValue, Row } from "@libsql/client";
+import {
+  assertGameStatus,
+  assertMemberRole,
+  assertRsvpResponse,
+} from "../../domain/guards";
+import type {
+  AuditLog,
+  Game,
+  Member,
+  MemberRsvp,
+  Rsvp,
+  Team,
+} from "../../domain/types";
+
+export const str = (v: InValue): string => String(v);
+export const nullable = (v: InValue): string | null =>
+  v === null || v === undefined ? null : String(v);
+
+export function rowToTeam(row: Row): Team {
+  return {
+    id: str(row.id),
+    name: str(row.name),
+    home_area: nullable(row.home_area),
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToMember(row: Row): Member {
+  return {
+    id: str(row.id),
+    team_id: str(row.team_id),
+    name: str(row.name),
+    email: nullable(row.email),
+    role: assertMemberRole(str(row.role)),
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToGame(row: Row): Game {
+  return {
+    id: str(row.id),
+    team_id: str(row.team_id),
+    title: str(row.title),
+    status: assertGameStatus(str(row.status)),
+    game_date: nullable(row.game_date),
+    ground_name: nullable(row.ground_name),
+    min_players: Number(row.min_players),
+    note: nullable(row.note),
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToRsvp(row: Row): Rsvp {
+  return {
+    id: str(row.id),
+    game_id: str(row.game_id),
+    member_id: str(row.member_id),
+    response: assertRsvpResponse(str(row.response)),
+    responded_at: str(row.responded_at),
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToMemberRsvp(row: Row): MemberRsvp {
+  return {
+    member_id: str(row.member_id),
+    member_name: str(row.member_name),
+    member_role: assertMemberRole(str(row.member_role)),
+    response: assertRsvpResponse(str(row.response)),
+    responded_at: nullable(row.responded_at),
+  };
+}
+
+export function rowToAuditLog(row: Row): AuditLog {
+  return {
+    id: str(row.id),
+    actor: str(row.actor),
+    action: str(row.action),
+    target_type: str(row.target_type),
+    target_id: str(row.target_id),
+    before_json: nullable(row.before_json),
+    after_json: nullable(row.after_json),
+    created_at: str(row.created_at),
+  };
+}

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,0 +1,65 @@
+export const SCHEMA_VERSION = 1;
+
+export const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS teams (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  home_area TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS members (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  email TEXT,
+  role TEXT NOT NULL CHECK (role IN ('ADMIN', 'MEMBER')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_members_team ON members(team_id);
+
+CREATE TABLE IF NOT EXISTS games (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('DRAFT','COLLECTING','CONFIRMED','COMPLETED','SETTLED','CANCELLED')
+  ),
+  game_date TEXT,
+  ground_name TEXT,
+  min_players INTEGER NOT NULL DEFAULT 9,
+  note TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_games_team ON games(team_id);
+CREATE INDEX IF NOT EXISTS idx_games_status ON games(status);
+
+CREATE TABLE IF NOT EXISTS rsvps (
+  id TEXT PRIMARY KEY,
+  game_id TEXT NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+  member_id TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  response TEXT NOT NULL CHECK (
+    response IN ('AVAILABLE','UNAVAILABLE','MAYBE','NO_RESPONSE')
+  ),
+  responded_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(game_id, member_id)
+);
+CREATE INDEX IF NOT EXISTS idx_rsvps_game ON rsvps(game_id);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id TEXT PRIMARY KEY,
+  actor TEXT NOT NULL,
+  action TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  before_json TEXT,
+  after_json TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_target ON audit_logs(target_type, target_id);
+`;

--- a/packages/cli/src/domain/guards.ts
+++ b/packages/cli/src/domain/guards.ts
@@ -1,0 +1,57 @@
+import {
+  GAME_STATUSES,
+  type GameStatus,
+  MEMBER_ROLES,
+  type MemberRole,
+  RSVP_RESPONSES,
+  type RsvpResponse,
+} from "./types";
+
+export function isGameStatus(value: unknown): value is GameStatus {
+  return (
+    typeof value === "string" &&
+    (GAME_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function isRsvpResponse(value: unknown): value is RsvpResponse {
+  return (
+    typeof value === "string" &&
+    (RSVP_RESPONSES as readonly string[]).includes(value)
+  );
+}
+
+export function isMemberRole(value: unknown): value is MemberRole {
+  return (
+    typeof value === "string" &&
+    (MEMBER_ROLES as readonly string[]).includes(value)
+  );
+}
+
+export class DomainInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DomainInvariantError";
+  }
+}
+
+export function assertGameStatus(value: unknown): GameStatus {
+  if (!isGameStatus(value)) {
+    throw new DomainInvariantError(`不正な GameStatus: ${String(value)}`);
+  }
+  return value;
+}
+
+export function assertRsvpResponse(value: unknown): RsvpResponse {
+  if (!isRsvpResponse(value)) {
+    throw new DomainInvariantError(`不正な RsvpResponse: ${String(value)}`);
+  }
+  return value;
+}
+
+export function assertMemberRole(value: unknown): MemberRole {
+  if (!isMemberRole(value)) {
+    throw new DomainInvariantError(`不正な MemberRole: ${String(value)}`);
+  }
+  return value;
+}

--- a/packages/cli/src/domain/state-machine.ts
+++ b/packages/cli/src/domain/state-machine.ts
@@ -1,0 +1,60 @@
+import type { GameStatus, RsvpSummary } from "./types";
+
+const TRANSITIONS: Record<GameStatus, GameStatus[]> = {
+  DRAFT: ["COLLECTING", "CONFIRMED", "CANCELLED"],
+  COLLECTING: ["CONFIRMED", "CANCELLED"],
+  CONFIRMED: ["COMPLETED", "CANCELLED"],
+  COMPLETED: ["SETTLED"],
+  SETTLED: [],
+  CANCELLED: [],
+};
+
+export function canTransition(from: GameStatus, to: GameStatus): boolean {
+  return TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function getAvailableTransitions(current: GameStatus): GameStatus[] {
+  return TRANSITIONS[current] ?? [];
+}
+
+export interface GuardContext {
+  rsvp: RsvpSummary;
+  minPlayers: number;
+  gameDate: string | null;
+  now: Date;
+}
+
+export interface GuardResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+export function checkGuard(
+  from: GameStatus,
+  to: GameStatus,
+  ctx: GuardContext,
+): GuardResult {
+  if (!canTransition(from, to)) {
+    return { allowed: false, reason: `状態遷移が不正です: ${from} → ${to}` };
+  }
+  if (to === "CONFIRMED") {
+    if (ctx.rsvp.available < ctx.minPlayers) {
+      return {
+        allowed: false,
+        reason: `参加可 (${ctx.rsvp.available}) が最低人数 (${ctx.minPlayers}) に満たないため確定できません`,
+      };
+    }
+  }
+  if (from === "CONFIRMED" && to === "COMPLETED") {
+    if (!ctx.gameDate) {
+      return { allowed: false, reason: "試合日が設定されていません" };
+    }
+    const game = new Date(ctx.gameDate);
+    const today = new Date(ctx.now);
+    today.setHours(0, 0, 0, 0);
+    if (game > today) {
+      return { allowed: false, reason: "試合日がまだ到来していません" };
+    }
+  }
+  return { allowed: true };
+}

--- a/packages/cli/src/domain/types.ts
+++ b/packages/cli/src/domain/types.ts
@@ -1,0 +1,94 @@
+export const GAME_STATUSES = [
+  "DRAFT",
+  "COLLECTING",
+  "CONFIRMED",
+  "COMPLETED",
+  "SETTLED",
+  "CANCELLED",
+] as const;
+export type GameStatus = (typeof GAME_STATUSES)[number];
+
+export const RSVP_RESPONSES = [
+  "AVAILABLE",
+  "UNAVAILABLE",
+  "MAYBE",
+  "NO_RESPONSE",
+] as const;
+export type RsvpResponse = (typeof RSVP_RESPONSES)[number];
+
+export const MEMBER_ROLES = ["ADMIN", "MEMBER"] as const;
+export type MemberRole = (typeof MEMBER_ROLES)[number];
+
+export interface Team {
+  id: string;
+  name: string;
+  home_area: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Member {
+  id: string;
+  team_id: string;
+  name: string;
+  email: string | null;
+  role: MemberRole;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Game {
+  id: string;
+  team_id: string;
+  title: string;
+  status: GameStatus;
+  game_date: string | null;
+  ground_name: string | null;
+  min_players: number;
+  note: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Rsvp {
+  id: string;
+  game_id: string;
+  member_id: string;
+  response: RsvpResponse;
+  responded_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AuditLog {
+  id: string;
+  actor: string;
+  action: string;
+  target_type: string;
+  target_id: string;
+  before_json: string | null;
+  after_json: string | null;
+  created_at: string;
+}
+
+export interface RsvpSummary {
+  available: number;
+  unavailable: number;
+  maybe: number;
+  no_response: number;
+}
+
+export interface MemberRsvp {
+  member_id: string;
+  member_name: string;
+  member_role: MemberRole;
+  response: RsvpResponse;
+  responded_at: string | null;
+}
+
+export interface RsvpBreakdown {
+  available: MemberRsvp[];
+  unavailable: MemberRsvp[];
+  maybe: MemberRsvp[];
+  no_response: MemberRsvp[];
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+import { run } from "./adapters/cli/cli";
+
+const exit = await run({
+  argv: process.argv.slice(2),
+  env: process.env,
+});
+process.exit(exit);

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -1,0 +1,69 @@
+// Application ports. Usecases depend only on these interfaces.
+// Concrete implementations live in adapters/.
+import type {
+  AuditLog,
+  Game,
+  GameStatus,
+  Member,
+  MemberRsvp,
+  Rsvp,
+  RsvpBreakdown,
+  RsvpSummary,
+  Team,
+} from "./domain/types";
+
+export interface TeamRepository {
+  insert(team: Team): Promise<Team>;
+  list(): Promise<Team[]>;
+  get(id: string): Promise<Team | null>;
+}
+
+export interface MemberRepository {
+  insert(member: Member): Promise<Member>;
+  list(teamId: string): Promise<Member[]>;
+  get(id: string): Promise<Member | null>;
+}
+
+export interface GameRepository {
+  insert(game: Game): Promise<Game>;
+  list(filter: { teamId?: string; status?: GameStatus }): Promise<Game[]>;
+  get(id: string): Promise<Game | null>;
+  updateStatus(
+    id: string,
+    status: GameStatus,
+    updatedAt: string,
+  ): Promise<void>;
+}
+
+export interface RsvpRepository {
+  upsert(rsvp: Rsvp): Promise<Rsvp>;
+  list(gameId: string): Promise<Rsvp[]>;
+  listWithMembers(gameId: string, teamId: string): Promise<MemberRsvp[]>;
+  breakdown(gameId: string, teamId: string): Promise<RsvpBreakdown>;
+  summarize(gameId: string, teamId: string): Promise<RsvpSummary>;
+}
+
+export interface AuditRepository {
+  insert(log: AuditLog): Promise<AuditLog>;
+  list(targetType: string, targetId: string): Promise<AuditLog[]>;
+}
+
+export interface Repositories {
+  teams: TeamRepository;
+  members: MemberRepository;
+  games: GameRepository;
+  rsvps: RsvpRepository;
+  audit: AuditRepository;
+}
+
+export interface Clock {
+  now(): Date;
+}
+
+export interface IdGenerator {
+  newId(): string;
+}
+
+export interface UseCaseContext extends Clock, IdGenerator {
+  repo: Repositories;
+}

--- a/packages/cli/src/usecases/agenda.ts
+++ b/packages/cli/src/usecases/agenda.ts
@@ -1,0 +1,88 @@
+import type { Game, RsvpSummary } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+
+export interface AgendaCollecting {
+  game: Game;
+  rsvp: RsvpSummary;
+  ready_to_confirm: boolean;
+  shortage: number;
+}
+
+export interface AgendaUpcoming {
+  game: Game;
+  days_until: number;
+}
+
+export interface Agenda {
+  generated_at: string;
+  team_id: string | null;
+  horizon_days: number;
+  needs_publish: Game[];
+  collecting: AgendaCollecting[];
+  upcoming: AgendaUpcoming[];
+  needs_completion: Game[];
+  needs_settlement: Game[];
+}
+
+export interface AgendaInput {
+  teamId?: string;
+  horizonDays: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function computeAgenda(
+  ctx: UseCaseContext,
+  input: AgendaInput,
+): Promise<Agenda> {
+  const { teamId, horizonDays } = input;
+  const now = ctx.now();
+  const today = startOfDay(now);
+
+  const [drafts, collectingGames, confirmedGames, completedGames] =
+    await Promise.all([
+      ctx.repo.games.list({ teamId, status: "DRAFT" }),
+      ctx.repo.games.list({ teamId, status: "COLLECTING" }),
+      ctx.repo.games.list({ teamId, status: "CONFIRMED" }),
+      ctx.repo.games.list({ teamId, status: "COMPLETED" }),
+    ]);
+
+  const collecting = await Promise.all(
+    collectingGames.map(async (game): Promise<AgendaCollecting> => {
+      const rsvp = await ctx.repo.rsvps.summarize(game.id, game.team_id);
+      const shortage = Math.max(0, game.min_players - rsvp.available);
+      return { game, rsvp, ready_to_confirm: shortage === 0, shortage };
+    }),
+  );
+
+  const upcoming: AgendaUpcoming[] = [];
+  const needsCompletion: Game[] = [];
+  for (const game of confirmedGames) {
+    if (!game.game_date) continue;
+    const date = startOfDay(new Date(game.game_date));
+    const diff = Math.round((date.getTime() - today.getTime()) / DAY_MS);
+    if (diff < 0) {
+      needsCompletion.push(game);
+    } else if (diff <= horizonDays) {
+      upcoming.push({ game, days_until: diff });
+    }
+  }
+  upcoming.sort((a, b) => a.days_until - b.days_until);
+
+  return {
+    generated_at: now.toISOString(),
+    team_id: teamId ?? null,
+    horizon_days: horizonDays,
+    needs_publish: drafts,
+    collecting,
+    upcoming,
+    needs_completion: needsCompletion,
+    needs_settlement: completedGames,
+  };
+}
+
+function startOfDay(d: Date): Date {
+  const c = new Date(d);
+  c.setHours(0, 0, 0, 0);
+  return c;
+}

--- a/packages/cli/src/usecases/audit.ts
+++ b/packages/cli/src/usecases/audit.ts
@@ -1,0 +1,35 @@
+import type { AuditLog } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+
+export interface AuditEvent {
+  action: string;
+  targetType: string;
+  targetId: string;
+  before?: unknown;
+  after?: unknown;
+}
+
+export async function writeAuditLog(
+  ctx: UseCaseContext,
+  event: AuditEvent,
+): Promise<void> {
+  await ctx.repo.audit.insert({
+    id: ctx.newId(),
+    actor: "cli",
+    action: event.action,
+    target_type: event.targetType,
+    target_id: event.targetId,
+    before_json:
+      event.before === undefined ? null : JSON.stringify(event.before),
+    after_json: event.after === undefined ? null : JSON.stringify(event.after),
+    created_at: ctx.now().toISOString(),
+  });
+}
+
+export async function listAuditLogs(
+  ctx: UseCaseContext,
+  targetType: string,
+  targetId: string,
+): Promise<AuditLog[]> {
+  return ctx.repo.audit.list(targetType, targetId);
+}

--- a/packages/cli/src/usecases/errors.ts
+++ b/packages/cli/src/usecases/errors.ts
@@ -1,0 +1,41 @@
+export class NotFoundError extends Error {
+  constructor(entity: string, id: string) {
+    super(`${entity} が存在しません: ${id}`);
+    this.name = "NotFoundError";
+  }
+}
+
+export class TeamNotFoundError extends NotFoundError {
+  constructor(id: string) {
+    super("team", id);
+    this.name = "TeamNotFoundError";
+  }
+}
+
+export class GameNotFoundError extends NotFoundError {
+  constructor(id: string) {
+    super("game", id);
+    this.name = "GameNotFoundError";
+  }
+}
+
+export class MemberNotFoundError extends NotFoundError {
+  constructor(id: string) {
+    super("member", id);
+    this.name = "MemberNotFoundError";
+  }
+}
+
+export class CrossTeamRsvpError extends Error {
+  constructor() {
+    super("member の所属チームが game と一致しません");
+    this.name = "CrossTeamRsvpError";
+  }
+}
+
+export class TransitionDeniedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "TransitionDeniedError";
+  }
+}

--- a/packages/cli/src/usecases/game.ts
+++ b/packages/cli/src/usecases/game.ts
@@ -1,0 +1,120 @@
+import { checkGuard } from "../domain/state-machine";
+import type { Game, GameStatus, RsvpBreakdown } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+import {
+  GameNotFoundError,
+  TeamNotFoundError,
+  TransitionDeniedError,
+} from "./errors";
+
+export interface CreateGameInput {
+  teamId: string;
+  title: string;
+  date: string | null;
+  ground: string | null;
+  minPlayers: number;
+  note: string | null;
+}
+
+export async function createGame(
+  ctx: UseCaseContext,
+  input: CreateGameInput,
+): Promise<Game> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const now = ctx.now().toISOString();
+  const game: Game = {
+    id: ctx.newId(),
+    team_id: team.id,
+    title: input.title,
+    status: "DRAFT",
+    game_date: input.date,
+    ground_name: input.ground,
+    min_players: input.minPlayers,
+    note: input.note,
+    created_at: now,
+    updated_at: now,
+  };
+  await ctx.repo.games.insert(game);
+  await writeAuditLog(ctx, {
+    action: "GAME_CREATED",
+    targetType: "game",
+    targetId: game.id,
+    after: game,
+  });
+  return game;
+}
+
+export interface ListGamesInput {
+  teamId?: string;
+  status?: GameStatus;
+}
+
+export async function listGames(
+  ctx: UseCaseContext,
+  input: ListGamesInput,
+): Promise<Game[]> {
+  return ctx.repo.games.list(input);
+}
+
+export interface GameDetail {
+  game: Game;
+  rsvp_summary: {
+    available: number;
+    unavailable: number;
+    maybe: number;
+    no_response: number;
+  };
+  rsvp_breakdown: RsvpBreakdown;
+}
+
+export async function showGame(
+  ctx: UseCaseContext,
+  id: string,
+): Promise<GameDetail> {
+  const game = await ctx.repo.games.get(id);
+  if (!game) throw new GameNotFoundError(id);
+  const breakdown = await ctx.repo.rsvps.breakdown(game.id, game.team_id);
+  return {
+    game,
+    rsvp_summary: {
+      available: breakdown.available.length,
+      unavailable: breakdown.unavailable.length,
+      maybe: breakdown.maybe.length,
+      no_response: breakdown.no_response.length,
+    },
+    rsvp_breakdown: breakdown,
+  };
+}
+
+export async function transitionGame(
+  ctx: UseCaseContext,
+  id: string,
+  to: GameStatus,
+): Promise<Game> {
+  const game = await ctx.repo.games.get(id);
+  if (!game) throw new GameNotFoundError(id);
+  const rsvp = await ctx.repo.rsvps.summarize(game.id, game.team_id);
+  const guard = checkGuard(game.status, to, {
+    rsvp,
+    minPlayers: game.min_players,
+    gameDate: game.game_date,
+    now: ctx.now(),
+  });
+  if (!guard.allowed) {
+    throw new TransitionDeniedError(guard.reason ?? "遷移が許可されていません");
+  }
+  const nowIso = ctx.now().toISOString();
+  const before = { ...game };
+  await ctx.repo.games.updateStatus(game.id, to, nowIso);
+  const after = { ...game, status: to, updated_at: nowIso };
+  await writeAuditLog(ctx, {
+    action: `GAME_TRANSITION:${game.status}->${to}`,
+    targetType: "game",
+    targetId: game.id,
+    before,
+    after,
+  });
+  return after;
+}

--- a/packages/cli/src/usecases/member.ts
+++ b/packages/cli/src/usecases/member.ts
@@ -1,0 +1,44 @@
+import type { Member, MemberRole } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+import { TeamNotFoundError } from "./errors";
+
+export interface AddMemberInput {
+  teamId: string;
+  name: string;
+  email: string | null;
+  role: MemberRole;
+}
+
+export async function addMember(
+  ctx: UseCaseContext,
+  input: AddMemberInput,
+): Promise<Member> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const now = ctx.now().toISOString();
+  const member: Member = {
+    id: ctx.newId(),
+    team_id: team.id,
+    name: input.name,
+    email: input.email,
+    role: input.role,
+    created_at: now,
+    updated_at: now,
+  };
+  await ctx.repo.members.insert(member);
+  await writeAuditLog(ctx, {
+    action: "MEMBER_ADDED",
+    targetType: "member",
+    targetId: member.id,
+    after: member,
+  });
+  return member;
+}
+
+export async function listMembers(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<Member[]> {
+  return ctx.repo.members.list(teamId);
+}

--- a/packages/cli/src/usecases/rsvp.ts
+++ b/packages/cli/src/usecases/rsvp.ts
@@ -1,0 +1,67 @@
+import type {
+  MemberRsvp,
+  Rsvp,
+  RsvpResponse,
+  RsvpSummary,
+} from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+import {
+  CrossTeamRsvpError,
+  GameNotFoundError,
+  MemberNotFoundError,
+} from "./errors";
+
+export interface SetRsvpInput {
+  gameId: string;
+  memberId: string;
+  response: RsvpResponse;
+}
+
+export async function setRsvp(
+  ctx: UseCaseContext,
+  input: SetRsvpInput,
+): Promise<Rsvp> {
+  const game = await ctx.repo.games.get(input.gameId);
+  if (!game) throw new GameNotFoundError(input.gameId);
+  const member = await ctx.repo.members.get(input.memberId);
+  if (!member) throw new MemberNotFoundError(input.memberId);
+  if (member.team_id !== game.team_id) throw new CrossTeamRsvpError();
+  const now = ctx.now().toISOString();
+  const rsvp: Rsvp = {
+    id: ctx.newId(),
+    game_id: game.id,
+    member_id: member.id,
+    response: input.response,
+    responded_at: now,
+    created_at: now,
+    updated_at: now,
+  };
+  const saved = await ctx.repo.rsvps.upsert(rsvp);
+  await writeAuditLog(ctx, {
+    action: `RSVP_${input.response}`,
+    targetType: "game",
+    targetId: game.id,
+    after: saved,
+  });
+  return saved;
+}
+
+export async function listRsvpsWithMembers(
+  ctx: UseCaseContext,
+  gameId: string,
+): Promise<MemberRsvp[]> {
+  const game = await ctx.repo.games.get(gameId);
+  if (!game) throw new GameNotFoundError(gameId);
+  return ctx.repo.rsvps.listWithMembers(gameId, game.team_id);
+}
+
+export async function summarizeRsvps(
+  ctx: UseCaseContext,
+  gameId: string,
+  teamIdOverride?: string,
+): Promise<RsvpSummary> {
+  const game = await ctx.repo.games.get(gameId);
+  if (!game) throw new GameNotFoundError(gameId);
+  return ctx.repo.rsvps.summarize(gameId, teamIdOverride ?? game.team_id);
+}

--- a/packages/cli/src/usecases/team.ts
+++ b/packages/cli/src/usecases/team.ts
@@ -1,0 +1,34 @@
+import type { Team } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+
+export interface CreateTeamInput {
+  name: string;
+  homeArea: string | null;
+}
+
+export async function createTeam(
+  ctx: UseCaseContext,
+  input: CreateTeamInput,
+): Promise<Team> {
+  const now = ctx.now().toISOString();
+  const team: Team = {
+    id: ctx.newId(),
+    name: input.name,
+    home_area: input.homeArea,
+    created_at: now,
+    updated_at: now,
+  };
+  await ctx.repo.teams.insert(team);
+  await writeAuditLog(ctx, {
+    action: "TEAM_CREATED",
+    targetType: "team",
+    targetId: team.id,
+    after: team,
+  });
+  return team;
+}
+
+export async function listTeams(ctx: UseCaseContext): Promise<Team[]> {
+  return ctx.repo.teams.list();
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true,
+    "types": ["bun"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/scripts/generate-formula.sh
+++ b/scripts/generate-formula.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Generate a Homebrew formula for mound from release artifacts.
+#
+# Usage:
+#   scripts/generate-formula.sh <version> <owner/repo> <dist-dir> > Formula/mound.rb
+#
+# Reads <dist-dir>/mound-<version>-<platform>.tar.gz.sha256 for each platform
+# and emits a Ruby formula with the correct URL + SHA256 per arch.
+set -euo pipefail
+
+VERSION="${1:?version (e.g. v0.1.0) required}"
+REPO="${2:?owner/repo required}"
+DIST="${3:?dist dir required}"
+
+bare_version="${VERSION#v}"
+
+read_sha() {
+  local platform="$1"
+  local file="$DIST/mound-$VERSION-$platform.tar.gz.sha256"
+  if [ ! -f "$file" ]; then
+    echo "missing checksum file: $file" >&2
+    exit 1
+  fi
+  awk '{print $1}' "$file"
+}
+
+SHA_MACOS_ARM=$(read_sha macos-arm64)
+SHA_MACOS_X86=$(read_sha macos-x86_64)
+SHA_LINUX_ARM=$(read_sha linux-arm64)
+SHA_LINUX_X86=$(read_sha linux-x86_64)
+
+cat <<EOF
+class Mound < Formula
+  desc "草野球チーム向け試合成立 CLI"
+  homepage "https://github.com/$REPO"
+  version "$bare_version"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/$REPO/releases/download/$VERSION/mound-$VERSION-macos-arm64.tar.gz"
+      sha256 "$SHA_MACOS_ARM"
+    end
+    on_intel do
+      url "https://github.com/$REPO/releases/download/$VERSION/mound-$VERSION-macos-x86_64.tar.gz"
+      sha256 "$SHA_MACOS_X86"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/$REPO/releases/download/$VERSION/mound-$VERSION-linux-arm64.tar.gz"
+      sha256 "$SHA_LINUX_ARM"
+    end
+    on_intel do
+      url "https://github.com/$REPO/releases/download/$VERSION/mound-$VERSION-linux-x86_64.tar.gz"
+      sha256 "$SHA_LINUX_X86"
+    end
+  end
+
+  def install
+    if OS.mac? && Hardware::CPU.arm?
+      bin.install "mound-macos-arm64" => "mound"
+    elsif OS.mac?
+      bin.install "mound-macos-x86_64" => "mound"
+    elsif OS.linux? && Hardware::CPU.arm?
+      bin.install "mound-linux-arm64" => "mound"
+    else
+      bin.install "mound-linux-x86_64" => "mound"
+    end
+  end
+
+  test do
+    assert_match "mound 0.1.0", shell_output("#{bin}/mound --version")
+  end
+end
+EOF

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    root: "packages/core",
-    include: ["src/__tests__/**/*.test.ts"],
+    include: ["packages/*/src/__tests__/**/*.test.ts"],
     globals: false,
   },
 });


### PR DESCRIPTION
## Summary

- 旧 Next.js/Supabase スタック (`packages/core` / `packages/web` / `packages/mcp`) を撤去し、**Bun + libSQL ベースの単一バイナリ CLI `mound`** に作り直す。
- Clean Architecture (依存方向: `domain → ports → usecases → adapters` の一方向) に再編。
- バイナリ配布: GitHub Releases に 4 ターゲット tarball + checksums + Homebrew formula を自動生成。`brew install susumutomita/tap/mound` で入る。

## 主な変更

### `packages/cli/` (新規)

```
src/
├── domain/              # 純粋ロジック (I/O 非依存)
│   ├── types.ts, guards.ts, state-machine.ts
├── ports.ts             # Repository インターフェイス + UseCaseContext
├── usecases/            # ports のみ依存。DB も CLI も知らない
│   └── team / member / game / rsvp / audit / agenda / errors
└── adapters/
    ├── libsql/          # ports の libSQL 実装 + lazy migration + 型ガード経由のrow-mapper
    └── cli/             # argv → usecase → 出力 (薄い駆動層)
```

カバーする Phase 1 ループ:
\`mound init → team → member → game create → transition → rsvp set → game transition CONFIRMED → agenda → audit\`

全コマンドが \`--json\` を受け付け、エージェント / GUI 連携を想定。

### リリース基盤

- \`.github/workflows/release.yml\`: \`v*\` タグ push で macOS arm64/x86_64 + linux arm64/x86_64 をクロスビルド、Release に tarball + \`.sha256\` + \`checksums.txt\` + 生成済み \`mound.rb\` を添付
- \`scripts/generate-formula.sh\`: リリース成果物から Homebrew formula を組み立てる
- \`Formula/mound.rb\`: テンプレ (毎リリース上書き)
- ワークフローへの \`${{ inputs.* }}\` 直接埋め込みは \`env:\` マッピング経由に変更 (workflow_injection 防御)
- shellcheck を CI に追加

### ローカル開発

- \`make cli-build\` → \`bin/mound\` (現プラットフォーム単一バイナリ)
- \`make install-local\` → \`~/.local/bin/mound\` に symlink
- \`make release-build\` → 4 ターゲット tarball

## テスト

| ファイル | 役割 | 件数 |
| --- | --- | --- |
| state-machine.test.ts | domain | 7 |
| domain-guards.test.ts | domain ガード | 8 |
| usecases/game.test.ts | usecase 単体 (in-memory fake) | 3 |
| adapters/cli/args.test.ts | flag parser | 8 |
| storage.test.ts | libSQL adapter | 4 |
| agenda.test.ts | agenda 統合 | 4 |
| use-case.test.ts | CLI 統合 (run() in-process) | 4 |
| e2e-binary.test.ts | 実バイナリ spawn シナリオ | 5 |
| **計** | | **48** |

## Test plan

- [ ] \`make check\` (lint + typecheck + 48 tests) が通る
- [ ] \`make cli-build && ./bin/mound --version\` が \`mound 0.1.0\` を返す
- [ ] \`make install-local\` 後、\`mound init && mound team create --name X --json\` が JSON で結果を返す
- [ ] e2e-binary.test.ts が実バイナリ越しに Phase 1 ループを踏み抜く (5 シナリオ)
- [ ] CI の \`build\` ジョブが \`./bin/mound --version\` smoke を通す
- [ ] \`shellcheck scripts/generate-formula.sh\` が clean
- [ ] (リリース時) \`git tag v0.1.0 && git push origin v0.1.0\` で release workflow が 4 プラットフォーム tarball + \`mound.rb\` を Release に添付

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a CLI application for managing grassroots baseball teams and games with support for team/member/game management, RSVP tracking, and game state transitions.
  * Added JSON output format for machine-readable responses.
  * Implemented multi-platform release builds and Homebrew installation support.
  * Added database persistence using SQLite with libSQL client.

* **Documentation**
  * Completely redesigned README and developer guide for the new CLI product.

* **Tests**
  * Added comprehensive test coverage for CLI commands, domain logic, and end-to-end scenarios.

* **Chores**
  * Updated CI/release workflows and build configuration for CLI-focused development.
  * Added MIT License.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/mound/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->