### PR TITLE
feat(ground-scraper): add standalone scraper CLI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ packages/
 │   │       └── cli/      # argv → usecase → 出力
 │   └── scripts/
 │       └── mound-launcher.sh   # POSIX sh launcher (配布物に同梱)
+├── ground-scraper/       # 独立 CLI: 公共予約システムをスクレイプして JSON
+│   ├── src/
+│   │   ├── adapters/     # mock / yokohama (stub) / …
+│   │   └── cli.ts        # mound-ground-scraper
+│   └── README.md
 └── menubar/              # macOS 14+ メニューバー常駐アプリ (SwiftPM)
     ├── Sources/MoundMenuBar/
     └── Tests/

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,20 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/ground-scraper": {
+      "name": "@match-engine/ground-scraper",
+      "version": "0.1.0",
+      "bin": {
+        "mound-ground-scraper": "./src/index.ts",
+      },
+      "dependencies": {
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "typescript": "^5.9.3",
+      },
+    },
   },
   "trustedDependencies": [
     "@biomejs/biome",
@@ -86,6 +100,8 @@
     "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.29", "", { "os": "win32", "cpu": "x64" }, "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg=="],
 
     "@match-engine/cli": ["@match-engine/cli@workspace:packages/cli"],
+
+    "@match-engine/ground-scraper": ["@match-engine/ground-scraper@workspace:packages/ground-scraper"],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
 

--- a/packages/ground-scraper/README.md
+++ b/packages/ground-scraper/README.md
@@ -1,0 +1,68 @@
+# mound-ground-scraper
+
+草野球グラウンドの予約システムをスクレイピングし、`GroundAvailability` JSON を stdout に吐く独立 CLI。`mound` 本体には侵入せず、将来 `mound ground import` (未実装) が ingest する想定。
+
+## 使い方
+
+```bash
+bun packages/ground-scraper/src/index.ts --list-sources --json
+bun packages/ground-scraper/src/index.ts --source mock --date 2026-06-01 --json
+bun packages/ground-scraper/src/index.ts --source yokohama --date 2026-06-01 --json   # exit 3 (未実装)
+```
+
+## 出力 schema
+
+詳細は `src/types.ts` を参照。
+
+```jsonc
+[
+  {
+    "schema_version": 1,
+    "scraped_at": "2026-05-22T10:00:00.000Z",
+    "source": "mock",
+    "ground": {
+      "id": "mock:港北:岸根",
+      "name": "岸根公園球技場 (mock)",
+      "area": "港北区",
+      "url": null
+    },
+    "date": "2026-06-01",
+    "slots": [
+      {
+        "start": "09:00",
+        "end": "12:00",
+        "available": true,
+        "reservation_key": "mock:港北:岸根|2026-06-01|09:00",
+        "price_yen": 3000,
+        "note": null
+      }
+    ]
+  }
+]
+```
+
+## Adapter
+
+| id | 実装状況 | URL |
+| --- | --- | --- |
+| `mock` | ✅ | (ダミーデータ。決定論的) |
+| `yokohama` | 🚧 stub | https://yoyaku.city.yokohama.lg.jp/ — 認証 / reCAPTCHA を要するため未実装。`exit 3` |
+
+新しいサイトの adapter を足す場合は `src/adapters/<source>.ts` を追加し、`src/cli.ts` の `SOURCES` と `dispatch` に登録する。`GroundAvailability[]` を返すこと。
+
+## Exit code
+
+| code | 意味 |
+| --- | --- |
+| 0 | 正常 |
+| 1 | 想定外エラー |
+| 2 | Usage / バリデーション |
+| 3 | adapter 未実装 (`yokohama` 等) |
+
+## 開発
+
+```bash
+bun install
+bun run --filter @match-engine/ground-scraper typecheck
+bun run test                # vitest が __tests__ を拾う
+```

--- a/packages/ground-scraper/package.json
+++ b/packages/ground-scraper/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@match-engine/ground-scraper",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "bin": {
+    "mound-ground-scraper": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/ground-scraper/src/__tests__/cli.test.ts
+++ b/packages/ground-scraper/src/__tests__/cli.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { run } from "../cli";
+import { GroundAvailabilitySchema, SourceInfoSchema } from "../types";
+
+interface CaptureRun {
+  code: number;
+  out: string[];
+  err: string[];
+}
+
+async function exec(argv: string[]): Promise<CaptureRun> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const code = await run({
+    argv,
+    stdout: (l) => out.push(l),
+    stderr: (l) => err.push(l),
+    now: () => new Date("2026-05-20T09:00:00.000Z"),
+  });
+  return { code, out, err };
+}
+
+function lastJson<T>(r: CaptureRun): T {
+  const last = r.out[r.out.length - 1];
+  if (!last) throw new Error("no output");
+  return JSON.parse(last) as T;
+}
+
+describe("mound-ground-scraper CLI", () => {
+  describe("--help / 引数なしのとき", () => {
+    it("ヘルプを出して exit 0", async () => {
+      const r1 = await exec([]);
+      expect(r1.code).toBe(0);
+      expect(r1.out.join("\n")).toContain("mound-ground-scraper");
+
+      const r2 = await exec(["--help"]);
+      expect(r2.code).toBe(0);
+      expect(r2.out.join("\n")).toContain("mound-ground-scraper");
+    });
+  });
+
+  describe("--version --json のとき", () => {
+    it("{ version } を返す", async () => {
+      const r = await exec(["--version", "--json"]);
+      expect(r.code).toBe(0);
+      expect(lastJson<{ version: string }>(r).version).toMatch(
+        /^\d+\.\d+\.\d+$/,
+      );
+    });
+  });
+
+  describe("--list-sources --json のとき", () => {
+    it("実装/未実装の adapter を schema 通り出す", async () => {
+      const r = await exec(["--list-sources", "--json"]);
+      expect(r.code).toBe(0);
+      const list = lastJson<unknown[]>(r);
+      expect(list.length).toBeGreaterThan(0);
+      for (const s of list) {
+        expect(SourceInfoSchema.safeParse(s).success).toBe(true);
+      }
+      const ids = (list as Array<{ id: string }>).map((s) => s.id);
+      expect(ids).toContain("mock");
+      expect(ids).toContain("yokohama");
+    });
+  });
+
+  describe("--source mock --date YYYY-MM-DD のとき", () => {
+    it("配列を返し、各要素が GroundAvailability schema を満たす", async () => {
+      const r = await exec([
+        "--source",
+        "mock",
+        "--date",
+        "2026-06-01",
+        "--json",
+      ]);
+      expect(r.code).toBe(0);
+      const rows = lastJson<unknown[]>(r);
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) {
+        expect(GroundAvailabilitySchema.safeParse(row).success).toBe(true);
+      }
+    });
+
+    it("text モードは表 (○/×) を出力する", async () => {
+      const r = await exec(["--source", "mock", "--date", "2026-06-01"]);
+      expect(r.code).toBe(0);
+      const text = r.out.join("\n");
+      // 少なくとも 1 つのスロットマーカが含まれる
+      expect(/[○×]/.test(text)).toBe(true);
+    });
+  });
+
+  describe("--source yokohama --date YYYY-MM-DD のとき (未実装)", () => {
+    it("exit 3 + 構造化エラー JSON (not_implemented: true)", async () => {
+      const r = await exec([
+        "--source",
+        "yokohama",
+        "--date",
+        "2026-06-01",
+        "--json",
+      ]);
+      expect(r.code).toBe(3);
+      const errLast = r.err[r.err.length - 1];
+      const j = JSON.parse(errLast as string) as {
+        ok: boolean;
+        not_implemented: boolean;
+        source: string;
+      };
+      expect(j.ok).toBe(false);
+      expect(j.not_implemented).toBe(true);
+      expect(j.source).toBe("yokohama");
+    });
+  });
+
+  describe("バリデーションエラーのとき", () => {
+    it("--source 未指定で exit 2", async () => {
+      const r = await exec(["--date", "2026-06-01", "--json"]);
+      expect(r.code).toBe(2);
+      const j = JSON.parse(r.err[r.err.length - 1] as string) as {
+        ok: boolean;
+        error: string;
+      };
+      expect(j.ok).toBe(false);
+      expect(j.error).toContain("--source");
+    });
+
+    it("--date 形式不正で exit 2", async () => {
+      const r = await exec(["--source", "mock", "--date", "06/01", "--json"]);
+      expect(r.code).toBe(2);
+    });
+
+    it("未知の source で exit 2", async () => {
+      const r = await exec([
+        "--source",
+        "unknown",
+        "--date",
+        "2026-06-01",
+        "--json",
+      ]);
+      expect(r.code).toBe(2);
+    });
+  });
+});

--- a/packages/ground-scraper/src/__tests__/mock.test.ts
+++ b/packages/ground-scraper/src/__tests__/mock.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { listMockGrounds, scrapeMock } from "../adapters/mock";
+import {
+  type GroundAvailability,
+  GroundAvailabilitySchema,
+  SCHEMA_VERSION,
+} from "../types";
+
+const FROZEN_NOW = new Date("2026-05-20T09:00:00.000Z");
+
+describe("mock adapter", () => {
+  describe("全グラウンドのとき", () => {
+    it("listMockGrounds と同数の GroundAvailability を返す", () => {
+      const rows = scrapeMock({ date: "2026-06-01", now: FROZEN_NOW });
+      expect(rows.length).toBe(listMockGrounds().length);
+    });
+
+    it("各 row が schema を満たす", () => {
+      const rows = scrapeMock({ date: "2026-06-01", now: FROZEN_NOW });
+      for (const r of rows) {
+        const parsed = GroundAvailabilitySchema.safeParse(r);
+        expect(parsed.success).toBe(true);
+        expect(r.schema_version).toBe(SCHEMA_VERSION);
+        expect(r.source).toBe("mock");
+        expect(r.date).toBe("2026-06-01");
+        expect(r.scraped_at).toBe(FROZEN_NOW.toISOString());
+        expect(r.slots.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("available の分布は決定論的 (同じ入力で同じ結果)", () => {
+      const a = scrapeMock({ date: "2026-06-01", now: FROZEN_NOW });
+      const b = scrapeMock({ date: "2026-06-01", now: FROZEN_NOW });
+      expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+
+    it("日付が違えば slots の available パターンが変わる", () => {
+      const day1 = scrapeMock({ date: "2026-06-01", now: FROZEN_NOW });
+      const day2 = scrapeMock({ date: "2026-06-02", now: FROZEN_NOW });
+      const same = (a: GroundAvailability[], b: GroundAvailability[]) =>
+        JSON.stringify(a.map((r) => r.slots)) ===
+        JSON.stringify(b.map((r) => r.slots));
+      expect(same(day1, day2)).toBe(false);
+    });
+  });
+
+  describe("ground 指定のとき", () => {
+    it("該当 1 件だけ返す", () => {
+      const id = listMockGrounds()[0]?.id as string;
+      const rows = scrapeMock({
+        date: "2026-06-01",
+        groundId: id,
+        now: FROZEN_NOW,
+      });
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.ground.id).toBe(id);
+    });
+
+    it("存在しない id だと throw する", () => {
+      expect(() =>
+        scrapeMock({
+          date: "2026-06-01",
+          groundId: "non-existent",
+          now: FROZEN_NOW,
+        }),
+      ).toThrow(/該当 ground が無い/);
+    });
+  });
+});

--- a/packages/ground-scraper/src/adapters/mock.ts
+++ b/packages/ground-scraper/src/adapters/mock.ts
@@ -1,0 +1,82 @@
+// Mock adapter: ネットワークを叩かず、決定論的なダミーデータを返す。
+// 用途:
+//   - mound 本体側 (将来の ingest コマンド) が安定した shape で結合テストできる
+//   - スクレイパ未実装サイトのフォールバック
+import type { GroundAvailability } from "../types";
+import { SCHEMA_VERSION } from "../types";
+
+export interface MockOptions {
+  date: string; // YYYY-MM-DD
+  groundId?: string;
+  now: Date;
+}
+
+// 5 つの定型グラウンド × 4 つの定型タイムスロット。
+// available は (groundId + slot) の hash で決定論的にバラつかせる。
+const GROUNDS: Array<{ id: string; name: string; area: string }> = [
+  { id: "mock:港北:岸根", name: "岸根公園球技場 (mock)", area: "港北区" },
+  { id: "mock:港北:綱島", name: "綱島公園野球場 (mock)", area: "港北区" },
+  {
+    id: "mock:神奈川:三ツ沢",
+    name: "三ツ沢公園球技場 (mock)",
+    area: "神奈川区",
+  },
+  { id: "mock:鶴見:鶴見川", name: "鶴見川河川敷 (mock)", area: "鶴見区" },
+  { id: "mock:磯子:磯子球場", name: "磯子球場 (mock)", area: "磯子区" },
+];
+
+const SLOT_TIMES: Array<{ start: string; end: string; price: number }> = [
+  { start: "09:00", end: "12:00", price: 3000 },
+  { start: "12:00", end: "15:00", price: 3000 },
+  { start: "15:00", end: "18:00", price: 3500 },
+  { start: "18:00", end: "21:00", price: 4000 },
+];
+
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  }
+  return h;
+}
+
+export function listMockGrounds(): Array<{
+  id: string;
+  name: string;
+  area: string;
+}> {
+  return GROUNDS.slice();
+}
+
+export function scrapeMock(opts: MockOptions): GroundAvailability[] {
+  const targets = opts.groundId
+    ? GROUNDS.filter((g) => g.id === opts.groundId)
+    : GROUNDS;
+  if (targets.length === 0) {
+    throw new Error(`mock adapter: 該当 ground が無い: ${opts.groundId}`);
+  }
+  const scrapedAt = opts.now.toISOString();
+  return targets.map((g) => ({
+    schema_version: SCHEMA_VERSION as 1,
+    scraped_at: scrapedAt,
+    source: "mock",
+    ground: {
+      id: g.id,
+      name: g.name,
+      area: g.area,
+      url: null,
+    },
+    date: opts.date,
+    slots: SLOT_TIMES.map((t) => {
+      const available = hash(`${g.id}|${opts.date}|${t.start}`) % 3 !== 0;
+      return {
+        start: t.start,
+        end: t.end,
+        available,
+        reservation_key: `${g.id}|${opts.date}|${t.start}`,
+        price_yen: t.price,
+        note: null,
+      };
+    }),
+  }));
+}

--- a/packages/ground-scraper/src/adapters/yokohama.ts
+++ b/packages/ground-scraper/src/adapters/yokohama.ts
@@ -1,0 +1,27 @@
+// 横浜市 公共施設予約システム adapter (stub)。
+// 実 URL: https://yoyaku.city.yokohama.lg.jp/
+//
+// 現状はネットワーク・認証実装を持たず、呼ばれたら NotYetImplementedError を投げる。
+// 構造化エラーで返すことで、上位の CLI 層が exit code と JSON を整える。
+//
+// 将来の実装方針:
+//   - 認証不要のページ (予約状況一覧) を fetch して HTML パース
+//   - 必要なら playwright で reCAPTCHA バイパス … は ToS 違反になり得るので
+//     ガイドラインを確認してから着手する。
+//   - 出力 shape は src/types.ts の GroundAvailability に必ず揃える
+
+import { NotYetImplementedError } from "../errors";
+import type { GroundAvailability } from "../types";
+
+export interface YokohamaOptions {
+  date: string; // YYYY-MM-DD
+  area?: string;
+  now: Date;
+}
+
+export function scrapeYokohama(_opts: YokohamaOptions): GroundAvailability[] {
+  throw new NotYetImplementedError(
+    "yokohama",
+    "横浜市予約システムのスクレイピングはまだ実装されていない (--source mock で代用してください)",
+  );
+}

--- a/packages/ground-scraper/src/cli.ts
+++ b/packages/ground-scraper/src/cli.ts
@@ -1,0 +1,223 @@
+// CLI 駆動層: argv → adapter → JSON / text。
+// mound の adapters/cli と思想を合わせる: --json は機械可読、なしは人間可読。
+import { z } from "zod";
+import { scrapeMock } from "./adapters/mock";
+import { scrapeYokohama } from "./adapters/yokohama";
+import { NotYetImplementedError, UsageError } from "./errors";
+import type { GroundAvailability, SourceInfo } from "./types";
+
+const HELP = `mound-ground-scraper — 草野球グラウンドの予約状況スクレイパ
+
+使い方:
+  mound-ground-scraper --source <SOURCE> --date YYYY-MM-DD [--ground <ID>] [--area <NAME>] [--json]
+  mound-ground-scraper --list-sources [--json]
+  mound-ground-scraper --help
+  mound-ground-scraper --version
+
+フラグ:
+  --source <ID>       採用するスクレイパ adapter (mock | yokohama)
+  --date YYYY-MM-DD   照会する日付 (必須)
+  --ground <ID>       特定のグラウンドだけ (任意; 省略時は対象 source の全件)
+  --area <NAME>       エリア絞り込み (yokohama のみ; 任意)
+  --json              JSON 出力 (mound 側 ingest 向け)
+  --list-sources      利用可能な adapter とその実装状況を出力
+  --help              このヘルプ
+  --version           バージョン
+
+出力 (--json):
+  GroundAvailability[] (詳細は src/types.ts 参照)
+
+Exit code:
+  0  正常終了
+  2  Usage / バリデーションエラー
+  3  指定 source が未実装 (yokohama など)
+  1  その他
+`;
+
+const VERSION = "0.1.0";
+
+const SOURCES: SourceInfo[] = [
+  {
+    id: "mock",
+    label: "Mock (テスト用ダミーデータ)",
+    implemented: true,
+    description: "決定論的なダミーデータを返す。CI と mound 結合テスト用",
+  },
+  {
+    id: "yokohama",
+    label: "横浜市 公共施設予約システム",
+    implemented: false,
+    description:
+      "https://yoyaku.city.yokohama.lg.jp/ — ログイン + reCAPTCHA を要するため未実装",
+  },
+];
+
+interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === undefined) continue;
+    if (t.startsWith("--")) {
+      const eq = t.indexOf("=");
+      if (eq > 0) {
+        flags[t.slice(2, eq)] = t.slice(eq + 1);
+      } else {
+        const key = t.slice(2);
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith("--")) {
+          flags[key] = next;
+          i++;
+        } else {
+          flags[key] = true;
+        }
+      }
+    } else {
+      positional.push(t);
+    }
+  }
+  return { positional, flags };
+}
+
+function boolFlag(
+  flags: Record<string, string | boolean>,
+  name: string,
+): boolean {
+  const v = flags[name];
+  return v === true || v === "true";
+}
+
+function strFlag(
+  flags: Record<string, string | boolean>,
+  name: string,
+): string | undefined {
+  const v = flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+const ScrapeInput = z.object({
+  source: z.enum(["mock", "yokohama"]),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "date は YYYY-MM-DD 形式"),
+  ground: z.string().min(1).optional(),
+  area: z.string().min(1).optional(),
+});
+
+export interface RunOptions {
+  argv: string[];
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+  now?: () => Date;
+}
+
+export async function run(options: RunOptions): Promise<number> {
+  const { argv, stdout, stderr } = options;
+  const now = options.now ?? (() => new Date());
+  const parsed = parseArgs(argv);
+  const json = boolFlag(parsed.flags, "json");
+
+  try {
+    if (boolFlag(parsed.flags, "version")) {
+      if (json) stdout(JSON.stringify({ version: VERSION }));
+      else stdout(`mound-ground-scraper ${VERSION}`);
+      return 0;
+    }
+    if (boolFlag(parsed.flags, "help") || argv.length === 0) {
+      stdout(HELP);
+      return 0;
+    }
+    if (boolFlag(parsed.flags, "list-sources")) {
+      if (json) {
+        stdout(JSON.stringify(SOURCES));
+      } else {
+        for (const s of SOURCES) {
+          const impl = s.implemented ? "✅" : "🚧";
+          stdout(`${impl} ${s.id.padEnd(10)} ${s.label}`);
+          stdout(`   ${s.description}`);
+        }
+      }
+      return 0;
+    }
+
+    const source = strFlag(parsed.flags, "source");
+    if (!source) throw new UsageError("--source は必須です");
+    const date = strFlag(parsed.flags, "date");
+    if (!date) throw new UsageError("--date は必須です");
+    const input = ScrapeInput.safeParse({
+      source,
+      date,
+      ground: strFlag(parsed.flags, "ground"),
+      area: strFlag(parsed.flags, "area"),
+    });
+    if (!input.success) {
+      throw new UsageError(input.error.issues.map((i) => i.message).join("; "));
+    }
+
+    const out = dispatch(input.data, now());
+
+    if (json) {
+      stdout(JSON.stringify(out));
+    } else {
+      stdout(renderText(out));
+    }
+    return 0;
+  } catch (e) {
+    if (e instanceof UsageError) {
+      stderr(
+        json
+          ? JSON.stringify({ ok: false, error: e.message })
+          : `エラー: ${e.message}`,
+      );
+      return 2;
+    }
+    if (e instanceof NotYetImplementedError) {
+      stderr(
+        json
+          ? JSON.stringify({
+              ok: false,
+              error: e.message,
+              source: e.source,
+              not_implemented: true,
+            })
+          : `エラー: ${e.message}`,
+      );
+      return 3;
+    }
+    const m = e instanceof Error ? e.message : String(e);
+    stderr(json ? JSON.stringify({ ok: false, error: m }) : `エラー: ${m}`);
+    return 1;
+  }
+}
+
+function dispatch(
+  input: z.infer<typeof ScrapeInput>,
+  now: Date,
+): GroundAvailability[] {
+  if (input.source === "mock") {
+    return scrapeMock({ date: input.date, groundId: input.ground, now });
+  }
+  // yokohama: stub が NotYetImplementedError を投げる
+  return scrapeYokohama({ date: input.date, area: input.area, now });
+}
+
+function renderText(rows: GroundAvailability[]): string {
+  if (rows.length === 0) return "(該当なし)";
+  const lines: string[] = [];
+  for (const r of rows) {
+    lines.push(`# ${r.ground.name} (${r.ground.id})`);
+    lines.push(
+      `  source=${r.source}  area=${r.ground.area ?? "-"}  date=${r.date}`,
+    );
+    for (const s of r.slots) {
+      const mark = s.available ? "○" : "×";
+      const price = s.price_yen != null ? ` ¥${s.price_yen}` : "";
+      lines.push(`  ${mark} ${s.start}-${s.end}${price}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}

--- a/packages/ground-scraper/src/errors.ts
+++ b/packages/ground-scraper/src/errors.ts
@@ -1,0 +1,20 @@
+// CLI 層が exit code に翻訳する基準。
+//   - UsageError                  → exit 2
+//   - NotYetImplementedError      → exit 3 (未実装サイトを呼んだとき)
+//   - その他 (Error)              → exit 1
+
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
+export class NotYetImplementedError extends Error {
+  readonly source: string;
+  constructor(source: string, message: string) {
+    super(message);
+    this.name = "NotYetImplementedError";
+    this.source = source;
+  }
+}

--- a/packages/ground-scraper/src/index.ts
+++ b/packages/ground-scraper/src/index.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bun
+import { run } from "./cli";
+
+const exit = await run({
+  argv: process.argv.slice(2),
+  stdout: (l) => process.stdout.write(`${l}\n`),
+  stderr: (l) => process.stderr.write(`${l}\n`),
+});
+process.exit(exit);

--- a/packages/ground-scraper/src/types.ts
+++ b/packages/ground-scraper/src/types.ts
@@ -1,0 +1,50 @@
+// mound-ground-scraper の JSON 出力スキーマ。
+// mound 本体 (将来の `mound ground import`) がこの shape をそのまま ingest できることを意図する。
+// 破壊的変更が必要になった場合は version フィールドを増やす。
+
+import { z } from "zod";
+
+export const SCHEMA_VERSION = 1;
+
+// 1 スロット = 1 時間帯の予約単位。
+// (例: 9:00-12:00 が 1 スロット、13:00-17:00 が次のスロット)
+export const SlotSchema = z.object({
+  start: z.string().regex(/^\d{2}:\d{2}$/), // "HH:MM"
+  end: z.string().regex(/^\d{2}:\d{2}$/),
+  available: z.boolean(),
+  // 公式予約システム上での参照キー (再予約画面に直接飛ぶ等に使う)。
+  // adapter が出せなければ null。
+  reservation_key: z.string().nullable().default(null),
+  price_yen: z.number().int().nullable().default(null),
+  note: z.string().nullable().default(null),
+});
+export type Slot = z.infer<typeof SlotSchema>;
+
+export const GroundSchema = z.object({
+  // (source, id) で一意になる安定 id。
+  // 例: yokohama:港北区:岸根公園球技場
+  id: z.string().min(1),
+  name: z.string().min(1),
+  area: z.string().nullable().default(null),
+  url: z.string().url().nullable().default(null),
+});
+export type Ground = z.infer<typeof GroundSchema>;
+
+export const GroundAvailabilitySchema = z.object({
+  schema_version: z.literal(SCHEMA_VERSION),
+  scraped_at: z.string(), // ISO 8601
+  source: z.string().min(1), // adapter id (mock, yokohama, ...)
+  ground: GroundSchema,
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/), // "YYYY-MM-DD"
+  slots: z.array(SlotSchema),
+});
+export type GroundAvailability = z.infer<typeof GroundAvailabilitySchema>;
+
+// `--list-sources --json` の出力。
+export const SourceInfoSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  implemented: z.boolean(),
+  description: z.string(),
+});
+export type SourceInfo = z.infer<typeof SourceInfoSchema>;

--- a/packages/ground-scraper/tsconfig.json
+++ b/packages/ground-scraper/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true,
+    "types": ["bun"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

公共施設のグラウンド予約システムから空き / キャンセル情報を JSON で吐く独立 CLI を `packages/ground-scraper/` に追加。mound 本体には侵入せず、将来 \`mound ground import\` が ingest する想定の単方向データソース。

スコープは **スクレイパ単体**(通知 / mound 側 ingest / cron は別 PR):

- `GroundAvailability` JSON schema を確定 (`schema_version: 1`)
- `mock` adapter: 決定論的なダミーデータ。CI と mound 結合テスト用
- `yokohama` adapter: stub (\`NotYetImplementedError\`, exit 3)
- CLI: \`--source\` / \`--date\` / \`--ground\` / \`--list-sources\` / \`--help\` / \`--version\` / \`--json\` 全対応

### 例

```bash
$ bun packages/ground-scraper/src/index.ts --source mock --date 2026-06-01 --ground "mock:港北:岸根" --json
[{
  \"schema_version\": 1,
  \"scraped_at\": \"2026-05-22T08:59:50.501Z\",
  \"source\": \"mock\",
  \"ground\": {\"id\": \"mock:港北:岸根\", \"name\": \"岸根公園球技場 (mock)\", ...},
  \"date\": \"2026-06-01\",
  \"slots\": [{\"start\": \"09:00\", \"end\": \"12:00\", \"available\": true, \"reservation_key\": \"...\", \"price_yen\": 3000, ...}, ...]
}]

$ bun packages/ground-scraper/src/index.ts --source yokohama --date 2026-06-01 --json
{\"ok\":false,\"error\":\"...\",\"source\":\"yokohama\",\"not_implemented\":true}
$ echo \$?
3
```

### 拡張方針

新サイトの adapter は \`src/adapters/<source>.ts\` に追加して \`src/cli.ts\` の \`SOURCES\` と \`dispatch\` に登録。\`GroundAvailability[]\` を返す契約だけ守れば mound 側との結合は崩れない。

## Test plan

- [x] \`make check\` (lint + typecheck + test) 緑 — **78 passed** (新規 15)
- [x] \`--list-sources --json\` / \`--source mock\` / \`--source yokohama\` を実バイナリ経由で動作確認
- [ ] CI (\`ci.yml\`) 緑を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ground-scraper CLI tool for scraping baseball field reservation availability data from Japanese systems.
  * Supports listing available sources and querying availability by source and date.
  * Includes a mock adapter for testing and a Yokohama adapter stub for future integration.
  * Outputs availability data as JSON with detailed slot information (times, pricing, reservation status).

* **Documentation**
  * Added comprehensive documentation for the ground-scraper package with usage examples and API reference.
  * Updated architecture diagram to reflect the new ground-scraper module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/mound/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->