### PR TITLE
feat(notify): webhook notifications for game transitions and ground cancellations

### DIFF
--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -48,7 +48,11 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
 
   beforeAll(() => {
     dbDir = mkdtempSync(join(tmpdir(), "mound-e2e-"));
-    env = { MOUND_DB_URL: `file:${join(dbDir, "deep", "mound.db")}` };
+    env = {
+      MOUND_DB_URL: `file:${join(dbDir, "deep", "mound.db")}`,
+      // 実 HTTP を叩かないよう log-only で起動
+      MOUND_NOTIFY_MODE: "log-only",
+    };
   });
 
   describe("セットアップのとき", () => {
@@ -461,6 +465,110 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
         env,
       );
       expect(r.code).toBe(2);
+    });
+  });
+
+  describe("notify チャネル管理のとき", () => {
+    it("add / list / remove のひと通りができる", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "通知テスト", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+
+      const addR = runMound(
+        [
+          "notify",
+          "add",
+          "--team",
+          team.id,
+          "--kind",
+          "DISCORD",
+          "--webhook",
+          "https://discord.com/api/webhooks/dummy",
+          "--label",
+          "main",
+          "--json",
+        ],
+        env,
+      );
+      expect(addR.code).toBe(0);
+      const channel = parseJson<{ id: string; enabled: boolean }>(addR.stdout);
+      expect(channel.enabled).toBe(true);
+
+      const listR = runMound(
+        ["notify", "list", "--team", team.id, "--json"],
+        env,
+      );
+      expect(listR.code).toBe(0);
+      expect(parseJson<unknown[]>(listR.stdout)).toHaveLength(1);
+
+      // log-only モードなのでテスト送信は ok=true で返るはず
+      const testR = runMound(
+        ["notify", "test", channel.id, "--message", "hello", "--json"],
+        env,
+      );
+      expect(testR.code).toBe(0);
+      const result = parseJson<{ ok: boolean; channel_kind: string }>(
+        testR.stdout,
+      );
+      expect(result.ok).toBe(true);
+      expect(result.channel_kind).toBe("DISCORD");
+      // log-only sender が stderr に書き出すので mound からのテスト通知が乗る
+      expect(testR.stderr).toContain("[notify:DISCORD]");
+
+      const removeR = runMound(["notify", "remove", channel.id, "--json"], env);
+      expect(removeR.code).toBe(0);
+      expect(parseJson<{ ok: boolean }>(removeR.stdout).ok).toBe(true);
+
+      const list2R = runMound(
+        ["notify", "list", "--team", team.id, "--json"],
+        env,
+      );
+      expect(parseJson<unknown[]>(list2R.stdout)).toEqual([]);
+    });
+
+    it("game transition 後に log-only sender が stderr に書き出す", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "遷移通知テスト", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+      runMound(
+        [
+          "notify",
+          "add",
+          "--team",
+          team.id,
+          "--kind",
+          "SLACK",
+          "--webhook",
+          "https://hooks.slack.com/services/dummy",
+          "--json",
+        ],
+        env,
+      );
+      const gR = runMound(
+        [
+          "game",
+          "create",
+          "--team",
+          team.id,
+          "--title",
+          "遷移通知の試合",
+          "--json",
+        ],
+        env,
+      );
+      const game = parseJson<{ id: string }>(gR.stdout);
+      const tx = runMound(
+        ["game", "transition", game.id, "--to", "COLLECTING", "--json"],
+        env,
+      );
+      expect(tx.code).toBe(0);
+      // sender が log-only → stderr に "[notify:SLACK]" + DRAFT → COLLECTING が出るはず
+      expect(tx.stderr).toContain("[notify:SLACK]");
+      expect(tx.stderr).toContain("DRAFT → COLLECTING");
     });
   });
 

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -7,6 +7,7 @@ import type {
   GroundSlot,
   Member,
   MemberRsvp,
+  NotificationChannel,
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
@@ -17,6 +18,8 @@ import type {
   GameRepository,
   GroundSlotRepository,
   MemberRepository,
+  NotificationChannelRepository,
+  NotificationSender,
   Repositories,
   RsvpRepository,
   TeamRepository,
@@ -33,6 +36,8 @@ interface Fake {
   rsvpStore: Map<string, Rsvp>;
   auditStore: AuditLog[];
   groundStore: Map<string, GroundSlot>;
+  notificationStore: Map<string, NotificationChannel>;
+  notifierCalls: Array<{ channel: NotificationChannel; message: string }>;
   repo: Repositories;
 }
 
@@ -172,6 +177,24 @@ function buildFake(): Fake {
     getByKey: async (slotKey) => groundStore.get(slotKey) ?? null,
   };
 
+  const notificationStore = new Map<string, NotificationChannel>();
+  const notifications: NotificationChannelRepository = {
+    insert: async (c) => {
+      notificationStore.set(c.id, c);
+      return c;
+    },
+    list: async (teamId) =>
+      Array.from(notificationStore.values()).filter(
+        (c) => c.team_id === teamId,
+      ),
+    listEnabled: async (teamId) =>
+      Array.from(notificationStore.values()).filter(
+        (c) => c.team_id === teamId && c.enabled,
+      ),
+    get: async (id) => notificationStore.get(id) ?? null,
+    remove: async (id) => notificationStore.delete(id),
+  };
+
   return {
     teamStore,
     memberStore,
@@ -179,7 +202,33 @@ function buildFake(): Fake {
     rsvpStore,
     auditStore,
     groundStore,
-    repo: { teams, members, games, rsvps, audit, groundSlots },
+    notificationStore,
+    notifierCalls: [],
+    repo: {
+      teams,
+      members,
+      games,
+      rsvps,
+      audit,
+      groundSlots,
+      notifications,
+    },
+  };
+}
+
+// 送信を記録するだけの fake notifier。テストから .calls を見て検証する。
+function buildFakeNotifier(fake: Fake): NotificationSender {
+  return {
+    send: async (channel, message) => {
+      fake.notifierCalls.push({ channel, message });
+      return {
+        channel_id: channel.id,
+        channel_kind: channel.kind,
+        ok: true,
+        status_code: null,
+        error: null,
+      };
+    },
   };
 }
 
@@ -188,6 +237,7 @@ function createCtx(): { ctx: UseCaseContext; fake: Fake } {
   let counter = 0;
   const ctx: UseCaseContext = {
     repo: fake.repo,
+    notifier: buildFakeNotifier(fake),
     now: () => new Date("2026-05-20T09:00:00.000Z"),
     newId: () => `id-${++counter}`,
   };
@@ -238,6 +288,48 @@ describe("createGame use case", () => {
 });
 
 describe("transitionGame use case", () => {
+  describe("通知チャネルがあるとき", () => {
+    it("遷移成功後に登録チャネルへ通知を送る", async () => {
+      const { ctx, fake } = createCtx();
+      await fake.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await fake.repo.games.insert({
+        id: "g",
+        team_id: "t",
+        title: "練習試合",
+        status: "DRAFT",
+        game_date: "2026-06-01",
+        ground_name: "公園",
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await fake.repo.notifications.insert({
+        id: "ch1",
+        team_id: "t",
+        kind: "DISCORD",
+        webhook_url: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+        enabled: true,
+        created_at: "x",
+        updated_at: "x",
+      });
+
+      const after = await transitionGame(ctx, "g", "COLLECTING");
+      expect(after.status).toBe("COLLECTING");
+      expect(fake.notifierCalls).toHaveLength(1);
+      expect(fake.notifierCalls[0]?.message).toContain("DRAFT → COLLECTING");
+    });
+  });
+
   describe("人数不足のとき", () => {
     it("CONFIRMED への遷移を拒否する", async () => {
       const { ctx, fake } = createCtx();

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -55,12 +55,23 @@ function buildCtx(opts: { now: Date; idSeed?: number }): {
     rsvps: stub,
     audit: stub,
     groundSlots,
+    notifications: stub,
+  };
+  const notifier = {
+    send: async () => ({
+      channel_id: "stub",
+      channel_kind: "stub",
+      ok: true,
+      status_code: null,
+      error: null,
+    }),
   };
   let seed = opts.idSeed ?? 0;
   return {
     store,
     ctx: {
       repo,
+      notifier,
       now: () => opts.now,
       newId: () => `gs-${++seed}`,
     },

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Game,
+  GroundSlot,
+  NotificationChannel,
+  Team,
+} from "../../domain/types";
+import type {
+  GroundSlotRepository,
+  NotificationChannelRepository,
+  NotificationDeliveryResult,
+  NotificationSender,
+  Repositories,
+  TeamRepository,
+  UseCaseContext,
+} from "../../ports";
+import {
+  addNotificationChannel,
+  listNotificationChannels,
+  notifyGameTransition,
+  notifyGroundCancellation,
+  removeNotificationChannel,
+  testNotificationChannel,
+} from "../../usecases/notification";
+
+interface Fake {
+  teams: Map<string, Team>;
+  channels: Map<string, NotificationChannel>;
+  notifierCalls: Array<{ channel: NotificationChannel; message: string }>;
+  ctx: UseCaseContext;
+}
+
+function buildFake(opts?: { senderError?: Error }): Fake {
+  const teams = new Map<string, Team>();
+  const channels = new Map<string, NotificationChannel>();
+  const notifierCalls: Array<{
+    channel: NotificationChannel;
+    message: string;
+  }> = [];
+
+  const teamRepo: TeamRepository = {
+    insert: async (t) => {
+      teams.set(t.id, t);
+      return t;
+    },
+    list: async () => Array.from(teams.values()),
+    get: async (id) => teams.get(id) ?? null,
+  };
+
+  const notificationRepo: NotificationChannelRepository = {
+    insert: async (c) => {
+      channels.set(c.id, c);
+      return c;
+    },
+    list: async (teamId) =>
+      Array.from(channels.values()).filter((c) => c.team_id === teamId),
+    listEnabled: async (teamId) =>
+      Array.from(channels.values()).filter(
+        (c) => c.team_id === teamId && c.enabled,
+      ),
+    get: async (id) => channels.get(id) ?? null,
+    remove: async (id) => channels.delete(id),
+  };
+
+  const stub = new Proxy({}, { get: () => async () => null }) as never;
+
+  // GroundSlotRepository だけは型を埋めるためのスタブ。本テストでは使わない。
+  const groundSlots: GroundSlotRepository = stub;
+
+  const repo: Repositories = {
+    teams: teamRepo,
+    members: stub,
+    games: stub,
+    rsvps: stub,
+    audit: stub,
+    groundSlots,
+    notifications: notificationRepo,
+  };
+
+  const notifier: NotificationSender = {
+    send: async (channel, message): Promise<NotificationDeliveryResult> => {
+      notifierCalls.push({ channel, message });
+      if (opts?.senderError) throw opts.senderError;
+      return {
+        channel_id: channel.id,
+        channel_kind: channel.kind,
+        ok: true,
+        status_code: null,
+        error: null,
+      };
+    },
+  };
+
+  let seq = 0;
+  const ctx: UseCaseContext = {
+    repo,
+    notifier,
+    now: () => new Date("2026-05-22T10:00:00.000Z"),
+    newId: () => `n-${++seq}`,
+  };
+
+  return { teams, channels, notifierCalls, ctx };
+}
+
+async function seedTeam(fake: Fake, id: string): Promise<void> {
+  await fake.ctx.repo.teams.insert({
+    id,
+    name: id,
+    home_area: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+describe("addNotificationChannel", () => {
+  describe("チームが存在するとき", () => {
+    it("enabled=true で保存される", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      const channel = await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/abc",
+        secret: null,
+        target: null,
+        label: "main",
+      });
+      expect(channel.id).toBe("n-1");
+      expect(channel.enabled).toBe(true);
+      expect(channel.kind).toBe("DISCORD");
+    });
+  });
+
+  describe("チームが存在しないとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const fake = buildFake();
+      await expect(
+        addNotificationChannel(fake.ctx, {
+          teamId: "ghost",
+          kind: "DISCORD",
+          webhookUrl: "https://discord.com/api/webhooks/abc",
+          secret: null,
+          target: null,
+          label: null,
+        }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+});
+
+describe("listNotificationChannels", () => {
+  describe("複数チームのとき", () => {
+    it("指定チームの channel だけ返す", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      await seedTeam(fake, "t2");
+      await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      await addNotificationChannel(fake.ctx, {
+        teamId: "t2",
+        kind: "SLACK",
+        webhookUrl: "https://hooks.slack.com/y",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      const onlyT1 = await listNotificationChannels(fake.ctx, "t1");
+      expect(onlyT1).toHaveLength(1);
+      expect(onlyT1[0]?.team_id).toBe("t1");
+    });
+  });
+});
+
+describe("removeNotificationChannel", () => {
+  describe("存在する ID のとき", () => {
+    it("true を返して以後 list に出ない", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      const c = await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      const ok = await removeNotificationChannel(fake.ctx, c.id);
+      expect(ok).toBe(true);
+      expect(await listNotificationChannels(fake.ctx, "t1")).toEqual([]);
+    });
+  });
+
+  describe("存在しない ID のとき", () => {
+    it("false を返す", async () => {
+      const fake = buildFake();
+      const ok = await removeNotificationChannel(fake.ctx, "missing");
+      expect(ok).toBe(false);
+    });
+  });
+});
+
+describe("testNotificationChannel", () => {
+  describe("チャネルが存在するとき", () => {
+    it("notifier に send を呼んで結果を返す", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      const c = await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      const result = await testNotificationChannel(fake.ctx, c.id, "hi");
+      expect(result?.ok).toBe(true);
+      expect(fake.notifierCalls).toHaveLength(1);
+      expect(fake.notifierCalls[0]?.message).toBe("hi");
+    });
+  });
+
+  describe("チャネルが存在しないとき", () => {
+    it("null を返し send は呼ばれない", async () => {
+      const fake = buildFake();
+      const result = await testNotificationChannel(fake.ctx, "missing", "x");
+      expect(result).toBeNull();
+      expect(fake.notifierCalls).toHaveLength(0);
+    });
+  });
+});
+
+describe("notifyGameTransition", () => {
+  describe("enabled channel が複数あるとき", () => {
+    it("全 channel に message を送る", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "SLACK",
+        webhookUrl: "https://hooks.slack.com/y",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      const game: Game = {
+        id: "g1",
+        team_id: "t1",
+        title: "練習試合",
+        status: "CONFIRMED",
+        game_date: "2026-06-01",
+        ground_name: "公園グラウンド",
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      };
+      const results = await notifyGameTransition(
+        fake.ctx,
+        game,
+        "COLLECTING",
+        "CONFIRMED",
+      );
+      expect(results).toHaveLength(2);
+      const messages = fake.notifierCalls.map((c) => c.message);
+      expect(messages[0]).toContain("COLLECTING → CONFIRMED");
+      expect(messages[0]).toContain("練習試合");
+    });
+  });
+
+  describe("channel が無いとき", () => {
+    it("notifier を呼ばず空配列を返す", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      const game: Game = {
+        id: "g1",
+        team_id: "t1",
+        title: "x",
+        status: "DRAFT",
+        game_date: null,
+        ground_name: null,
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      };
+      const results = await notifyGameTransition(
+        fake.ctx,
+        game,
+        "DRAFT",
+        "COLLECTING",
+      );
+      expect(results).toEqual([]);
+      expect(fake.notifierCalls).toEqual([]);
+    });
+  });
+
+  describe("notifier が例外を投げるとき", () => {
+    it("失敗結果を ok=false で返し、伝播はしない", async () => {
+      const fake = buildFake({ senderError: new Error("network down") });
+      await seedTeam(fake, "t1");
+      await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      const game: Game = {
+        id: "g1",
+        team_id: "t1",
+        title: "x",
+        status: "CONFIRMED",
+        game_date: null,
+        ground_name: null,
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      };
+      const results = await notifyGameTransition(
+        fake.ctx,
+        game,
+        "COLLECTING",
+        "CONFIRMED",
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.ok).toBe(false);
+      expect(results[0]?.error).toContain("network down");
+    });
+  });
+});
+
+describe("notifyGroundCancellation", () => {
+  describe("slot が 0 件のとき", () => {
+    it("notifier を呼ばずに空配列を返す", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      const results = await notifyGroundCancellation(fake.ctx, "t1", []);
+      expect(results).toEqual([]);
+      expect(fake.notifierCalls).toEqual([]);
+    });
+  });
+
+  describe("slot が複数あるとき", () => {
+    it("先頭 10 件までを含む 1 通を送る", async () => {
+      const fake = buildFake();
+      await seedTeam(fake, "t1");
+      await addNotificationChannel(fake.ctx, {
+        teamId: "t1",
+        kind: "DISCORD",
+        webhookUrl: "https://discord.com/api/webhooks/x",
+        secret: null,
+        target: null,
+        label: null,
+      });
+      const slots: GroundSlot[] = Array.from({ length: 12 }, (_, i) => ({
+        id: `s${i}`,
+        slot_key: `k${i}`,
+        source: "yokohama",
+        facility_name: `球場${i}`,
+        date_iso: "2026-06-15",
+        date_raw: "2026/06/15",
+        time_range: "09:00-12:00",
+        status: null,
+        raw: "",
+        scraped_at: "x",
+        first_seen_at: "x",
+        ingested_at: "x",
+      }));
+      const results = await notifyGroundCancellation(fake.ctx, "t1", slots);
+      expect(results).toHaveLength(1);
+      const message = fake.notifierCalls[0]?.message ?? "";
+      expect(message).toContain("12 件の空き");
+      expect(message).toContain("球場0");
+      expect(message).toContain("ほか 2 件");
+    });
+  });
+});

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -21,6 +21,7 @@ function isUserError(e: unknown): boolean {
   if (e instanceof Error && USER_ERROR_NAMES.has(e.name)) return true;
   return false;
 }
+import type { NotificationSender } from "../../ports";
 import { TransitionDeniedError } from "../../usecases/errors";
 import { runAgenda } from "./commands/agenda";
 import { runAudit } from "./commands/audit";
@@ -28,6 +29,7 @@ import { runGame } from "./commands/game";
 import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
 import { runMember } from "./commands/member";
+import { runNotify } from "./commands/notify";
 import { runRsvp } from "./commands/rsvp";
 import { runTeam } from "./commands/team";
 import { composeContext } from "./compose";
@@ -48,6 +50,7 @@ export interface RunOptions {
   db?: DbClient;
   now?: () => Date;
   newId?: () => string;
+  notifier?: NotificationSender;
 }
 
 export async function run(options: RunOptions): Promise<number> {
@@ -82,8 +85,10 @@ export async function run(options: RunOptions): Promise<number> {
     }
     const ctx = composeContext({
       db,
+      env: options.env,
       now: options.now ?? (() => new Date()),
       newId: options.newId ?? (() => crypto.randomUUID()),
+      notifier: options.notifier,
     });
 
     switch (command) {
@@ -110,6 +115,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "ground":
         await runGround(subArgs, ctx, renderOpts);
+        return 0;
+      case "notify":
+        await runNotify(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/commands/ground.ts
+++ b/packages/cli/src/adapters/cli/commands/ground.ts
@@ -6,6 +6,7 @@ import {
   importGroundAvailability,
   listGroundSlots,
 } from "../../../usecases/ground";
+import { notifyGroundCancellation } from "../../../usecases/notification";
 import { type ParsedArgs, UsageError, boolFlag, optionalFlag } from "../args";
 import { type RenderOptions, emit, formatRows } from "../output";
 import { parseOrUsage } from "../zod-helper";
@@ -135,7 +136,24 @@ async function diffCommand(
     source: optionalFlag(args.flags, "source"),
     dateIso: optionalFlag(args.flags, "game-date"),
   });
-  const result = { since, count: slots.length, slots };
+
+  // --notify --team T が同時にあれば、検出結果をそのチームの enabled channel に push。
+  let notifications: unknown[] = [];
+  const shouldNotify = boolFlag(args.flags, "notify");
+  if (shouldNotify) {
+    const teamId = optionalFlag(args.flags, "team");
+    if (!teamId) {
+      throw new UsageError("--notify を指定したら --team も必要です");
+    }
+    notifications = await notifyGroundCancellation(ctx, teamId, slots);
+  }
+
+  const result = {
+    since,
+    count: slots.length,
+    slots,
+    ...(shouldNotify ? { notifications } : {}),
+  };
   const text =
     slots.length === 0
       ? `since ${since} 以降の新規空きはありません`
@@ -149,6 +167,9 @@ async function diffCommand(
             "status",
             "first_seen_at",
           ]),
-        ].join("\n");
+          shouldNotify ? `通知送信: ${notifications.length} 件` : "",
+        ]
+          .filter(Boolean)
+          .join("\n");
   emit(result, text, opts);
 }

--- a/packages/cli/src/adapters/cli/commands/notify.ts
+++ b/packages/cli/src/adapters/cli/commands/notify.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { NOTIFICATION_KINDS } from "../../../domain/types";
+import type { UseCaseContext } from "../../../ports";
+import {
+  addNotificationChannel,
+  listNotificationChannels,
+  removeNotificationChannel,
+  testNotificationChannel,
+} from "../../../usecases/notification";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const addInput = z.object({
+  teamId: z.string().min(1),
+  kind: z.enum(NOTIFICATION_KINDS),
+  webhookUrl: z.string().url("--webhook は URL を指定してください"),
+  secret: z.string().min(1).optional(),
+  target: z.string().min(1).optional(),
+  label: z.string().max(80).optional(),
+});
+
+export async function runNotify(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound notify <add|list|remove|test>");
+  if (sub === "add") return addCmd(args, ctx, opts);
+  if (sub === "list") return listCmd(args, ctx, opts);
+  if (sub === "remove") return removeCmd(args, ctx, opts);
+  if (sub === "test") return testCmd(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: notify ${sub}`);
+}
+
+async function addCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(addInput, {
+    teamId: requireFlag(args.flags, "team"),
+    kind: requireFlag(args.flags, "kind"),
+    webhookUrl: requireFlag(args.flags, "webhook"),
+    secret: optionalFlag(args.flags, "secret"),
+    target: optionalFlag(args.flags, "target"),
+    label: optionalFlag(args.flags, "label"),
+  });
+  const channel = await addNotificationChannel(ctx, {
+    teamId: data.teamId,
+    kind: data.kind,
+    webhookUrl: data.webhookUrl,
+    secret: data.secret ?? null,
+    target: data.target ?? null,
+    label: data.label ?? null,
+  });
+  emit(
+    channel,
+    `通知チャネルを追加しました: ${channel.id} (${channel.kind})`,
+    opts,
+  );
+}
+
+async function listCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const channels = await listNotificationChannels(ctx, teamId);
+  // webhook_url / secret はサマリ列には出さない (秘匿)
+  emit(
+    channels,
+    formatRows(channels, ["id", "kind", "label", "enabled", "created_at"]),
+    opts,
+  );
+}
+
+async function removeCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id) throw new UsageError("使い方: mound notify remove <ID>");
+  const removed = await removeNotificationChannel(ctx, id);
+  emit(
+    { ok: removed, id },
+    removed
+      ? `通知チャネルを削除しました: ${id}`
+      : `該当する通知チャネルが見つかりません: ${id}`,
+    opts,
+  );
+}
+
+async function testCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id) throw new UsageError("使い方: mound notify test <ID>");
+  const message =
+    optionalFlag(args.flags, "message") ??
+    "mound からのテスト通知です (mound notify test)";
+  const result = await testNotificationChannel(ctx, id, message);
+  if (!result) {
+    throw new UsageError(`該当する通知チャネルが見つかりません: ${id}`);
+  }
+  emit(
+    result,
+    result.ok
+      ? `送信成功 (${result.channel_kind})`
+      : `送信失敗 (${result.channel_kind}): ${result.error ?? "unknown"}`,
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/compose.ts
+++ b/packages/cli/src/adapters/cli/compose.ts
@@ -1,16 +1,21 @@
-import type { UseCaseContext } from "../../ports";
+import type { NotificationSender, UseCaseContext } from "../../ports";
 import type { DbClient } from "../libsql/client";
 import { buildRepositories } from "../libsql/repositories";
+import { buildNotifierFromEnv } from "../notification/sender";
 
 export interface ComposeOptions {
   db: DbClient;
+  env: Record<string, string | undefined>;
   now: () => Date;
   newId: () => string;
+  // テスト等で notifier を差し替えるための override。
+  notifier?: NotificationSender;
 }
 
 export function composeContext(options: ComposeOptions): UseCaseContext {
   return {
     repo: buildRepositories(options.db),
+    notifier: options.notifier ?? buildNotifierFromEnv(options.env),
     now: options.now,
     newId: options.newId,
   };

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -21,6 +21,13 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   ground import [--file PATH | --stdin]      外部スクレイパの JSON を取り込む
   ground list [--source S] [--date YYYY-MM-DD]
   ground diff [--since ISO | --minutes N] [--source S] [--game-date YYYY-MM-DD]
+  notify add --team <ID> --kind DISCORD|SLACK|LINE --webhook <URL> [--secret S] [--target T] [--label L]
+  notify list --team <ID>
+  notify remove <ID>
+  notify test <ID> [--message TEXT]
+
+環境変数 (追加):
+  MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
 
 サブコマンドの詳細:
   mound <command> [subcommand] --help        例: mound game create --help
@@ -356,6 +363,73 @@ JSON 出力:
 JSON 出力:
   GroundSlot[] { id, slot_key, source, facility_name, date_iso, date_raw,
                  time_range, status, raw, scraped_at, first_seen_at, ingested_at }
+`,
+
+  notify: `mound notify — Discord / Slack / LINE への通知チャネル
+
+サブコマンド:
+  notify add --team <ID> --kind DISCORD|SLACK|LINE --webhook <URL> [--secret S] [--target T] [--label L]
+  notify list   --team <ID>
+  notify remove <ID>
+  notify test   <ID> [--message TEXT]
+
+トリガ:
+  - 試合の状態遷移 (game transition) が成功するとチームの enabled channel に送信
+  - 送信失敗してもドメイン操作は成功扱い (fire-and-forget)
+
+環境変数:
+  MOUND_NOTIFY_MODE=log-only   実 HTTP を叩かず stderr に出すだけ (dev/test)
+  MOUND_NOTIFY_MODE=disabled   すべての送信を no-op にする
+  未指定                       実 HTTP (Discord/Slack/LINE) を叩く
+`,
+
+  "notify add": `mound notify add — 通知チャネルを追加
+
+使い方:
+  mound notify add --team <TEAM_ID> --kind <DISCORD|SLACK|LINE> \\
+    --webhook <URL> [--secret <TOKEN>] [--target <ID>] [--label <NAME>] [--json]
+
+フラグ:
+  --team      (必須) 通知先チームの ID
+  --kind      (必須) DISCORD | SLACK | LINE
+  --webhook   (必須) Webhook URL (LINE は https://api.line.me/v2/bot/message/push)
+  --secret    (任意 / LINE 必須) チャネルアクセストークン
+  --target    (任意 / LINE 必須) 送信先 userId / groupId
+  --label     (任意) 表示名
+
+JSON 出力:
+  NotificationChannel { id, team_id, kind, webhook_url, secret, target, label,
+                        enabled, created_at, updated_at }
+`,
+
+  "notify list": `mound notify list — チームの通知チャネル一覧
+
+使い方:
+  mound notify list --team <TEAM_ID> [--json]
+
+JSON 出力:
+  NotificationChannel[] (webhook_url / secret も含む。秘匿に注意)
+`,
+
+  "notify remove": `mound notify remove — 通知チャネルを削除
+
+使い方:
+  mound notify remove <ID> [--json]
+
+JSON 出力:
+  { "ok": boolean, "id": string }
+`,
+
+  "notify test": `mound notify test — 通知チャネルに即時テスト送信
+
+使い方:
+  mound notify test <ID> [--message TEXT] [--json]
+
+フラグ:
+  --message  (任意) 送信文面 (デフォルトはテスト文)
+
+JSON 出力:
+  NotificationDeliveryResult { channel_id, channel_kind, ok, status_code, error }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -6,6 +6,7 @@ import type {
   GroundSlot,
   Member,
   MemberRsvp,
+  NotificationChannel,
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
@@ -18,6 +19,7 @@ import type {
   GroundSlotFilter,
   GroundSlotRepository,
   MemberRepository,
+  NotificationChannelRepository,
   Repositories,
   RsvpRepository,
   TeamRepository,
@@ -29,6 +31,7 @@ import {
   rowToGroundSlot,
   rowToMember,
   rowToMemberRsvp,
+  rowToNotificationChannel,
   rowToRsvp,
   rowToTeam,
 } from "./row-mappers";
@@ -392,6 +395,68 @@ class LibsqlGroundSlotRepository implements GroundSlotRepository {
   }
 }
 
+class LibsqlNotificationChannelRepository
+  implements NotificationChannelRepository
+{
+  constructor(private readonly db: DbClient) {}
+
+  async insert(channel: NotificationChannel): Promise<NotificationChannel> {
+    await this.db.execute({
+      sql: `INSERT INTO notification_channels (
+              id, team_id, kind, webhook_url, secret, target, label,
+              enabled, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        channel.id,
+        channel.team_id,
+        channel.kind,
+        channel.webhook_url,
+        channel.secret,
+        channel.target,
+        channel.label,
+        channel.enabled ? 1 : 0,
+        channel.created_at,
+        channel.updated_at,
+      ],
+    });
+    return channel;
+  }
+
+  async list(teamId: string): Promise<NotificationChannel[]> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM notification_channels WHERE team_id = ? ORDER BY created_at ASC",
+      args: [teamId],
+    });
+    return r.rows.map(rowToNotificationChannel);
+  }
+
+  async listEnabled(teamId: string): Promise<NotificationChannel[]> {
+    const r = await this.db.execute({
+      sql: `SELECT * FROM notification_channels
+            WHERE team_id = ? AND enabled <> 0
+            ORDER BY created_at ASC`,
+      args: [teamId],
+    });
+    return r.rows.map(rowToNotificationChannel);
+  }
+
+  async get(id: string): Promise<NotificationChannel | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM notification_channels WHERE id = ?",
+      args: [id],
+    });
+    return r.rows[0] ? rowToNotificationChannel(r.rows[0]) : null;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const r = await this.db.execute({
+      sql: "DELETE FROM notification_channels WHERE id = ?",
+      args: [id],
+    });
+    return r.rowsAffected > 0;
+  }
+}
+
 export function buildRepositories(db: DbClient): Repositories {
   return {
     teams: new LibsqlTeamRepository(db),
@@ -400,5 +465,6 @@ export function buildRepositories(db: DbClient): Repositories {
     rsvps: new LibsqlRsvpRepository(db),
     audit: new LibsqlAuditRepository(db),
     groundSlots: new LibsqlGroundSlotRepository(db),
+    notifications: new LibsqlNotificationChannelRepository(db),
   };
 }

--- a/packages/cli/src/adapters/libsql/row-mappers.ts
+++ b/packages/cli/src/adapters/libsql/row-mappers.ts
@@ -2,6 +2,7 @@ import type { InValue, Row } from "@libsql/client";
 import {
   assertGameStatus,
   assertMemberRole,
+  assertNotificationKind,
   assertRsvpResponse,
 } from "../../domain/guards";
 import type {
@@ -10,6 +11,7 @@ import type {
   GroundSlot,
   Member,
   MemberRsvp,
+  NotificationChannel,
   Rsvp,
   Team,
 } from "../../domain/types";
@@ -87,6 +89,21 @@ export function rowToAuditLog(row: Row): AuditLog {
     before_json: nullable(row.before_json),
     after_json: nullable(row.after_json),
     created_at: str(row.created_at),
+  };
+}
+
+export function rowToNotificationChannel(row: Row): NotificationChannel {
+  return {
+    id: str(row.id),
+    team_id: str(row.team_id),
+    kind: assertNotificationKind(str(row.kind)),
+    webhook_url: str(row.webhook_url),
+    secret: nullable(row.secret),
+    target: nullable(row.target),
+    label: nullable(row.label),
+    enabled: Number(row.enabled) !== 0,
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
   };
 }
 

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS teams (
@@ -81,4 +81,20 @@ CREATE TABLE IF NOT EXISTS ground_slots (
 );
 CREATE INDEX IF NOT EXISTS idx_ground_slots_source ON ground_slots(source);
 CREATE INDEX IF NOT EXISTS idx_ground_slots_date ON ground_slots(date_iso);
+
+-- 通知チャネル設定。Discord/Slack は webhook_url のみ、LINE Messaging API は
+-- webhook_url + secret (channel access token) + target (user/group id) を使う。
+CREATE TABLE IF NOT EXISTS notification_channels (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (kind IN ('DISCORD', 'SLACK', 'LINE')),
+  webhook_url TEXT NOT NULL,
+  secret TEXT,
+  target TEXT,
+  label TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notif_channels_team ON notification_channels(team_id);
 `;

--- a/packages/cli/src/adapters/notification/sender.ts
+++ b/packages/cli/src/adapters/notification/sender.ts
@@ -1,0 +1,158 @@
+import type { NotificationChannel } from "../../domain/types";
+import type {
+  NotificationDeliveryResult,
+  NotificationSender,
+} from "../../ports";
+
+// 各 kind に対する HTTP request の組み立て。
+//   DISCORD: webhook URL に POST { content }
+//   SLACK:   incoming webhook URL に POST { text }
+//   LINE:    Messaging API push に POST { to, messages } + Authorization: Bearer secret
+function buildRequest(
+  channel: NotificationChannel,
+  message: string,
+): { url: string; init: RequestInit } | { error: string } {
+  if (channel.kind === "DISCORD") {
+    return {
+      url: channel.webhook_url,
+      init: {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: message }),
+      },
+    };
+  }
+  if (channel.kind === "SLACK") {
+    return {
+      url: channel.webhook_url,
+      init: {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: message }),
+      },
+    };
+  }
+  if (channel.kind === "LINE") {
+    if (!channel.secret || !channel.target) {
+      return {
+        error:
+          "LINE は secret (channel access token) と target (userId/groupId) が必須です",
+      };
+    }
+    return {
+      url: channel.webhook_url,
+      init: {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${channel.secret}`,
+        },
+        body: JSON.stringify({
+          to: channel.target,
+          messages: [{ type: "text", text: message }],
+        }),
+      },
+    };
+  }
+  return { error: `未対応の kind: ${String(channel.kind)}` };
+}
+
+// 実 HTTP を叩く sender。fetch のタイムアウトは 8 秒。
+export class HttpNotificationSender implements NotificationSender {
+  constructor(private readonly fetchImpl: typeof fetch = fetch) {}
+
+  async send(
+    channel: NotificationChannel,
+    message: string,
+  ): Promise<NotificationDeliveryResult> {
+    const built = buildRequest(channel, message);
+    if ("error" in built) {
+      return {
+        channel_id: channel.id,
+        channel_kind: channel.kind,
+        ok: false,
+        status_code: null,
+        error: built.error,
+      };
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    try {
+      const res = await this.fetchImpl(built.url, {
+        ...built.init,
+        signal: controller.signal,
+      });
+      return {
+        channel_id: channel.id,
+        channel_kind: channel.kind,
+        ok: res.ok,
+        status_code: res.status,
+        error: res.ok ? null : `HTTP ${res.status}`,
+      };
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return {
+        channel_id: channel.id,
+        channel_kind: channel.kind,
+        ok: false,
+        status_code: null,
+        error: msg,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// テスト / dev 用: stderr に「送信したつもり」を出すだけ。HTTP は叩かない。
+// MOUND_NOTIFY_MODE=log-only でこちらに切り替える。
+export class LogNotificationSender implements NotificationSender {
+  constructor(
+    private readonly write: (line: string) => void = (l) =>
+      process.stderr.write(`${l}\n`),
+  ) {}
+
+  async send(
+    channel: NotificationChannel,
+    message: string,
+  ): Promise<NotificationDeliveryResult> {
+    this.write(
+      `[notify:${channel.kind}] team=${channel.team_id} label=${channel.label ?? "-"} message=${JSON.stringify(message)}`,
+    );
+    return {
+      channel_id: channel.id,
+      channel_kind: channel.kind,
+      ok: true,
+      status_code: null,
+      error: null,
+    };
+  }
+}
+
+// チャネル 1 件も無いとき / notifier が無効化されているときに使う no-op。
+export class NoopNotificationSender implements NotificationSender {
+  async send(
+    channel: NotificationChannel,
+  ): Promise<NotificationDeliveryResult> {
+    return {
+      channel_id: channel.id,
+      channel_kind: channel.kind,
+      ok: true,
+      status_code: null,
+      error: null,
+    };
+  }
+}
+
+// env を見て適切な NotificationSender を選ぶ。
+//   MOUND_NOTIFY_MODE === "disabled" -> Noop
+//   MOUND_NOTIFY_MODE === "log-only" -> Log
+//   それ以外 / unset                  -> Http
+export function buildNotifierFromEnv(
+  env: Record<string, string | undefined>,
+): NotificationSender {
+  const mode = env.MOUND_NOTIFY_MODE;
+  if (mode === "disabled") return new NoopNotificationSender();
+  if (mode === "log-only") return new LogNotificationSender();
+  return new HttpNotificationSender();
+}

--- a/packages/cli/src/domain/guards.ts
+++ b/packages/cli/src/domain/guards.ts
@@ -3,6 +3,8 @@ import {
   type GameStatus,
   MEMBER_ROLES,
   type MemberRole,
+  NOTIFICATION_KINDS,
+  type NotificationKind,
   RSVP_RESPONSES,
   type RsvpResponse,
 } from "./types";
@@ -52,6 +54,20 @@ export function assertRsvpResponse(value: unknown): RsvpResponse {
 export function assertMemberRole(value: unknown): MemberRole {
   if (!isMemberRole(value)) {
     throw new DomainInvariantError(`不正な MemberRole: ${String(value)}`);
+  }
+  return value;
+}
+
+export function isNotificationKind(value: unknown): value is NotificationKind {
+  return (
+    typeof value === "string" &&
+    (NOTIFICATION_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function assertNotificationKind(value: unknown): NotificationKind {
+  if (!isNotificationKind(value)) {
+    throw new DomainInvariantError(`不正な NotificationKind: ${String(value)}`);
   }
   return value;
 }

--- a/packages/cli/src/domain/types.ts
+++ b/packages/cli/src/domain/types.ts
@@ -19,6 +19,9 @@ export type RsvpResponse = (typeof RSVP_RESPONSES)[number];
 export const MEMBER_ROLES = ["ADMIN", "MEMBER"] as const;
 export type MemberRole = (typeof MEMBER_ROLES)[number];
 
+export const NOTIFICATION_KINDS = ["DISCORD", "SLACK", "LINE"] as const;
+export type NotificationKind = (typeof NOTIFICATION_KINDS)[number];
+
 export interface Team {
   id: string;
   name: string;
@@ -91,6 +94,25 @@ export interface RsvpBreakdown {
   unavailable: MemberRsvp[];
   maybe: MemberRsvp[];
   no_response: MemberRsvp[];
+}
+
+// チームに紐づく通知チャネル設定。
+// kind === "DISCORD" | "SLACK" は webhook_url 単独で動く。
+// kind === "LINE"  は LINE Messaging API push を想定:
+//   webhook_url: 'https://api.line.me/v2/bot/message/push' 固定の想定
+//   secret:      チャネルアクセストークン (Authorization: Bearer)
+//   target:      送信先 userId / groupId
+export interface NotificationChannel {
+  id: string;
+  team_id: string;
+  kind: NotificationKind;
+  webhook_url: string;
+  secret: string | null;
+  target: string | null;
+  label: string | null;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 // 外部スクレイパ (ground-reservation 等) から ingest した 1 件の空き枠。

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -7,6 +7,7 @@ import type {
   GroundSlot,
   Member,
   MemberRsvp,
+  NotificationChannel,
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
@@ -67,6 +68,31 @@ export interface GroundSlotRepository {
   getByKey(slotKey: string): Promise<GroundSlot | null>;
 }
 
+export interface NotificationChannelRepository {
+  insert(channel: NotificationChannel): Promise<NotificationChannel>;
+  list(teamId: string): Promise<NotificationChannel[]>;
+  listEnabled(teamId: string): Promise<NotificationChannel[]>;
+  get(id: string): Promise<NotificationChannel | null>;
+  remove(id: string): Promise<boolean>;
+}
+
+// 1 件分の送信結果。送信失敗でも例外は投げず、ok=false で返す。
+// (送信エラーで上位のドメイン操作 — 試合の状態遷移など — を巻き戻したくない)
+export interface NotificationDeliveryResult {
+  channel_id: string;
+  channel_kind: string;
+  ok: boolean;
+  status_code: number | null;
+  error: string | null;
+}
+
+export interface NotificationSender {
+  send(
+    channel: NotificationChannel,
+    message: string,
+  ): Promise<NotificationDeliveryResult>;
+}
+
 export interface Repositories {
   teams: TeamRepository;
   members: MemberRepository;
@@ -74,6 +100,7 @@ export interface Repositories {
   rsvps: RsvpRepository;
   audit: AuditRepository;
   groundSlots: GroundSlotRepository;
+  notifications: NotificationChannelRepository;
 }
 
 export interface Clock {
@@ -86,4 +113,5 @@ export interface IdGenerator {
 
 export interface UseCaseContext extends Clock, IdGenerator {
   repo: Repositories;
+  notifier: NotificationSender;
 }

--- a/packages/cli/src/usecases/game.ts
+++ b/packages/cli/src/usecases/game.ts
@@ -7,6 +7,7 @@ import {
   TeamNotFoundError,
   TransitionDeniedError,
 } from "./errors";
+import { notifyGameTransition } from "./notification";
 
 export interface CreateGameInput {
   teamId: string;
@@ -125,5 +126,8 @@ export async function transitionGame(
     before,
     after,
   });
+  // 通知は fire-and-forget で送る。失敗してもドメイン遷移は成功扱い。
+  // sender 内部で try/catch しているので例外は来ない想定だが念のため握り潰す。
+  await notifyGameTransition(ctx, after, game.status, to).catch(() => []);
   return after;
 }

--- a/packages/cli/src/usecases/notification.ts
+++ b/packages/cli/src/usecases/notification.ts
@@ -1,0 +1,133 @@
+import type {
+  Game,
+  GameStatus,
+  GroundSlot,
+  NotificationChannel,
+  NotificationKind,
+} from "../domain/types";
+import type { NotificationDeliveryResult, UseCaseContext } from "../ports";
+import { TeamNotFoundError } from "./errors";
+
+export interface AddChannelInput {
+  teamId: string;
+  kind: NotificationKind;
+  webhookUrl: string;
+  secret: string | null;
+  target: string | null;
+  label: string | null;
+}
+
+export async function addNotificationChannel(
+  ctx: UseCaseContext,
+  input: AddChannelInput,
+): Promise<NotificationChannel> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const now = ctx.now().toISOString();
+  const channel: NotificationChannel = {
+    id: ctx.newId(),
+    team_id: team.id,
+    kind: input.kind,
+    webhook_url: input.webhookUrl,
+    secret: input.secret,
+    target: input.target,
+    label: input.label,
+    enabled: true,
+    created_at: now,
+    updated_at: now,
+  };
+  return ctx.repo.notifications.insert(channel);
+}
+
+export async function listNotificationChannels(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<NotificationChannel[]> {
+  return ctx.repo.notifications.list(teamId);
+}
+
+export async function removeNotificationChannel(
+  ctx: UseCaseContext,
+  id: string,
+): Promise<boolean> {
+  return ctx.repo.notifications.remove(id);
+}
+
+export async function testNotificationChannel(
+  ctx: UseCaseContext,
+  id: string,
+  message: string,
+): Promise<NotificationDeliveryResult | null> {
+  const channel = await ctx.repo.notifications.get(id);
+  if (!channel) return null;
+  return ctx.notifier.send(channel, message);
+}
+
+// 共通の送信処理: 失敗しても全 channel に try する。
+async function dispatch(
+  ctx: UseCaseContext,
+  teamId: string,
+  message: string,
+): Promise<NotificationDeliveryResult[]> {
+  const channels = await ctx.repo.notifications.listEnabled(teamId);
+  if (channels.length === 0) return [];
+  return Promise.all(
+    channels.map((c) =>
+      ctx.notifier.send(c, message).catch((e: unknown) => ({
+        channel_id: c.id,
+        channel_kind: c.kind,
+        ok: false,
+        status_code: null,
+        error: e instanceof Error ? e.message : String(e),
+      })),
+    ),
+  );
+}
+
+function formatGameTransitionMessage(
+  game: Game,
+  from: GameStatus,
+  to: GameStatus,
+): string {
+  const date = game.game_date ?? "日付未定";
+  const ground = game.ground_name ?? "会場未定";
+  const emoji = to === "CONFIRMED" ? "✅" : to === "CANCELLED" ? "❌" : "🔄";
+  return [
+    `${emoji} 試合の状態が変わりました: ${from} → ${to}`,
+    `${game.title}`,
+    `${date} / ${ground}`,
+  ].join("\n");
+}
+
+export async function notifyGameTransition(
+  ctx: UseCaseContext,
+  game: Game,
+  from: GameStatus,
+  to: GameStatus,
+): Promise<NotificationDeliveryResult[]> {
+  const message = formatGameTransitionMessage(game, from, to);
+  return dispatch(ctx, game.team_id, message);
+}
+
+function formatGroundCancellationMessage(slots: GroundSlot[]): string {
+  if (slots.length === 0) return "";
+  const head = `🟢 グラウンドに ${slots.length} 件の空きが出ました`;
+  const lines = slots.slice(0, 10).map((s) => {
+    const date = s.date_iso ?? s.date_raw;
+    const time = s.time_range ?? "";
+    const status = s.status ? ` [${s.status}]` : "";
+    return `- ${date} ${time} ${s.facility_name}${status} (${s.source})`;
+  });
+  const overflow = slots.length > 10 ? `\n…ほか ${slots.length - 10} 件` : "";
+  return [head, ...lines].join("\n") + overflow;
+}
+
+export async function notifyGroundCancellation(
+  ctx: UseCaseContext,
+  teamId: string,
+  slots: GroundSlot[],
+): Promise<NotificationDeliveryResult[]> {
+  if (slots.length === 0) return [];
+  const message = formatGroundCancellationMessage(slots);
+  return dispatch(ctx, teamId, message);
+}


### PR DESCRIPTION
Closes #169.

## Summary

mound の状態変化(試合の状態遷移、グラウンドのキャンセル検知)を Discord / Slack / LINE に push できるようにする。

### 使い方

\`\`\`bash
# 1. チームに通知チャネルを追加
mound notify add --team \$TEAM --kind DISCORD --webhook https://discord.com/api/webhooks/... --label main --json
mound notify add --team \$TEAM --kind SLACK --webhook https://hooks.slack.com/services/... --json
mound notify add --team \$TEAM --kind LINE   --webhook https://api.line.me/v2/bot/message/push --secret \$LINE_TOKEN --target \$LINE_USER_ID --json

# 2. テスト送信
mound notify test \$CHANNEL_ID --message "hello"

# 3. 試合の状態を変えると勝手に飛ぶ (fire-and-forget)
mound game transition \$GAME --to CONFIRMED  # → 登録チャネルへ "COLLECTING → CONFIRMED" のメッセージ

# 4. グラウンドのキャンセルを通知
mound ground diff --minutes 30 --notify --team \$TEAM
\`\`\`

### スコープ

- **domain / ports**: \`NotificationKind\` / \`NotificationChannel\` / \`NotificationChannelRepository\` / \`NotificationSender\`、\`UseCaseContext\` に \`notifier\` を追加
- **adapter**:
  - \`HttpNotificationSender\` — kind 別に body を組み立てる (Discord: \`{content}\`, Slack: \`{text}\`, LINE Messaging API push: \`Authorization: Bearer\` + \`{to, messages}\`)
  - \`LogNotificationSender\` — stderr に書き出すだけ (dev / test)
  - \`NoopNotificationSender\` — 無効化
  - \`MOUND_NOTIFY_MODE\` で切替 (\`log-only\` | \`disabled\` | 未指定 = HTTP)
- **libsql**: \`SCHEMA_VERSION\` 2→3 + \`notification_channels\` テーブル
- **usecase**: チャネル CRUD + \`notifyGameTransition\` (game.transition 成功後に fire-and-forget) + \`notifyGroundCancellation\` (ground diff から)
- **CLI**: \`mound notify add/list/remove/test\` + \`mound ground diff --notify --team T\` フラグ追加。サブコマンド別 \`--help\` も追加

### 設計上の判断

- 送信失敗してもドメイン操作は成功扱い(状態遷移を巻き戻さない)
- 送信は \`Promise.allSettled\` 的に並列。1 channel の失敗が他を巻き込まない
- 秘匿情報 (\`webhook_url\` / \`secret\`) は \`notify list\` の表 view では出さない(JSON view には載るので扱い注意)
- グラウンドキャンセルの送信先は \`--team\` を明示する形にして、安易な全員 broadcast を避けた

## Test plan

- [x] \`make check\` (lint + typecheck + test) 緑 — 94 passed (新規 15)
- [x] e2e で \`notify add → list → test → remove\` と \`game transition\` 後の \`log-only\` 出力を実バイナリで確認
- [ ] CI 緑を確認

## 受け入れ条件 (#169 より)

- [x] game transition 後に対応チームの enabled channel へ送信(失敗しても transition は成功)
- [x] ground diff の検出結果からチーム指定で webhook 送信できる
- [x] BDD テスト + log-only モードの e2e

## やらないこと (#169 のスコープに沿う)

- グループチャット双方向対話
- retry / dead-letter
- 通知文面のテンプレ化 / カスタマイズ UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)