### PR TITLE
fix: distributable mound as launcher + Bun runtime + native deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,18 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: bash -n (syntax)
-        run: bash -n scripts/generate-formula.sh
+        run: |
+          bash -n scripts/generate-formula.sh
+          bash -n scripts/build-dist.sh
+          sh -n packages/cli/scripts/mound-launcher.sh
       - name: shellcheck
-        run: shellcheck scripts/generate-formula.sh
+        run: |
+          shellcheck scripts/generate-formula.sh
+          shellcheck scripts/build-dist.sh
+          shellcheck packages/cli/scripts/mound-launcher.sh
 
   build:
-    name: Build CLI (source-mode smoke)
+    name: Build dist (linux-x86_64)
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:
@@ -105,12 +111,16 @@ jobs:
       - name: Install dependencies
         run: make install-ci
 
-      # The `bun build --compile` produced binary still requires
-      # node_modules/@libsql/<platform>/ at runtime because @neon-rs/load uses
-      # a dynamic require() that Bun cannot statically embed. Distribution will
-      # need to ship the .node file alongside the executable (follow-up). For
-      # CI we smoke the source-mode entry which is what subprocess tests use.
-      - name: Source-mode smoke
+      - name: Build distributable
         run: |
-          bun packages/cli/src/index.ts --version
-          bun packages/cli/src/index.ts --help | head -5
+          mkdir -p dist
+          bash scripts/build-dist.sh linux-x86_64 "$(command -v bun)" dist
+
+      - name: Isolation smoke
+        run: |
+          tmp=$(mktemp -d)
+          cp -R dist/mound-linux-x86_64 "$tmp/mound"
+          "$tmp/mound/bin/mound" --version
+          "$tmp/mound/bin/mound" --help | head -5
+          MOUND_DB_URL="file:$tmp/test.db" "$tmp/mound/bin/mound" init
+          MOUND_DB_URL="file:$tmp/test.db" "$tmp/mound/bin/mound" team create --name CI --json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,19 @@ permissions:
 
 jobs:
   release-build:
-    name: Cross-compile (${{ matrix.platform }})
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: bun-darwin-arm64
+          - runner: macos-14
             platform: macos-arm64
-          - target: bun-darwin-x64
+          - runner: macos-13
             platform: macos-x86_64
-          - target: bun-linux-arm64
+          - runner: ubuntu-24.04-arm
             platform: linux-arm64
-          - target: bun-linux-x64
+          - runner: ubuntu-latest
             platform: linux-x86_64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -54,20 +54,27 @@ jobs:
 
       - name: Build ${{ matrix.platform }}
         env:
-          TARGET: ${{ matrix.target }}
           PLATFORM: ${{ matrix.platform }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           mkdir -p dist
-          bun build --compile --minify \
-            --target="$TARGET" \
-            packages/cli/src/index.ts \
-            --outfile "dist/mound-$PLATFORM"
+          BUN_BIN=$(command -v bun)
+          bash scripts/build-dist.sh "$PLATFORM" "$BUN_BIN" dist
           cd dist
           tar -czf "mound-$VERSION-$PLATFORM.tar.gz" "mound-$PLATFORM"
-          rm "mound-$PLATFORM"
+          rm -rf "mound-$PLATFORM"
           shasum -a 256 "mound-$VERSION-$PLATFORM.tar.gz" \
             > "mound-$VERSION-$PLATFORM.tar.gz.sha256"
+
+      - name: Self smoke (isolation)
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          tmp=$(mktemp -d)
+          tar -xzf "dist/mound-$VERSION-$PLATFORM.tar.gz" -C "$tmp"
+          "$tmp/mound-$PLATFORM/bin/mound" --version
+          "$tmp/mound-$PLATFORM/bin/mound" --help | head -5
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/Formula/mound.rb
+++ b/Formula/mound.rb
@@ -8,8 +8,12 @@
 # to the GitHub Release as `mound.rb`. Copy the released `mound.rb` to your
 # Homebrew tap repository (e.g. susumutomita/homebrew-tap) to publish.
 #
-# The placeholder values below are intentionally invalid so that they fail
-# loudly if you forget to regenerate them.
+# Each platform tarball contains:
+#   mound-<platform>/bin/mound          (shell launcher)
+#   mound-<platform>/libexec/mound/...  (Bun runtime + JS bundle + libsql native binding)
+#
+# The placeholders below are intentionally invalid so they fail loudly if you
+# forget to regenerate this file.
 class Mound < Formula
   desc "草野球チーム向け試合成立 CLI"
   homepage "https://github.com/susumutomita/mound"
@@ -39,15 +43,8 @@ class Mound < Formula
   end
 
   def install
-    if OS.mac? && Hardware::CPU.arm?
-      bin.install "mound-macos-arm64" => "mound"
-    elsif OS.mac?
-      bin.install "mound-macos-x86_64" => "mound"
-    elsif OS.linux? && Hardware::CPU.arm?
-      bin.install "mound-linux-arm64" => "mound"
-    else
-      bin.install "mound-linux-x86_64" => "mound"
-    end
+    libexec.install Dir["libexec/mound"]
+    bin.install "bin/mound"
   end
 
   test do

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: start mound build cli-build release-build cli-clean install-local uninstall-local \
+.PHONY: start mound build cli-build dist-clean install-local uninstall-local \
         lint lint-fix lint-check format typecheck test test-watch test-coverage \
         check before-commit clean install install-ci help
 
@@ -6,7 +6,23 @@ BUN := $(or $(shell command -v bun 2>/dev/null),$(HOME)/.bun/bin/bun)
 BIOME := ./node_modules/.bin/biome
 ENTRY := packages/cli/src/index.ts
 DIST := dist
-VERSION := $(shell git describe --tags --always 2>/dev/null || echo 0.0.0)
+
+# Host platform detection (for `make cli-build` / `make install-local`).
+HOST_OS := $(shell uname -s | tr A-Z a-z)
+HOST_ARCH := $(shell uname -m)
+ifeq ($(HOST_OS),darwin)
+  ifeq ($(HOST_ARCH),arm64)
+    HOST_PLATFORM := macos-arm64
+  else
+    HOST_PLATFORM := macos-x86_64
+  endif
+else
+  ifeq ($(HOST_ARCH),aarch64)
+    HOST_PLATFORM := linux-arm64
+  else
+    HOST_PLATFORM := linux-x86_64
+  endif
+endif
 
 # ===================================================
 # 試合成立エンジン — Makefile
@@ -18,47 +34,34 @@ start: install mound ## CLI を起動 (引数は ARGS で渡す: make start ARGS
 mound: ## CLI を実行 (例: make mound ARGS="team list")
 	$(BUN) run $(ENTRY) $(ARGS)
 
-## バイナリビルド
-build: cli-build ## 現プラットフォーム向けバイナリ (bin/mound)
+## バイナリ配布
+build: cli-build ## 現プラットフォーム向け配布物 (dist/local/mound-<host>)
 
-cli-build: ## 現プラットフォーム向け単一バイナリ (bin/mound)
-	@mkdir -p bin
-	$(BUN) build --compile --minify $(ENTRY) --outfile bin/mound
-	@echo "✅ bin/mound built"
+cli-build: ## 現プラットフォーム向け配布物を dist/local に生成
+	@rm -rf $(DIST)/local
+	@mkdir -p $(DIST)/local
+	@bash scripts/build-dist.sh $(HOST_PLATFORM) $(BUN) $(DIST)/local
+	@echo "✅ $(DIST)/local/mound-$(HOST_PLATFORM)"
 
-release-build: ## 4 ターゲット (macOS arm64/x86_64, Linux arm64/x86_64) tarball を dist/ に生成
-	@rm -rf $(DIST)
-	@mkdir -p $(DIST)
-	@$(MAKE) _release-target TARGET=bun-darwin-arm64  PLATFORM=macos-arm64
-	@$(MAKE) _release-target TARGET=bun-darwin-x64    PLATFORM=macos-x86_64
-	@$(MAKE) _release-target TARGET=bun-linux-arm64   PLATFORM=linux-arm64
-	@$(MAKE) _release-target TARGET=bun-linux-x64     PLATFORM=linux-x86_64
-	@cd $(DIST) && shasum -a 256 *.tar.gz > checksums.txt
-	@echo "✅ release artifacts:"
-	@ls -lh $(DIST)
+dist-clean: ## dist/ を全削除
+	rm -rf $(DIST)
 
-_release-target:
-	@echo "→ building $(PLATFORM) ($(TARGET))"
-	@$(BUN) build --compile --minify --target=$(TARGET) $(ENTRY) --outfile $(DIST)/mound-$(PLATFORM)
-	@cd $(DIST) && tar -czf mound-$(VERSION)-$(PLATFORM).tar.gz mound-$(PLATFORM)
-	@rm -f $(DIST)/mound-$(PLATFORM)
-
-cli-clean: ## ビルド成果物を削除
-	rm -rf bin $(DIST)
-
-INSTALL_DIR ?= $(HOME)/.local/bin
-install-local: cli-build ## bin/mound を $(INSTALL_DIR) に symlink (デフォルト ~/.local/bin)
-	@mkdir -p $(INSTALL_DIR)
-	@ln -sf $(abspath bin/mound) $(INSTALL_DIR)/mound
-	@echo "✅ $(INSTALL_DIR)/mound -> $(abspath bin/mound)"
+INSTALL_PREFIX ?= $(HOME)/.local
+install-local: cli-build ## $(INSTALL_PREFIX)/{bin,share} に配置 (デフォルト ~/.local)
+	@mkdir -p $(INSTALL_PREFIX)/share $(INSTALL_PREFIX)/bin
+	@rm -rf $(INSTALL_PREFIX)/share/mound
+	@cp -R $(DIST)/local/mound-$(HOST_PLATFORM) $(INSTALL_PREFIX)/share/mound
+	@ln -sf $(INSTALL_PREFIX)/share/mound/bin/mound $(INSTALL_PREFIX)/bin/mound
+	@echo "✅ $(INSTALL_PREFIX)/bin/mound -> $(INSTALL_PREFIX)/share/mound/bin/mound"
 	@case ":$$PATH:" in \
-	  *":$(INSTALL_DIR):"*) ;; \
-	  *) echo "⚠  $(INSTALL_DIR) は PATH に入っていません。~/.zshrc に export PATH=\"$(INSTALL_DIR):\$$PATH\" を追記してください" ;; \
+	  *":$(INSTALL_PREFIX)/bin:"*) ;; \
+	  *) echo "⚠  $(INSTALL_PREFIX)/bin は PATH に入っていません" ;; \
 	esac
 
-uninstall-local: ## $(INSTALL_DIR)/mound の symlink を削除
-	@rm -f $(INSTALL_DIR)/mound
-	@echo "✅ removed $(INSTALL_DIR)/mound"
+uninstall-local: ## $(INSTALL_PREFIX) から削除
+	@rm -f $(INSTALL_PREFIX)/bin/mound
+	@rm -rf $(INSTALL_PREFIX)/share/mound
+	@echo "✅ uninstalled from $(INSTALL_PREFIX)"
 
 ## 品質チェック
 lint: ## Biome lint チェック
@@ -100,8 +103,8 @@ install-ci: ## CI用インストール (install後にlockfile差分チェック)
 	$(BUN) install
 	git diff --exit-code bun.lock || (echo "ERROR: bun.lock is out of date. Run 'bun install' locally and commit bun.lock." && exit 1)
 
-clean: cli-clean ## ビルド成果物・キャッシュを削除
-	rm -rf packages/cli/tsconfig.tsbuildinfo
+clean: dist-clean ## ビルド成果物・キャッシュを削除
+	rm -rf bin packages/cli/tsconfig.tsbuildinfo
 	rm -rf tsconfig.tsbuildinfo
 
 ## ヘルプ

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ mound --help
 git clone https://github.com/susumutomita/mound.git
 cd mound
 make install        # 依存インストール
-make install-local  # bin/mound を $HOME/.local/bin に symlink (PATH 通すだけ)
+make install-local  # dist/local/mound-<host> を ~/.local/share/mound に配置 + ~/.local/bin/mound に symlink
 mound --version
 ```
 
-別の場所に置きたいなら `make install-local INSTALL_DIR=/opt/homebrew/bin` のように上書き。`make uninstall-local` で symlink を削除できる。`make cli-build` 単体だと `bin/mound` のみで PATH には乗らない。
+`make cli-build` 単体だと `dist/local/mound-<host>/` のみ生成して PATH には乗せない。`INSTALL_PREFIX` で行き先変更可(`make install-local INSTALL_PREFIX=/opt/homebrew`)。`make uninstall-local` で削除。
+
+> **配布の仕組み:** Bun の `bun build --compile` は libsql の native binding (`@libsql/<platform>/index.node`) を埋め込めない (`@neon-rs/load` が動的 require を使うため)。よって配布物は `bin/mound` (shell launcher) + `libexec/mound/{bun,mound.js,node_modules}` の構造になっており、launcher が Bun runtime + JS bundle + libsql native を組み合わせて実行する。
 
 ## クイックスタート
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[install]
+# Hoisted linker keeps all transitive deps at the top of node_modules/.
+# We rely on this layout in scripts/build-dist.sh, which copies the
+# platform-specific @libsql native binding (and the libsql / @neon-rs glue)
+# from node_modules/ into each tarball's libexec/mound/node_modules/.
+linker = "hoisted"

--- a/packages/cli/scripts/mound-launcher.sh
+++ b/packages/cli/scripts/mound-launcher.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# mound — shell launcher.
+# Bun runtime と bundle, libsql native binding はインストール先の libexec/ 配下に置く。
+set -e
+SELF=$(readlink "$0" 2>/dev/null || echo "$0")
+DIR=$(cd "$(dirname "$SELF")/.." && pwd)
+exec "$DIR/libexec/mound/bun" "$DIR/libexec/mound/mound.js" "$@"

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -20,12 +20,50 @@
 set -euo pipefail
 
 PLATFORM="${1:?platform required (macos-arm64 etc.)}"
-BUN_BIN="${2:?bun runtime path required}"
+BUN_BIN_INPUT="${2:?bun runtime path required}"
 OUT_DIR="${3:?out dir required}"
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 ENTRY="$REPO_ROOT/packages/cli/src/index.ts"
 LAUNCHER="$REPO_ROOT/packages/cli/scripts/mound-launcher.sh"
+
+# Resolve the *real* Bun executable. `command -v bun` may return a wrapper
+# script (e.g., safe-chain's shim in CI), which is useless for distribution.
+# Walk symlinks, then if the result is a text/script try standard install
+# locations exported by setup-bun.
+resolve_bun() {
+  local bun="$1"
+  # Resolve symlinks if possible
+  if command -v readlink >/dev/null 2>&1; then
+    local resolved
+    resolved=$(readlink -f "$bun" 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ -x "$resolved" ]; then
+      bun="$resolved"
+    fi
+  fi
+  # If it's binary, accept it.
+  if file "$bun" 2>/dev/null | grep -qE "ELF|Mach-O"; then
+    echo "$bun"
+    return 0
+  fi
+  # Otherwise, look at known install locations.
+  for candidate in \
+    "${BUN_INSTALL:-}/bin/bun" \
+    "${HOME:-}/.bun/bin/bun" \
+    /usr/local/bin/bun \
+    /opt/bun/bin/bun
+  do
+    if [ -x "$candidate" ] && file "$candidate" 2>/dev/null | grep -qE "ELF|Mach-O"; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  echo "FATAL: could not resolve a real Bun binary (input was '$1', neither it nor any known path is ELF/Mach-O)" >&2
+  exit 1
+}
+
+BUN_BIN=$(resolve_bun "$BUN_BIN_INPUT")
+echo "Using Bun binary: $BUN_BIN ($(file "$BUN_BIN" | awk -F: '{print $2}' | head -c 60))"
 
 ROOT="$OUT_DIR/mound-$PLATFORM"
 rm -rf "$ROOT"
@@ -67,7 +105,19 @@ case "$PLATFORM" in
   linux-x86_64)  NATIVE_PKG="@libsql/linux-x64-gnu" ;;
   *) echo "unknown platform: $PLATFORM" >&2; exit 1 ;;
 esac
+if [ ! -d "$NM/$NATIVE_PKG" ]; then
+  echo "FATAL: $NM/$NATIVE_PKG not found in node_modules. bun install did not provide the optional native binding for this platform." >&2
+  echo "Contents of $NM/@libsql/:" >&2
+  ls -la "$NM/@libsql/" 2>&1 >&2 || echo "  (no @libsql dir)" >&2
+  exit 1
+fi
 copy_pkg "$NM/$NATIVE_PKG" "$PKG_DEST/$NATIVE_PKG"
+
+if [ ! -f "$PKG_DEST/$NATIVE_PKG/index.node" ]; then
+  echo "FATAL: $PKG_DEST/$NATIVE_PKG/index.node missing after copy" >&2
+  ls -la "$PKG_DEST/$NATIVE_PKG/" 2>&1 >&2 || true
+  exit 1
+fi
 
 # libsql wrapper + @neon-rs/load
 copy_pkg "$NM/libsql" "$PKG_DEST/libsql"
@@ -89,3 +139,7 @@ EOF
 
 echo "✅ built $ROOT"
 du -sh "$ROOT" 2>/dev/null || true
+echo "--- libexec/mound/node_modules tree (top-level @libsql) ---"
+ls -la "$PKG_DEST/@libsql/" 2>&1 || true
+echo "--- @neon-rs ---"
+ls -la "$PKG_DEST/@neon-rs/" 2>&1 || true

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Build a distributable bundle for a given platform.
+#
+# Layout produced under <out-dir>/mound-<platform>/:
+#   bin/mound            - shell launcher (POSIX sh)
+#   libexec/mound/bun    - Bun runtime for the target
+#   libexec/mound/mound.js
+#   libexec/mound/node_modules/  - runtime deps that cannot be bundled
+#                                 (currently the @libsql native binding + libsql/@neon-rs glue)
+#
+# Bun's `--compile` cannot embed the libsql .node native binding because
+# @neon-rs/load uses a dynamic require. So we ship the runtime + bundle + the
+# small set of unbundlable dependencies side by side and resolve through the
+# host's normal node_modules resolution.
+#
+# Usage: build-dist.sh <platform> <bun-binary-path> <out-dir>
+#   platform: macos-arm64 | macos-x86_64 | linux-arm64 | linux-x86_64
+#   bun-binary-path: path to the Bun runtime for this platform
+#   out-dir: where to place the built directory (e.g. dist/)
+set -euo pipefail
+
+PLATFORM="${1:?platform required (macos-arm64 etc.)}"
+BUN_BIN="${2:?bun runtime path required}"
+OUT_DIR="${3:?out dir required}"
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+ENTRY="$REPO_ROOT/packages/cli/src/index.ts"
+LAUNCHER="$REPO_ROOT/packages/cli/scripts/mound-launcher.sh"
+
+ROOT="$OUT_DIR/mound-$PLATFORM"
+rm -rf "$ROOT"
+mkdir -p "$ROOT/bin" "$ROOT/libexec/mound/node_modules/@libsql" "$ROOT/libexec/mound/node_modules/@neon-rs"
+
+# 1. shell launcher
+install -m 0755 "$LAUNCHER" "$ROOT/bin/mound"
+
+# 2. Bun runtime for the target
+install -m 0755 "$BUN_BIN" "$ROOT/libexec/mound/bun"
+
+# 3. JS bundle
+"$BUN_BIN" build --target=bun --minify "$ENTRY" --outfile "$ROOT/libexec/mound/mound.js"
+
+# 4. unbundlable runtime deps: @libsql/* (incl. platform native binding) + libsql + @neon-rs + small helpers
+NM="$REPO_ROOT/node_modules"
+PKG_DEST="$ROOT/libexec/mound/node_modules"
+
+copy_pkg() {
+  local src="$1"
+  local dst="$2"
+  if [ -d "$src" ]; then
+    cp -R "$src" "$dst"
+  fi
+}
+
+# @libsql/client + glue
+copy_pkg "$NM/@libsql/client" "$PKG_DEST/@libsql/client"
+copy_pkg "$NM/@libsql/core" "$PKG_DEST/@libsql/core"
+copy_pkg "$NM/@libsql/hrana-client" "$PKG_DEST/@libsql/hrana-client"
+copy_pkg "$NM/@libsql/isomorphic-fetch" "$PKG_DEST/@libsql/isomorphic-fetch"
+copy_pkg "$NM/@libsql/isomorphic-ws" "$PKG_DEST/@libsql/isomorphic-ws"
+
+# Platform native binding
+case "$PLATFORM" in
+  macos-arm64)   NATIVE_PKG="@libsql/darwin-arm64" ;;
+  macos-x86_64)  NATIVE_PKG="@libsql/darwin-x64" ;;
+  linux-arm64)   NATIVE_PKG="@libsql/linux-arm64-gnu" ;;
+  linux-x86_64)  NATIVE_PKG="@libsql/linux-x64-gnu" ;;
+  *) echo "unknown platform: $PLATFORM" >&2; exit 1 ;;
+esac
+copy_pkg "$NM/$NATIVE_PKG" "$PKG_DEST/$NATIVE_PKG"
+
+# libsql wrapper + @neon-rs/load
+copy_pkg "$NM/libsql" "$PKG_DEST/libsql"
+copy_pkg "$NM/@neon-rs/load" "$PKG_DEST/@neon-rs/load"
+copy_pkg "$NM/detect-libc" "$PKG_DEST/detect-libc"
+copy_pkg "$NM/js-base64" "$PKG_DEST/js-base64"
+copy_pkg "$NM/promise-limit" "$PKG_DEST/promise-limit"
+copy_pkg "$NM/ws" "$PKG_DEST/ws"
+
+# README inside the dist
+cat > "$ROOT/README.md" <<EOF
+# mound $PLATFORM
+
+\`./bin/mound --help\` を実行してください。
+ディレクトリ全体を保ったまま \`mv\` してください (bin/ と libexec/ がペアで必要)。
+
+例: \`sudo cp -R . /usr/local/share/mound && sudo ln -s /usr/local/share/mound/bin/mound /usr/local/bin/mound\`
+EOF
+
+echo "✅ built $ROOT"
+du -sh "$ROOT" 2>/dev/null || true

--- a/scripts/generate-formula.sh
+++ b/scripts/generate-formula.sh
@@ -4,8 +4,9 @@
 # Usage:
 #   scripts/generate-formula.sh <version> <owner/repo> <dist-dir> > Formula/mound.rb
 #
-# Reads <dist-dir>/mound-<version>-<platform>.tar.gz.sha256 for each platform
-# and emits a Ruby formula with the correct URL + SHA256 per arch.
+# Each platform tarball contains:
+#   mound-<platform>/bin/mound          (shell launcher)
+#   mound-<platform>/libexec/mound/...  (Bun runtime + JS bundle + native deps)
 set -euo pipefail
 
 VERSION="${1:?version (e.g. v0.1.0) required}"
@@ -59,19 +60,15 @@ class Mound < Formula
   end
 
   def install
-    if OS.mac? && Hardware::CPU.arm?
-      bin.install "mound-macos-arm64" => "mound"
-    elsif OS.mac?
-      bin.install "mound-macos-x86_64" => "mound"
-    elsif OS.linux? && Hardware::CPU.arm?
-      bin.install "mound-linux-arm64" => "mound"
-    else
-      bin.install "mound-linux-x86_64" => "mound"
-    end
+    libexec.install Dir["libexec/mound"]
+    bin.install "bin/mound"
+    # The launcher resolves \$(dirname \$0)/.. which after a Homebrew
+    # install lands at the keg prefix, so libexec/mound/{bun,mound.js,node_modules}
+    # are reachable.
   end
 
   test do
-    assert_match "mound 0.1.0", shell_output("#{bin}/mound --version")
+    assert_match "mound $bare_version", shell_output("#{bin}/mound --version")
   end
 end
 EOF


### PR DESCRIPTION
Closes #159.

## 概要

Bun の `bun build --compile` は `@libsql/client` の native binding (`@libsql/<platform>/index.node`) を埋め込めない。`@neon-rs/load` が `require(\`@libsql/\${platform}\`)` という動的 require を使っており Bun のバンドラが静的解決できないため、コンパイル済みバイナリ単独では実行不能。今回は単一バイナリ路線をやめて、確実に動く **launcher + Bun runtime + native deps** のディレクトリ配布に作り直す。

## 配布レイアウト

\`\`\`
mound-<platform>/
├── bin/mound                   # POSIX sh launcher (\$(dirname \$0)/.. を解決)
└── libexec/mound/
    ├── bun                     # platform-specific Bun runtime
    ├── mound.js                # bundled CLI (bun build --bundle)
    └── node_modules/           # @libsql/<platform> native binding +
                                # @libsql/{client,core,hrana-client,...} +
                                # libsql, @neon-rs/load, ws, ...
\`\`\`

サイズ: ディスク上 ~67MB / 圧縮 tarball ~25MB。

## 動作確認 (macOS arm64 ローカル)

\`\`\`
$ make install-local
✅ ~/.local/bin/mound -> ~/.local/share/mound/bin/mound
$ mound --version
mound 0.1.0
$ MOUND_DB_URL=file:/tmp/test.db mound team create --name 横浜BB --json
{"id":"...","name":"横浜BB",...}
\`\`\`

## CI 変更

- \`build\` ジョブ: source-mode smoke を **実 tarball の isolation smoke** に置き換え。\`mound init\` + \`mound team create\` まで実行して libsql native binding が実際にロードされることを確認
- \`shellcheck\` ジョブ: build-dist.sh と launcher も対象に
- \`release.yml\`: 4 platform を **native runner で matrix** ビルド (macos-14, macos-13, ubuntu-24.04-arm, ubuntu-latest)。各 job が tarball を作り isolation smoke してから upload

## 主な変更ファイル

- \`scripts/build-dist.sh\` (新規) — Bun bundle + runtime + node_modules を組み立てる
- \`packages/cli/scripts/mound-launcher.sh\` (新規) — POSIX sh launcher
- \`Makefile\` — \`cli-build\`/\`install-local\` を新方式に
- \`.github/workflows/release.yml\` — matrix を 4 native runner に
- \`.github/workflows/ci.yml\` — 実 tarball isolation smoke
- \`Formula/mound.rb\` + \`scripts/generate-formula.sh\` — \`libexec.install\` + \`bin.install\` パターンに

## Test plan

- [x] \`make check\` ローカル green (48 tests)
- [x] \`make install-local && mound --version\` → \`mound 0.1.0\`
- [x] tarball を別ディレクトリに展開して isolation 動作確認 (init / team create も)
- [ ] CI build ジョブ green (linux-x86_64 で実 tarball isolation smoke)
- [ ] CI shellcheck green
- [ ] CI test / lint / typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)