### PR TITLE
feat(ground): mound ground sync — spawn ground-monitoring and ingest in one shot

### DIFF
--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -466,6 +466,153 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
       );
       expect(r.code).toBe(2);
     });
+
+    it("ground sync が --bin で渡したスクリプトの出力を取り込む", () => {
+      const mockBin = join(dbDir, "fake-ground-monitoring.sh");
+      const payload = {
+        schema_version: 1,
+        scraped_at: "2026-05-23T18:00:00+09:00",
+        regions: [
+          {
+            region: "yokohama",
+            records: [
+              {
+                region: "yokohama",
+                facility_name: "syncテスト公園",
+                date_raw: "令和8年7月1日(日)",
+                date_iso: "2026-07-01",
+                time_range: "09:00-12:00",
+                status: null,
+                raw: "\n令和8年7月1日(日) 09:00-12:00 syncテスト公園",
+              },
+            ],
+            errors: [],
+          },
+        ],
+      };
+      writeFileSync(
+        mockBin,
+        `#!/usr/bin/env bash
+cat <<'JSON'
+${JSON.stringify(payload)}
+JSON
+`,
+        { mode: 0o755 },
+      );
+
+      const r = runMound(
+        ["ground", "sync", "--region", "yokohama", "--bin", mockBin, "--json"],
+        env,
+      );
+      expect(r.code).toBe(0);
+      const out = parseJson<{
+        total_records: number;
+        inserted: number;
+        new_slots: Array<{ facility_name: string }>;
+      }>(r.stdout);
+      expect(out.total_records).toBe(1);
+      expect(out.inserted).toBe(1);
+      expect(
+        out.new_slots.some((s) => s.facility_name === "syncテスト公園"),
+      ).toBe(true);
+    });
+
+    it("ground sync が exit non-zero のスクリプトでは exit 1", () => {
+      const mockBin = join(dbDir, "fake-ground-monitoring-fail.sh");
+      writeFileSync(
+        mockBin,
+        '#!/usr/bin/env bash\necho "scraper failed" >&2\nexit 3\n',
+        { mode: 0o755 },
+      );
+      const r = runMound(["ground", "sync", "--bin", mockBin, "--json"], env);
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain("exit 3");
+    });
+
+    it("ground sync --notify --team で新規 slot が log-only sender に流れる", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "sync 通知テスト", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+      runMound(
+        [
+          "notify",
+          "add",
+          "--team",
+          team.id,
+          "--kind",
+          "DISCORD",
+          "--webhook",
+          "https://discord.com/api/webhooks/dummy",
+          "--json",
+        ],
+        env,
+      );
+
+      const mockBin = join(dbDir, "fake-ground-monitoring-notify.sh");
+      const payload = {
+        schema_version: 1,
+        scraped_at: "2026-05-24T18:00:00+09:00",
+        regions: [
+          {
+            region: "kanagawa",
+            records: [
+              {
+                region: "kanagawa",
+                facility_name: "通知トリガ球場",
+                date_raw: "2026/08/10",
+                date_iso: "2026-08-10",
+                time_range: "13:00-17:00",
+                status: "空き",
+                raw: "\n2026/08/10 13:00-17:00 空き 通知トリガ球場",
+              },
+            ],
+            errors: [],
+          },
+        ],
+      };
+      writeFileSync(
+        mockBin,
+        `#!/usr/bin/env bash\ncat <<'JSON'\n${JSON.stringify(payload)}\nJSON\n`,
+        { mode: 0o755 },
+      );
+
+      const r = runMound(
+        [
+          "ground",
+          "sync",
+          "--region",
+          "kanagawa",
+          "--bin",
+          mockBin,
+          "--notify",
+          "--team",
+          team.id,
+          "--json",
+        ],
+        env,
+      );
+      expect(r.code).toBe(0);
+      const out = parseJson<{
+        new_slots: unknown[];
+        notifications: Array<{ ok: boolean }>;
+      }>(r.stdout);
+      expect(out.new_slots.length).toBeGreaterThan(0);
+      expect(out.notifications.length).toBe(1);
+      expect(out.notifications[0]?.ok).toBe(true);
+      expect(r.stderr).toContain("[notify:DISCORD]");
+      expect(r.stderr).toContain("通知トリガ球場");
+    });
+
+    it("ground sync --notify には --team が必要 (exit 2)", () => {
+      const r = runMound(
+        ["ground", "sync", "--notify", "--bin", "/bin/true", "--json"],
+        env,
+      );
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("--team");
+    });
   });
 
   describe("notify チャネル管理のとき", () => {

--- a/packages/cli/src/adapters/cli/commands/ground.ts
+++ b/packages/cli/src/adapters/cli/commands/ground.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 import type { UseCaseContext } from "../../../ports";
@@ -17,10 +18,12 @@ export async function runGround(
   opts: RenderOptions,
 ): Promise<void> {
   const sub = args.positional[0];
-  if (!sub) throw new UsageError("使い方: mound ground <import|list|diff>");
+  if (!sub)
+    throw new UsageError("使い方: mound ground <import|list|diff|sync>");
   if (sub === "import") return importCommand(args, ctx, opts);
   if (sub === "list") return listCommand(args, ctx, opts);
   if (sub === "diff") return diffCommand(args, ctx, opts);
+  if (sub === "sync") return syncCommand(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: ground ${sub}`);
 }
 
@@ -123,6 +126,86 @@ function resolveSince(args: ParsedArgs, now: Date): string {
   }
   const minutes = minutesFlag ? parseOrUsage(minutesInput, minutesFlag) : 60;
   return new Date(now.getTime() - minutes * 60_000).toISOString();
+}
+
+const timeoutInput = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .max(10 * 60 * 1000);
+
+async function syncCommand(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const region = optionalFlag(args.flags, "region") ?? "all";
+  const bin = optionalFlag(args.flags, "bin") ?? "ground-monitoring";
+  const timeoutFlag = optionalFlag(args.flags, "timeout-ms");
+  const timeout = timeoutFlag
+    ? parseOrUsage(timeoutInput, timeoutFlag)
+    : 60_000;
+  const shouldNotify = boolFlag(args.flags, "notify");
+  const teamId = optionalFlag(args.flags, "team");
+  if (shouldNotify && !teamId) {
+    throw new UsageError("--notify を指定したら --team も必要です");
+  }
+
+  // この sync で初めて見る slot は first_seen_at >= beforeSyncAt になるはず。
+  const beforeSyncAt = ctx.now().toISOString();
+
+  // ground-monitoring を spawn して JSON を取る。
+  const result = spawnSync(bin, ["--region", region, "--json"], {
+    encoding: "utf-8",
+    timeout,
+  });
+  if (result.error) {
+    // ENOENT (バイナリ未インストール) もここで包まれる。
+    throw new Error(`scraper 起動に失敗: ${result.error.message}`);
+  }
+  if (result.signal === "SIGTERM") {
+    throw new Error(`scraper がタイムアウトしました (${timeout}ms)`);
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    throw new Error(
+      `scraper が exit ${result.status} で終了しました${stderr ? `: ${stderr}` : ""}`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(result.stdout);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`scraper の stdout が JSON ではありません: ${msg}`);
+  }
+
+  const importResult = await importGroundAvailability(ctx, payload);
+
+  // --notify --team が指定されていれば、この sync で初観測の slot だけ抽出して送る。
+  const newSlots = await detectNewSlots(ctx, { since: beforeSyncAt });
+  let notifications: unknown[] = [];
+  if (shouldNotify && teamId) {
+    notifications = await notifyGroundCancellation(ctx, teamId, newSlots);
+  }
+
+  const out = {
+    region,
+    bin,
+    ...importResult,
+    new_slots: newSlots,
+    ...(shouldNotify ? { notifications } : {}),
+  };
+  const text = [
+    `sync (${bin} --region ${region}) 完了`,
+    `取り込み: ${importResult.total_records} 件 (新規 ${importResult.inserted} / 更新 ${importResult.updated})`,
+    `新規観測 slot: ${newSlots.length} 件`,
+    shouldNotify ? `通知送信: ${notifications.length} 件` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+  emit(out, text, opts);
 }
 
 async function diffCommand(

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -21,6 +21,7 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   ground import [--file PATH | --stdin]      外部スクレイパの JSON を取り込む
   ground list [--source S] [--date YYYY-MM-DD]
   ground diff [--since ISO | --minutes N] [--source S] [--game-date YYYY-MM-DD]
+  ground sync [--region R] [--bin PATH] [--timeout-ms N] [--notify --team T]
   notify add --team <ID> --kind DISCORD|SLACK|LINE --webhook <URL> [--secret S] [--target T] [--label L]
   notify list --team <ID>
   notify remove <ID>
@@ -301,11 +302,13 @@ JSON 出力:
   ground import [--file PATH | --stdin] [--json]
   ground list   [--source S] [--date YYYY-MM-DD] [--json]
   ground diff   [--since ISO | --minutes N] [--source S] [--game-date YYYY-MM-DD] [--json]
+  ground sync   [--region R] [--bin PATH] [--timeout-ms N] [--notify --team T] [--json]
 
 詳細:
   mound ground import --help
   mound ground list --help
   mound ground diff --help
+  mound ground sync --help
 `,
 
   "ground import": `mound ground import — 外部スクレイパの JSON を取り込む
@@ -330,6 +333,42 @@ JSON 出力:
 
 エラー:
   - UsageError: --file / --stdin 未指定、JSON 不正、schema 不一致 (exit 2)
+`,
+
+  "ground sync": `mound ground sync — ground-monitoring を呼んで import + (任意で) 通知まで 1 コマンド
+
+使い方:
+  mound ground sync [--region all|<R>] [--bin PATH] [--timeout-ms N] \\
+    [--notify --team <ID>] [--json]
+
+フラグ:
+  --region       (任意) all | yokohama | hiratsuka | kanagawa | kamakura |
+                       fujisawa | samukawa | ayase (既定: all)
+  --bin          (任意) ground-monitoring の絶対パス (既定: PATH から解決)
+  --timeout-ms   (任意) scraper のタイムアウト ms (既定: 60000)
+  --notify       (任意) 検出された新規 slot を通知する (要 --team)
+  --team         (--notify 必須) 通知先チーム ID
+
+挙動:
+  1. now() を beforeSyncAt として記録
+  2. <bin> --region <R> --json を spawn
+  3. exit code / stderr / timeout を見て失敗なら exit 1
+  4. stdout JSON を import (mound ground import と同じロジック)
+  5. detectNewSlots({ since: beforeSyncAt }) で「今回 sync で初観測」slot を抽出
+  6. --notify --team が指定されていれば notifyGroundCancellation で送信
+
+JSON 出力:
+  {
+    "region": string,
+    "bin": string,
+    "scraped_at": ISO8601,
+    "total_records": number,
+    "inserted": number,
+    "updated": number,
+    "regions_with_errors": [{ "region": string, "errors": string[] }],
+    "new_slots": GroundSlot[],
+    "notifications"?: NotificationDeliveryResult[]
+  }
 `,
 
   "ground diff": `mound ground diff — 直近キャンセル候補 (新規観測 slot) を抽出


### PR DESCRIPTION
Closes #172.

## Summary

\`ground-monitoring\` (susumutomita/ground-reservation) を mound から spawn して、scrape → import → 新規 slot 抽出 → (任意で) 通知まで 1 コマンドで閉じる。これで cron / launchd / メニューバーアプリから 1 行で叩ける状態になる。

### 使い方

\`\`\`bash
# 既定: ground-monitoring を PATH から探して全 region を scrape & ingest
mound ground sync

# 特定 region + チーム宛通知
mound ground sync --region yokohama --notify --team \$TEAM --json

# 別パスの binary を指す (Homebrew でない / venv 経由など)
mound ground sync --bin /opt/local/bin/ground-monitoring --json
\`\`\`

### 挙動

1. \`beforeSyncAt = ctx.now()\` を記録
2. \`spawnSync(bin, ["--region", region, "--json"], { timeout })\`
3. \`exit\` / \`signal\` / \`stdout JSON.parse\` を順にチェック。失敗なら exit 1 + stderr に scraper のエラーを付ける
4. \`importGroundAvailability\` で ingest
5. \`detectNewSlots({ since: beforeSyncAt })\` で「この sync で初観測」slot を抽出
6. \`--notify --team\` があれば \`notifyGroundCancellation\` で送信

### JSON 出力

\`\`\`json
{
  "region": "yokohama",
  "bin": "ground-monitoring",
  "scraped_at": "2026-05-23T18:00:00+09:00",
  "total_records": 7,
  "inserted": 3,
  "updated": 4,
  "regions_with_errors": [],
  "new_slots": [{...}],
  "notifications": [{"channel_id": "...", "ok": true, ...}]
}
\`\`\`

## Test plan

- [x] \`make check\` (lint + typecheck + test) 緑 — 98 passed (新規 4)
- [x] e2e で mock script を \`--bin\` で指して 4 シナリオ網羅:
  - 正常 ingest (\`inserted=1\`、\`new_slots\` に乗る)
  - exit non-zero で \`mound\` も exit 1 + scraper stderr 引用
  - \`--notify --team\` で \`log-only\` sender が stderr に新規 slot を出す
  - \`--notify\` だけで \`--team\` 無しは exit 2
- [ ] CI 緑を確認

## 受け入れ条件 (#172 より)

- [x] \`--bin\` で渡したスクリプトの stdout を ingest できる
- [x] non-zero exit で exit 1 + stderr に scraper の stderr が出る
- [x] \`--notify --team\` で \`first_seen_at >= beforeSyncAt\` の slot だけ通知に乗る
- [x] BDD テスト (e2e で mock script 経由)

## 次のステップ

- ground-reservation で v0.1.0 タグを切って release workflow を実走、4 ターゲット binary を publish する(別作業)

🤖 Generated with [Claude Code](https://claude.com/claude-code)