### PR TITLE
feat(ground): mound ground import — ingest ground-reservation JSON

### DIFF
--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -2,7 +2,7 @@
 // `bun packages/cli/src/index.ts` 経由でソースモード実行する (--compile した bin/mound は
 // libsql の native binding を埋め込めず単独動作しないため、CI ではソースモードを使う)。
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -287,6 +287,75 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
       expect(errJson.available_transitions).toEqual(
         expect.arrayContaining(["COLLECTING", "CONFIRMED", "CANCELLED"]),
       );
+    });
+  });
+
+  describe("ground import / list (ground-reservation 連携) のとき", () => {
+    it("--file から JSON を取り込み list で読み出せる", () => {
+      const payload = {
+        schema_version: 1,
+        scraped_at: "2026-05-22T18:00:00+09:00",
+        regions: [
+          {
+            region: "yokohama",
+            records: [
+              {
+                region: "yokohama",
+                facility_name: "e2eテスト公園",
+                date_raw: "令和6年6月1日(土)",
+                date_iso: "2026-06-01",
+                time_range: "09:00-12:00",
+                status: null,
+                raw: "\n令和6年6月1日(土) 09:00-12:00 e2eテスト公園",
+              },
+            ],
+            errors: [],
+          },
+        ],
+      };
+      const jsonPath = join(dbDir, "ground-import.json");
+      writeFileSync(jsonPath, JSON.stringify(payload));
+
+      const importR = runMound(
+        ["ground", "import", "--file", jsonPath, "--json"],
+        env,
+      );
+      expect(importR.code).toBe(0);
+      const summary = parseJson<{
+        total_records: number;
+        inserted: number;
+        updated: number;
+      }>(importR.stdout);
+      expect(summary.total_records).toBe(1);
+      expect(summary.inserted).toBe(1);
+
+      const listR = runMound(
+        ["ground", "list", "--source", "yokohama", "--json"],
+        env,
+      );
+      expect(listR.code).toBe(0);
+      const slots = parseJson<
+        Array<{ source: string; facility_name: string; first_seen_at: string }>
+      >(listR.stdout);
+      expect(slots).toHaveLength(1);
+      expect(slots[0]?.facility_name).toBe("e2eテスト公園");
+
+      // 2 回目の取り込みは inserted=0 / updated=1 になる (first_seen_at を維持)
+      const importR2 = runMound(
+        ["ground", "import", "--file", jsonPath, "--json"],
+        env,
+      );
+      expect(importR2.code).toBe(0);
+      const summary2 = parseJson<{ inserted: number; updated: number }>(
+        importR2.stdout,
+      );
+      expect(summary2.inserted).toBe(0);
+      expect(summary2.updated).toBe(1);
+    });
+
+    it("--file も --stdin も無いと exit 2", () => {
+      const r = runMound(["ground", "import", "--json"], env);
+      expect(r.code).toBe(2);
     });
   });
 

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type {
   AuditLog,
   Game,
+  GroundSlot,
   Member,
   MemberRsvp,
   Rsvp,
@@ -14,6 +15,7 @@ import type {
 import type {
   AuditRepository,
   GameRepository,
+  GroundSlotRepository,
   MemberRepository,
   Repositories,
   RsvpRepository,
@@ -30,6 +32,7 @@ interface Fake {
   gameStore: Map<string, Game>;
   rsvpStore: Map<string, Rsvp>;
   auditStore: AuditLog[];
+  groundStore: Map<string, GroundSlot>;
   repo: Repositories;
 }
 
@@ -147,13 +150,29 @@ function buildFake(): Fake {
       ),
   };
 
+  const groundStore = new Map<string, GroundSlot>();
+  const groundSlots: GroundSlotRepository = {
+    upsert: async (s) => {
+      groundStore.set(s.slot_key, s);
+      return s;
+    },
+    list: async (filter) =>
+      Array.from(groundStore.values()).filter(
+        (s) =>
+          (!filter.source || s.source === filter.source) &&
+          (!filter.dateIso || s.date_iso === filter.dateIso),
+      ),
+    getByKey: async (slotKey) => groundStore.get(slotKey) ?? null,
+  };
+
   return {
     teamStore,
     memberStore,
     gameStore,
     rsvpStore,
     auditStore,
-    repo: { teams, members, games, rsvps, audit },
+    groundStore,
+    repo: { teams, members, games, rsvps, audit, groundSlots },
   };
 }
 

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import type { GroundSlot } from "../../domain/types";
+import type {
+  GroundSlotFilter,
+  GroundSlotRepository,
+  Repositories,
+  UseCaseContext,
+} from "../../ports";
+import {
+  ScrapeOutputSchema,
+  importGroundAvailability,
+  listGroundSlots,
+} from "../../usecases/ground";
+
+function fakeRepo(): {
+  store: Map<string, GroundSlot>;
+  repo: GroundSlotRepository;
+} {
+  const store = new Map<string, GroundSlot>();
+  const repo: GroundSlotRepository = {
+    upsert: async (s) => {
+      store.set(s.slot_key, s);
+      return s;
+    },
+    list: async (filter: GroundSlotFilter) =>
+      Array.from(store.values()).filter(
+        (s) =>
+          (!filter.source || s.source === filter.source) &&
+          (!filter.dateIso || s.date_iso === filter.dateIso),
+      ),
+    getByKey: async (k) => store.get(k) ?? null,
+  };
+  return { store, repo };
+}
+
+function buildCtx(opts: { now: Date; idSeed?: number }): {
+  ctx: UseCaseContext;
+  store: Map<string, GroundSlot>;
+} {
+  const { store, repo: groundSlots } = fakeRepo();
+  // 他 repository は本テストでは使わないのでダミー実装で型を満たすだけ。
+  const stub = new Proxy({}, { get: () => async () => null }) as never;
+  const repo: Repositories = {
+    teams: stub,
+    members: stub,
+    games: stub,
+    rsvps: stub,
+    audit: stub,
+    groundSlots,
+  };
+  let seed = opts.idSeed ?? 0;
+  return {
+    store,
+    ctx: {
+      repo,
+      now: () => opts.now,
+      newId: () => `gs-${++seed}`,
+    },
+  };
+}
+
+const SAMPLE_PAYLOAD = {
+  schema_version: 1,
+  scraped_at: "2026-05-22T18:00:00+09:00",
+  regions: [
+    {
+      region: "yokohama",
+      records: [
+        {
+          region: "yokohama",
+          facility_name: "こども自然公園",
+          date_raw: "令和5年11月24日(金)",
+          date_iso: "2023-11-24",
+          time_range: "19:00-21:00",
+          status: null,
+          raw: "\n令和5年11月24日(金) 19:00～21:00 こども自然公園",
+        },
+      ],
+      errors: [],
+    },
+    {
+      region: "kanagawa",
+      records: [
+        {
+          region: "kanagawa",
+          facility_name: "サーティーフォー保土ケ谷球場",
+          date_raw: "2026/06/15",
+          date_iso: "2026-06-15",
+          time_range: "09:00-13:00",
+          status: "空き",
+          raw: "\n2026/06/15 09:00～13:00 空き サーティーフォー保土ケ谷球場",
+        },
+      ],
+      errors: ["network: timeout (sample)"],
+    },
+  ],
+};
+
+describe("ScrapeOutputSchema", () => {
+  describe("ground-reservation の出力 shape を受け付けるとき", () => {
+    it("有効な payload は parse できる", () => {
+      const parsed = ScrapeOutputSchema.safeParse(SAMPLE_PAYLOAD);
+      expect(parsed.success).toBe(true);
+    });
+
+    it("schema_version が欠けていると弾く", () => {
+      const { schema_version: _drop, ...rest } = SAMPLE_PAYLOAD;
+      expect(ScrapeOutputSchema.safeParse(rest).success).toBe(false);
+    });
+  });
+});
+
+describe("importGroundAvailability use case", () => {
+  describe("初回取り込みのとき", () => {
+    it("全 record を新規挿入し inserted カウントが上がる", async () => {
+      const { ctx, store } = buildCtx({
+        now: new Date("2026-05-22T10:00:00Z"),
+      });
+      const result = await importGroundAvailability(ctx, SAMPLE_PAYLOAD);
+      expect(result.total_records).toBe(2);
+      expect(result.inserted).toBe(2);
+      expect(result.updated).toBe(0);
+      expect(store.size).toBe(2);
+    });
+
+    it("regions_with_errors に errors を含む region が乗る", async () => {
+      const { ctx } = buildCtx({ now: new Date("2026-05-22T10:00:00Z") });
+      const result = await importGroundAvailability(ctx, SAMPLE_PAYLOAD);
+      expect(result.regions_with_errors).toHaveLength(1);
+      expect(result.regions_with_errors[0]?.region).toBe("kanagawa");
+    });
+
+    it("slot_key が source|facility|date|time で組まれる", async () => {
+      const { ctx, store } = buildCtx({
+        now: new Date("2026-05-22T10:00:00Z"),
+      });
+      await importGroundAvailability(ctx, SAMPLE_PAYLOAD);
+      expect(store.has("yokohama|こども自然公園|2023-11-24|19:00-21:00")).toBe(
+        true,
+      );
+      expect(
+        store.has(
+          "kanagawa|サーティーフォー保土ケ谷球場|2026-06-15|09:00-13:00",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("2 回目の取り込みのとき", () => {
+    it("既存行は first_seen_at を保ち ingested_at を更新する", async () => {
+      const firstNow = new Date("2026-05-22T10:00:00Z");
+      const secondNow = new Date("2026-05-23T10:00:00Z");
+
+      const ctx1 = buildCtx({ now: firstNow });
+      await importGroundAvailability(ctx1.ctx, SAMPLE_PAYLOAD);
+      const beforeFirstSeen = ctx1.store.get(
+        "yokohama|こども自然公園|2023-11-24|19:00-21:00",
+      )?.first_seen_at;
+      expect(beforeFirstSeen).toBe(firstNow.toISOString());
+
+      // 同じ store を引き継ぐためコピー経由で 2 回目を回す。
+      const store = ctx1.store;
+      const ctx2: UseCaseContext = {
+        ...ctx1.ctx,
+        now: () => secondNow,
+      };
+      const result = await importGroundAvailability(ctx2, SAMPLE_PAYLOAD);
+      expect(result.inserted).toBe(0);
+      expect(result.updated).toBe(2);
+
+      const after = store.get("yokohama|こども自然公園|2023-11-24|19:00-21:00");
+      expect(after?.first_seen_at).toBe(firstNow.toISOString());
+      expect(after?.ingested_at).toBe(secondNow.toISOString());
+    });
+  });
+
+  describe("payload が壊れているとき", () => {
+    it("zod の ZodError が伝播する", async () => {
+      const { ctx } = buildCtx({ now: new Date("2026-05-22T10:00:00Z") });
+      await expect(
+        importGroundAvailability(ctx, { not: "valid" }),
+      ).rejects.toThrow();
+    });
+  });
+});
+
+describe("listGroundSlots use case", () => {
+  describe("source / date でフィルタするとき", () => {
+    it("条件に合うものだけ返す", async () => {
+      const { ctx } = buildCtx({ now: new Date("2026-05-22T10:00:00Z") });
+      await importGroundAvailability(ctx, SAMPLE_PAYLOAD);
+
+      const onlyYokohama = await listGroundSlots(ctx, { source: "yokohama" });
+      expect(onlyYokohama).toHaveLength(1);
+      expect(onlyYokohama[0]?.source).toBe("yokohama");
+
+      const onlyDate = await listGroundSlots(ctx, { dateIso: "2026-06-15" });
+      expect(onlyDate).toHaveLength(1);
+      expect(onlyDate[0]?.facility_name).toBe("サーティーフォー保土ケ谷球場");
+
+      const none = await listGroundSlots(ctx, { dateIso: "2099-01-01" });
+      expect(none).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -25,6 +25,7 @@ import { TransitionDeniedError } from "../../usecases/errors";
 import { runAgenda } from "./commands/agenda";
 import { runAudit } from "./commands/audit";
 import { runGame } from "./commands/game";
+import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
 import { runMember } from "./commands/member";
 import { runRsvp } from "./commands/rsvp";
@@ -106,6 +107,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "agenda":
         await runAgenda(subArgs, ctx, renderOpts);
+        return 0;
+      case "ground":
+        await runGround(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/commands/ground.ts
+++ b/packages/cli/src/adapters/cli/commands/ground.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import type { UseCaseContext } from "../../../ports";
+import {
+  importGroundAvailability,
+  listGroundSlots,
+} from "../../../usecases/ground";
+import { type ParsedArgs, UsageError, boolFlag, optionalFlag } from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+
+export async function runGround(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound ground <import|list>");
+  if (sub === "import") return importCommand(args, ctx, opts);
+  if (sub === "list") return listCommand(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: ground ${sub}`);
+}
+
+async function readPayload(args: ParsedArgs): Promise<unknown> {
+  const file = optionalFlag(args.flags, "file");
+  const useStdin = boolFlag(args.flags, "stdin");
+
+  if (file && useStdin) {
+    throw new UsageError("--file と --stdin は同時指定できません");
+  }
+  if (!file && !useStdin) {
+    throw new UsageError(
+      "--file <PATH> か --stdin のいずれかを指定してください",
+    );
+  }
+
+  const raw = file ? readFileSync(file, "utf-8") : await readStdin();
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new UsageError(`JSON のパースに失敗しました: ${msg}`);
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk) =>
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk),
+    );
+    process.stdin.on("end", () =>
+      resolve(Buffer.concat(chunks).toString("utf-8")),
+    );
+    process.stdin.on("error", reject);
+  });
+}
+
+async function importCommand(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const payload = await readPayload(args);
+  const result = await importGroundAvailability(ctx, payload);
+  const text = [
+    `取り込みました: ${result.total_records} 件 (新規 ${result.inserted} / 更新 ${result.updated})`,
+    `scraped_at: ${result.scraped_at}`,
+    result.regions_with_errors.length > 0
+      ? `エラー有り region: ${result.regions_with_errors.map((r) => r.region).join(", ")}`
+      : "エラー無し",
+  ].join("\n");
+  emit(result, text, opts);
+}
+
+async function listCommand(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const slots = await listGroundSlots(ctx, {
+    source: optionalFlag(args.flags, "source"),
+    dateIso: optionalFlag(args.flags, "date"),
+  });
+  emit(
+    slots,
+    formatRows(slots, [
+      "source",
+      "facility_name",
+      "date_iso",
+      "time_range",
+      "status",
+      "first_seen_at",
+    ]),
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -18,6 +18,8 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   rsvp summary --game <ID>
   audit --target <ID> [--type game|team|member]
   agenda [--team <ID>] [--horizon-days N]    いま注意すべき試合 (メニューバー向け)
+  ground import [--file PATH | --stdin]      外部スクレイパの JSON を取り込む
+  ground list [--source S] [--date YYYY-MM-DD]
 
 サブコマンドの詳細:
   mound <command> [subcommand] --help        例: mound game create --help
@@ -283,6 +285,55 @@ JSON 出力:
 
 JSON 出力:
   AuditLog[] { id, actor, action, target_type, target_id, before_json, after_json, created_at }
+`,
+
+  ground: `mound ground — 外部スクレイパ (ground-reservation 等) との接続
+
+サブコマンド:
+  ground import [--file PATH | --stdin] [--json]
+  ground list   [--source S] [--date YYYY-MM-DD] [--json]
+
+詳細:
+  mound ground import --help
+  mound ground list --help
+`,
+
+  "ground import": `mound ground import — 外部スクレイパの JSON を取り込む
+
+使い方:
+  mound ground import --file <PATH> [--json]
+  mound ground import --stdin       [--json]
+
+説明:
+  susumutomita/ground-reservation の \`ground-monitoring --json\` 出力を読み込み、
+  ground_slots テーブルに upsert する。(source, facility_name, date_iso,
+  time_range) のキーで一意。新規行のみ first_seen_at に取り込み時刻を入れる。
+
+JSON 出力:
+  {
+    "scraped_at": ISO8601,
+    "total_records": number,
+    "inserted": number,
+    "updated": number,
+    "regions_with_errors": [{ "region": string, "errors": string[] }]
+  }
+
+エラー:
+  - UsageError: --file / --stdin 未指定、JSON 不正、schema 不一致 (exit 2)
+`,
+
+  "ground list": `mound ground list — 取り込み済みの空き枠を表示
+
+使い方:
+  mound ground list [--source <SOURCE>] [--date YYYY-MM-DD] [--json]
+
+フラグ:
+  --source  (任意) スクレイパ source ID (yokohama, kanagawa, ...)
+  --date    (任意) 日付 (YYYY-MM-DD) で絞り込み
+
+JSON 出力:
+  GroundSlot[] { id, slot_key, source, facility_name, date_iso, date_raw,
+                 time_range, status, raw, scraped_at, first_seen_at, ingested_at }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -3,6 +3,7 @@ import type {
   AuditLog,
   Game,
   GameStatus,
+  GroundSlot,
   Member,
   MemberRsvp,
   Rsvp,
@@ -13,6 +14,8 @@ import type {
 import type {
   AuditRepository,
   GameRepository,
+  GroundSlotFilter,
+  GroundSlotRepository,
   MemberRepository,
   Repositories,
   RsvpRepository,
@@ -22,6 +25,7 @@ import type { DbClient } from "./client";
 import {
   rowToAuditLog,
   rowToGame,
+  rowToGroundSlot,
   rowToMember,
   rowToMemberRsvp,
   rowToRsvp,
@@ -298,6 +302,76 @@ class LibsqlAuditRepository implements AuditRepository {
   }
 }
 
+class LibsqlGroundSlotRepository implements GroundSlotRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async upsert(slot: GroundSlot): Promise<GroundSlot> {
+    // first_seen_at は新規挿入時にのみ書き込み、既存行は維持する。
+    await this.db.execute({
+      sql: `INSERT INTO ground_slots (
+              id, slot_key, source, facility_name, date_iso, date_raw,
+              time_range, status, raw, scraped_at, first_seen_at, ingested_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(slot_key) DO UPDATE SET
+              source = excluded.source,
+              facility_name = excluded.facility_name,
+              date_iso = excluded.date_iso,
+              date_raw = excluded.date_raw,
+              time_range = excluded.time_range,
+              status = excluded.status,
+              raw = excluded.raw,
+              scraped_at = excluded.scraped_at,
+              ingested_at = excluded.ingested_at`,
+      args: [
+        slot.id,
+        slot.slot_key,
+        slot.source,
+        slot.facility_name,
+        slot.date_iso,
+        slot.date_raw,
+        slot.time_range,
+        slot.status,
+        slot.raw,
+        slot.scraped_at,
+        slot.first_seen_at,
+        slot.ingested_at,
+      ],
+    });
+    const r = await this.db.execute({
+      sql: "SELECT * FROM ground_slots WHERE slot_key = ?",
+      args: [slot.slot_key],
+    });
+    if (!r.rows[0]) throw new Error("ground_slot upsert failed");
+    return rowToGroundSlot(r.rows[0]);
+  }
+
+  async list(filter: GroundSlotFilter): Promise<GroundSlot[]> {
+    const where: string[] = [];
+    const args: InValue[] = [];
+    if (filter.source) {
+      where.push("source = ?");
+      args.push(filter.source);
+    }
+    if (filter.dateIso) {
+      where.push("date_iso = ?");
+      args.push(filter.dateIso);
+    }
+    const sql = `SELECT * FROM ground_slots${
+      where.length ? ` WHERE ${where.join(" AND ")}` : ""
+    } ORDER BY date_iso ASC, time_range ASC, facility_name ASC`;
+    const r = await this.db.execute({ sql, args });
+    return r.rows.map(rowToGroundSlot);
+  }
+
+  async getByKey(slotKey: string): Promise<GroundSlot | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM ground_slots WHERE slot_key = ?",
+      args: [slotKey],
+    });
+    return r.rows[0] ? rowToGroundSlot(r.rows[0]) : null;
+  }
+}
+
 export function buildRepositories(db: DbClient): Repositories {
   return {
     teams: new LibsqlTeamRepository(db),
@@ -305,5 +379,6 @@ export function buildRepositories(db: DbClient): Repositories {
     games: new LibsqlGameRepository(db),
     rsvps: new LibsqlRsvpRepository(db),
     audit: new LibsqlAuditRepository(db),
+    groundSlots: new LibsqlGroundSlotRepository(db),
   };
 }

--- a/packages/cli/src/adapters/libsql/row-mappers.ts
+++ b/packages/cli/src/adapters/libsql/row-mappers.ts
@@ -7,6 +7,7 @@ import {
 import type {
   AuditLog,
   Game,
+  GroundSlot,
   Member,
   MemberRsvp,
   Rsvp,
@@ -86,5 +87,22 @@ export function rowToAuditLog(row: Row): AuditLog {
     before_json: nullable(row.before_json),
     after_json: nullable(row.after_json),
     created_at: str(row.created_at),
+  };
+}
+
+export function rowToGroundSlot(row: Row): GroundSlot {
+  return {
+    id: str(row.id),
+    slot_key: str(row.slot_key),
+    source: str(row.source),
+    facility_name: str(row.facility_name),
+    date_iso: nullable(row.date_iso),
+    date_raw: str(row.date_raw),
+    time_range: nullable(row.time_range),
+    status: nullable(row.status),
+    raw: str(row.raw),
+    scraped_at: str(row.scraped_at),
+    first_seen_at: str(row.first_seen_at),
+    ingested_at: str(row.ingested_at),
   };
 }

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS teams (
@@ -62,4 +62,23 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   created_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_audit_target ON audit_logs(target_type, target_id);
+
+-- 外部スクレイパ (ground-reservation 等) から取り込んだグラウンドの空き枠。
+-- slot_key = source|facility_name|date_iso|time_range で upsert する。
+CREATE TABLE IF NOT EXISTS ground_slots (
+  id TEXT PRIMARY KEY,
+  slot_key TEXT NOT NULL UNIQUE,
+  source TEXT NOT NULL,
+  facility_name TEXT NOT NULL,
+  date_iso TEXT,
+  date_raw TEXT NOT NULL,
+  time_range TEXT,
+  status TEXT,
+  raw TEXT NOT NULL,
+  scraped_at TEXT NOT NULL,
+  first_seen_at TEXT NOT NULL,
+  ingested_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ground_slots_source ON ground_slots(source);
+CREATE INDEX IF NOT EXISTS idx_ground_slots_date ON ground_slots(date_iso);
 `;

--- a/packages/cli/src/domain/types.ts
+++ b/packages/cli/src/domain/types.ts
@@ -92,3 +92,23 @@ export interface RsvpBreakdown {
   maybe: MemberRsvp[];
   no_response: MemberRsvp[];
 }
+
+// 外部スクレイパ (ground-reservation 等) から ingest した 1 件の空き枠。
+// slot_key = source|facility_name|date_iso|time_range (UNIQUE)
+//   ingest 時にこのキーで upsert する。
+// first_seen_at = 最初に観測した時刻 (新規 vs 継続を後から見るため)。
+// ingested_at   = 直近の取り込み時刻。
+export interface GroundSlot {
+  id: string;
+  slot_key: string;
+  source: string;
+  facility_name: string;
+  date_iso: string | null;
+  date_raw: string;
+  time_range: string | null;
+  status: string | null;
+  raw: string;
+  scraped_at: string;
+  first_seen_at: string;
+  ingested_at: string;
+}

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -4,6 +4,7 @@ import type {
   AuditLog,
   Game,
   GameStatus,
+  GroundSlot,
   Member,
   MemberRsvp,
   Rsvp,
@@ -48,12 +49,24 @@ export interface AuditRepository {
   list(targetType: string, targetId: string): Promise<AuditLog[]>;
 }
 
+export interface GroundSlotFilter {
+  source?: string;
+  dateIso?: string;
+}
+
+export interface GroundSlotRepository {
+  upsert(slot: GroundSlot): Promise<GroundSlot>;
+  list(filter: GroundSlotFilter): Promise<GroundSlot[]>;
+  getByKey(slotKey: string): Promise<GroundSlot | null>;
+}
+
 export interface Repositories {
   teams: TeamRepository;
   members: MemberRepository;
   games: GameRepository;
   rsvps: RsvpRepository;
   audit: AuditRepository;
+  groundSlots: GroundSlotRepository;
 }
 
 export interface Clock {

--- a/packages/cli/src/usecases/ground.ts
+++ b/packages/cli/src/usecases/ground.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import type { GroundSlot } from "../domain/types";
+import type { GroundSlotFilter, UseCaseContext } from "../ports";
+
+// ground-reservation (susumutomita/ground-reservation) の `--json` 出力 schema。
+// 破壊的変更が必要になったら schema_version を上げる。
+// 参考: ground-reservation/app/availability/record.py
+const AvailabilityRecordSchema = z.object({
+  region: z.string().min(1),
+  facility_name: z.string().min(1),
+  date_raw: z.string(),
+  date_iso: z.string().nullable(),
+  time_range: z.string().nullable(),
+  status: z.string().nullable(),
+  raw: z.string(),
+});
+
+const RegionResultSchema = z.object({
+  region: z.string().min(1),
+  records: z.array(AvailabilityRecordSchema),
+  errors: z.array(z.string()),
+});
+
+export const ScrapeOutputSchema = z.object({
+  schema_version: z.number().int().positive(),
+  scraped_at: z.string().min(1),
+  regions: z.array(RegionResultSchema),
+});
+
+export type ScrapeOutput = z.infer<typeof ScrapeOutputSchema>;
+
+export interface ImportGroundResult {
+  scraped_at: string;
+  total_records: number;
+  inserted: number; // 新規 (first_seen_at が今回の取り込みと一致)
+  updated: number; // 既存 (first_seen_at は前回以前)
+  regions_with_errors: Array<{ region: string; errors: string[] }>;
+}
+
+function makeSlotKey(
+  source: string,
+  facility: string,
+  dateIso: string | null,
+  timeRange: string | null,
+): string {
+  // SQLite の UNIQUE は NULL を別々と扱うので、null をプレースホルダ文字に潰す。
+  return [source, facility, dateIso ?? "", timeRange ?? ""].join("|");
+}
+
+export async function importGroundAvailability(
+  ctx: UseCaseContext,
+  payload: unknown,
+): Promise<ImportGroundResult> {
+  // 未知フィールドが増えても受けられるよう strict parse はせず、必要キーだけ検証。
+  const data = ScrapeOutputSchema.parse(payload);
+  const ingestedAt = ctx.now().toISOString();
+
+  let inserted = 0;
+  let updated = 0;
+  let total = 0;
+  const regionsWithErrors: Array<{ region: string; errors: string[] }> = [];
+
+  for (const region of data.regions) {
+    if (region.errors.length > 0) {
+      regionsWithErrors.push({ region: region.region, errors: region.errors });
+    }
+    for (const rec of region.records) {
+      total += 1;
+      const slotKey = makeSlotKey(
+        rec.region,
+        rec.facility_name,
+        rec.date_iso,
+        rec.time_range,
+      );
+      const existing = await ctx.repo.groundSlots.getByKey(slotKey);
+      const firstSeenAt = existing?.first_seen_at ?? ingestedAt;
+      const slot: GroundSlot = {
+        id: existing?.id ?? ctx.newId(),
+        slot_key: slotKey,
+        source: rec.region,
+        facility_name: rec.facility_name,
+        date_iso: rec.date_iso,
+        date_raw: rec.date_raw,
+        time_range: rec.time_range,
+        status: rec.status,
+        raw: rec.raw,
+        scraped_at: data.scraped_at,
+        first_seen_at: firstSeenAt,
+        ingested_at: ingestedAt,
+      };
+      await ctx.repo.groundSlots.upsert(slot);
+      if (existing) {
+        updated += 1;
+      } else {
+        inserted += 1;
+      }
+    }
+  }
+
+  return {
+    scraped_at: data.scraped_at,
+    total_records: total,
+    inserted,
+    updated,
+    regions_with_errors: regionsWithErrors,
+  };
+}
+
+export async function listGroundSlots(
+  ctx: UseCaseContext,
+  filter: GroundSlotFilter,
+): Promise<GroundSlot[]> {
+  return ctx.repo.groundSlots.list(filter);
+}


### PR DESCRIPTION
## Summary

[ground-reservation#114](https://github.com/susumutomita/ground-reservation/pull/114) で追加した \`ground-monitoring --json\` の出力を、mound 側で受け取って \`ground_slots\` テーブルに upsert する。状態管理と将来のキャンセル検知の基盤。

### 使い方

\`\`\`bash
# パイプで直接
ground-monitoring --region all --json | mound ground import --stdin --json

# ファイル経由
ground-monitoring --region all --json > /tmp/scrape.json
mound ground import --file /tmp/scrape.json --json

# 取り込み済みを確認
mound ground list --source yokohama --date 2026-06-01 --json
\`\`\`

### Import 出力 (--json)

\`\`\`json
{
  "scraped_at": "2026-05-22T19:02:06.166497+09:00",
  "total_records": 7,
  "inserted": 3,
  "updated": 4,
  "regions_with_errors": [{"region": "kanagawa", "errors": ["..."]}]
}
\`\`\`

### スコープ

- **domain** \`GroundSlot\` (slot_key, source, facility_name, date_iso, date_raw, time_range, status, raw, scraped_at, first_seen_at, ingested_at)
- **ports** \`GroundSlotRepository\` (upsert / list / getByKey)
- **libsql** \`SCHEMA_VERSION\` 1→2 + \`ground_slots\` テーブル + 2 index。lazy migration が走るので既存 DB も無痛で v2 になる
- **usecase** \`importGroundAvailability(ctx, payload)\` — zod で payload を検証、(source, facility, date, time) の slot_key で upsert。既存行は \`first_seen_at\` を維持して \`ingested_at\` / \`scraped_at\` のみ更新
- **CLI** \`mound ground import [--file PATH | --stdin]\`、\`mound ground list [--source S] [--date YYYY-MM-DD]\`。サブコマンド別 \`--help\` も追加

## Test plan

- [x] \`make check\` (lint + typecheck + test) 緑 — **73 passed** (新規 11)
- [x] 実バイナリで end-to-end 確認: ground-reservation \`--json\` → \`mound ground import --file\` (inserted=1) → \`mound ground list\` で読み出せる → 同 JSON を \`--stdin\` で再 import (inserted=0, updated=1, first_seen_at 維持)
- [ ] CI 緑を確認

## 将来

- **task 2**: 連続 import の diff から cancellation (\`first_seen_at\` >= ある時刻 の slot) を検知
- **task 3**: 検知結果を webhook で push
- **task 4**: ground-reservation 側に release build を整え、\`mound ground sync --region all\` で mound から自前 spawn できるようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ground import` command to import ground availability data from JSON via file or stdin input.
  * Added `ground list` command to view imported ground availability with optional filtering by source and date.
  * Import results now display insertion/update counts and region error summaries.
  * Re-importing existing data correctly tracks updated records while preserving original timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/mound/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->