### PR TITLE
build(make): install-local pulls ground-monitoring from GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,13 @@ jobs:
         run: |
           bash -n scripts/generate-formula.sh
           bash -n scripts/build-dist.sh
+          bash -n scripts/install-ground-monitoring.sh
           sh -n packages/cli/scripts/mound-launcher.sh
       - name: shellcheck
         run: |
           shellcheck scripts/generate-formula.sh
           shellcheck scripts/build-dist.sh
+          shellcheck scripts/install-ground-monitoring.sh
           shellcheck packages/cli/scripts/mound-launcher.sh
 
   menubar:

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ npm-debug.log*
 .vscode/
 .idea/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .last-run.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: start mound build cli-build dist-clean install-local uninstall-local \
+        install-ground-monitoring uninstall-ground-monitoring \
         lint lint-fix lint-check format typecheck test test-watch test-coverage \
         check before-commit clean install install-ci help
 
@@ -47,7 +48,13 @@ dist-clean: ## dist/ を全削除
 	rm -rf $(DIST)
 
 INSTALL_PREFIX ?= $(HOME)/.local
-install-local: cli-build ## $(INSTALL_PREFIX)/{bin,share} に配置 (デフォルト ~/.local)
+
+# 連携先 ground-monitoring (susumutomita/ground-reservation) のバージョンとリポジトリ。
+# `GROUND_RES_VERSION=v2.2.0 make install-local` のように上書き可能。
+GROUND_RES_VERSION ?= v2.1.0
+GROUND_RES_REPO ?= susumutomita/ground-reservation
+
+install-local: cli-build install-ground-monitoring ## $(INSTALL_PREFIX)/{bin,share} に mound + ground-monitoring を配置
 	@mkdir -p $(INSTALL_PREFIX)/share $(INSTALL_PREFIX)/bin
 	@rm -rf $(INSTALL_PREFIX)/share/mound
 	@cp -R $(DIST)/local/mound-$(HOST_PLATFORM) $(INSTALL_PREFIX)/share/mound
@@ -58,10 +65,19 @@ install-local: cli-build ## $(INSTALL_PREFIX)/{bin,share} に配置 (デフォ�
 	  *) echo "⚠  $(INSTALL_PREFIX)/bin は PATH に入っていません" ;; \
 	esac
 
-uninstall-local: ## $(INSTALL_PREFIX) から削除
+install-ground-monitoring: ## ground-monitoring を GitHub Releases から取って $(INSTALL_PREFIX) に配置
+	@bash scripts/install-ground-monitoring.sh \
+	  $(HOST_PLATFORM) $(INSTALL_PREFIX) $(GROUND_RES_VERSION) $(GROUND_RES_REPO)
+
+uninstall-local: uninstall-ground-monitoring ## $(INSTALL_PREFIX) から mound と ground-monitoring を削除
 	@rm -f $(INSTALL_PREFIX)/bin/mound
 	@rm -rf $(INSTALL_PREFIX)/share/mound
-	@echo "✅ uninstalled from $(INSTALL_PREFIX)"
+	@echo "✅ uninstalled mound from $(INSTALL_PREFIX)"
+
+uninstall-ground-monitoring: ## $(INSTALL_PREFIX) から ground-monitoring を削除
+	@rm -f $(INSTALL_PREFIX)/bin/ground-monitoring
+	@rm -rf $(INSTALL_PREFIX)/share/ground-monitoring
+	@echo "✅ uninstalled ground-monitoring from $(INSTALL_PREFIX)"
 
 ## 品質チェック
 lint: ## Biome lint チェック

--- a/README.md
+++ b/README.md
@@ -34,13 +34,20 @@ mound --version
 ```bash
 git clone https://github.com/susumutomita/mound.git
 cd mound
-make install        # 依存インストール
-make install-local  # dist/local/mound-<host>/ を $HOME/.local/share/mound にコピー +
-                    # $HOME/.local/bin/mound に launcher への symlink
+make install        # 依存インストール (Bun deps)
+make install-local  # mound + ground-monitoring を $HOME/.local/{bin,share} に配置
 mound --version
+ground-monitoring --version
 ```
 
-`make cli-build` 単体だと `dist/local/mound-<host>/` を生成するだけで PATH に乗らない。`INSTALL_PREFIX` で行き先変更可(例: `make install-local INSTALL_PREFIX=/opt/homebrew`)。`make uninstall-local` で削除。
+`make install-local` は以下を一括でやる:
+
+1. `dist/local/mound-<host>/` を生成し `$HOME/.local/share/mound` にコピー、`$HOME/.local/bin/mound` に launcher への symlink を張る
+2. `susumutomita/ground-reservation` の最新 release から `ground-monitoring-<host>` tarball を DL + sha256 検証し、`$HOME/.local/share/ground-monitoring` に展開、`$HOME/.local/bin/ground-monitoring` に symlink
+
+これで `mound ground sync --notify --team $TEAM` が依存込みで動く状態になる。`make cli-build` 単体だと `dist/local/mound-<host>/` を生成するだけで PATH に乗らない。
+
+`INSTALL_PREFIX` で行き先変更可(例: `make install-local INSTALL_PREFIX=/opt/homebrew`)。連携先 ground-reservation のタグは `GROUND_RES_VERSION=v2.2.0 make install-local` で上書き可能(既定: `v2.1.0`)。`make uninstall-local` で両方削除。ネットワーク不能等で ground-monitoring の取得に失敗しても mound 本体のインストールは続行される(警告のみ)。
 
 > **配布の仕組み:** Bun の `bun build --compile` は libsql の native binding (`@libsql/<platform>/index.node`) を埋め込めない(`@neon-rs/load` が動的 require を使うため)。配布物は `bin/mound` (POSIX sh launcher) + `libexec/mound/{bun, mound.js, node_modules}` の構造で、launcher が `$(dirname "$0")/../libexec/mound/bun` を `exec` して JS bundle を Bun runtime で動かす。
 

--- a/scripts/install-ground-monitoring.sh
+++ b/scripts/install-ground-monitoring.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ground-monitoring (susumutomita/ground-reservation) を GitHub Releases から
+# DL して INSTALL_PREFIX に配置する。
+#
+# 使い方:
+#   ./scripts/install-ground-monitoring.sh <HOST_PLATFORM> <INSTALL_PREFIX> [<VERSION>] [<REPO>]
+#
+# 引数:
+#   HOST_PLATFORM    mound の Makefile が決めるホスト識別子 (macos-arm64 / macos-x86_64 /
+#                    linux-arm64 / linux-x86_64)。macos-x86_64 は Rosetta 用に
+#                    内部で macos-arm64 にフォールバックする。
+#   INSTALL_PREFIX   配置先のプレフィックス。例: $HOME/.local
+#   VERSION          ground-reservation のタグ。省略時は v2.1.0
+#   REPO             susumutomita/ground-reservation を上書きしたい場合に
+#
+# 失敗 (network NG / 検証失敗 / 未対応 platform) しても exit 0 で返し、
+# 呼び出し元 (make install-local) を巻き込まない。代わりに警告を出す。
+#
+# DL は gh CLI があれば gh release download を、無ければ curl --location を使う。
+# GitHub の生 release download URL は時々 404 を返す (CDN propagation 等) ので
+# gh を優先する。
+set -uo pipefail
+
+PLATFORM="${1:-}"
+PREFIX="${2:-}"
+VERSION="${3:-v2.1.0}"
+REPO="${4:-susumutomita/ground-reservation}"
+
+if [ -z "$PLATFORM" ] || [ -z "$PREFIX" ]; then
+  echo "usage: $0 <HOST_PLATFORM> <INSTALL_PREFIX> [<VERSION>] [<REPO>]" >&2
+  exit 0
+fi
+
+# mound の HOST_PLATFORM → ground-reservation の配布物名にマップ。
+# ground-reservation は macos-x86_64 を配っていないので Rosetta 経由で macos-arm64 を使う。
+case "$PLATFORM" in
+  macos-arm64|macos-x86_64) GR_TARGET=macos-arm64 ;;
+  linux-x86_64)             GR_TARGET=linux-x86_64 ;;
+  linux-arm64)              GR_TARGET=linux-arm64 ;;
+  *)
+    echo "⚠  ground-monitoring: 未対応 platform '$PLATFORM' — スキップします" >&2
+    exit 0
+    ;;
+esac
+
+if [ "$PLATFORM" = "macos-x86_64" ]; then
+  echo "ℹ️ ground-monitoring: macos-x86_64 用バイナリは無いため Rosetta 経由で macos-arm64 を使います" >&2
+fi
+
+TARBALL="ground-monitoring-${GR_TARGET}.tar.gz"
+SHA="ground-monitoring-${GR_TARGET}.sha256"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# 1 ファイルを DL する。gh があれば優先、無ければ curl にフォールバック。
+download_file() {
+  local name="$1"
+  local out="$2"
+  if command -v gh >/dev/null 2>&1; then
+    if gh release download "$VERSION" --repo "$REPO" --pattern "$name" --output "$out" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  local url="https://github.com/${REPO}/releases/download/${VERSION}/${name}"
+  if curl --fail --location --silent --show-error -o "$out" "$url"; then
+    return 0
+  fi
+  echo "⚠  ground-monitoring: 取得失敗 $name (gh / curl 両方)" >&2
+  return 1
+}
+
+echo "==> ground-monitoring ${VERSION} (${GR_TARGET}) を取得"
+if ! download_file "$TARBALL" "$TMP/$TARBALL"; then exit 0; fi
+if ! download_file "$SHA" "$TMP/$SHA";       then exit 0; fi
+
+echo "==> sha256 検証"
+verify_ok=0
+if command -v shasum >/dev/null 2>&1; then
+  (cd "$TMP" && shasum -a 256 -c "$SHA" >/dev/null 2>&1) && verify_ok=1
+elif command -v sha256sum >/dev/null 2>&1; then
+  (cd "$TMP" && sha256sum -c "$SHA" >/dev/null 2>&1) && verify_ok=1
+else
+  echo "⚠  ground-monitoring: shasum / sha256sum が無いので検証スキップ" >&2
+  verify_ok=1
+fi
+if [ "$verify_ok" -ne 1 ]; then
+  echo "⚠  ground-monitoring: sha256 検証に失敗 — スキップします" >&2
+  exit 0
+fi
+
+echo "==> ${PREFIX}/share/ground-monitoring に展開"
+mkdir -p "$PREFIX/share" "$PREFIX/bin"
+rm -rf "$PREFIX/share/ground-monitoring"
+mkdir -p "$TMP/extract"
+tar -xzf "$TMP/$TARBALL" -C "$TMP/extract"
+if [ ! -d "$TMP/extract/ground-monitoring-${GR_TARGET}" ]; then
+  echo "⚠  ground-monitoring: tarball の構造が想定外 — スキップします" >&2
+  exit 0
+fi
+mv "$TMP/extract/ground-monitoring-${GR_TARGET}" "$PREFIX/share/ground-monitoring"
+
+ln -sf "$PREFIX/share/ground-monitoring/ground-monitoring" "$PREFIX/bin/ground-monitoring"
+
+if ! "$PREFIX/bin/ground-monitoring" --help >/dev/null 2>&1; then
+  echo "⚠  ground-monitoring: smoke test に失敗 — シンボリックリンクは残しますが動作確認してください" >&2
+fi
+
+echo "✅ ${PREFIX}/bin/ground-monitoring -> ${PREFIX}/share/ground-monitoring/ground-monitoring"


### PR DESCRIPTION
Closes #174.

## 問題

\`make install-local\` で mound を入れたあとに \`mound ground sync\` を叩くと、内部で spawn する \`ground-monitoring\` (susumutomita/ground-reservation) が PATH に無くて失敗する。「make install で動く」状態になっていなかった。

## 変更

- **\`scripts/install-ground-monitoring.sh\`**: \`HOST_PLATFORM\` を引数で受けて ground-reservation の Release tarball を DL + sha256 検証 + \`INSTALL_PREFIX/share/ground-monitoring\` に展開 + \`INSTALL_PREFIX/bin/ground-monitoring\` に symlink。\`gh release download\` を優先、無ければ \`curl --location\` にフォールバック (GitHub の生 download URL は CDN 起因で時々 404 を返すため)。失敗しても警告のみで \`exit 0\` (mound 本体のインストールは止めない)
- **\`Makefile\`**: \`install-ground-monitoring\` ターゲット新設、\`install-local\` から呼ぶ。\`uninstall-local\` も両方消す。\`GROUND_RES_VERSION\` / \`GROUND_RES_REPO\` で上書き可
- **\`README.md\`**: \`make install-local\` が両方入れる旨を反映、\`GROUND_RES_VERSION\` 上書きの例も
- **\`.github/workflows/ci.yml\`**: shellcheck 対象に \`install-ground-monitoring.sh\` 追加
- **\`.gitignore\`**: \`.claude/scheduled_tasks.lock\` を除外

## platform マッピング

| HOST_PLATFORM (mound) | ground-reservation の tarball |
| --- | --- |
| \`macos-arm64\` | \`ground-monitoring-macos-arm64\` |
| \`macos-x86_64\` | \`ground-monitoring-macos-arm64\` (Rosetta) |
| \`linux-x86_64\` | \`ground-monitoring-linux-x86_64\` |
| \`linux-arm64\` | \`ground-monitoring-linux-arm64\` |

## ローカル検証

\`\`\`bash
make uninstall-local
make install-local
# → mound + ground-monitoring が両方 \$HOME/.local/bin に入る
mound ground sync --region ayase --json
# → {"region":"ayase","bin":"ground-monitoring","scraped_at":"...","total_records":0,...}
\`\`\`

## Test plan

- [x] \`make uninstall-local && make install-local\` で両 binary が入る (ローカルで確認済)
- [x] \`mound ground sync --region ayase --json\` が PATH の ground-monitoring を spawn して 0 件 ingest する (ローカルで確認済)
- [x] \`make check\` (lint + typecheck + test) 緑 — 98 passed
- [x] \`bash -n\` でスクリプトの syntax 検証通過
- [ ] CI 緑を確認 (shellcheck も新スクリプトを通す)

## 受け入れ条件 (#174 より)

- [x] クリーン状態で \`make install-local\` を叩くと、\`mound\` と \`ground-monitoring\` が両方 \`$HOME/.local/bin\` に入る
- [x] PATH 解決の \`ground-monitoring\` で \`mound ground sync --region ayase --json\` が起動する (ネットワーク失敗は許容)
- [x] DL 失敗時に mound のインストールは成功扱いになる (\`exit 0\` で警告のみ)
- [x] \`make uninstall-local\` で両方消える
- [x] \`GROUND_RES_VERSION=v2.2.0 make install-local\` で別バージョンを引ける (Makefile 変数化済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)