### PR TITLE
feat(watch): per-team ground watch filters — notify only on matching slots

### DIFF
--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -613,6 +613,160 @@ JSON
       expect(r.code).toBe(2);
       expect(r.stderr).toContain("--team");
     });
+
+    it("watch を登録すると ground sync --notify はマッチした new_slots だけを送る", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "watch e2e", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+      runMound(
+        [
+          "notify",
+          "add",
+          "--team",
+          team.id,
+          "--kind",
+          "DISCORD",
+          "--webhook",
+          "https://discord.com/api/webhooks/dummy",
+          "--json",
+        ],
+        env,
+      );
+
+      // 週末午前の野球場だけを通すよう watch を登録
+      const addWatch = runMound(
+        [
+          "watch",
+          "add",
+          "--team",
+          team.id,
+          "--facility",
+          "%野球場%",
+          "--weekdays",
+          "sat,sun",
+          "--time-to",
+          "12:00",
+          "--label",
+          "週末午前",
+          "--json",
+        ],
+        env,
+      );
+      expect(addWatch.code).toBe(0);
+
+      // 3 件中 1 件だけ watch にマッチする mock JSON を吐くスクリプト
+      const mockBin = join(dbDir, "fake-watch-filter.sh");
+      const payload = {
+        schema_version: 1,
+        scraped_at: "2026-05-22T20:00:00+09:00",
+        regions: [
+          {
+            region: "kanagawa",
+            records: [
+              // 土曜 09-12 の野球場 → match
+              {
+                region: "kanagawa",
+                facility_name: "軟式野球場",
+                date_raw: "2026/05/30",
+                date_iso: "2026-05-30",
+                time_range: "09:00-12:00",
+                status: "空き",
+                raw: "",
+              },
+              // 土曜 15-18 の野球場 → time_to=12:00 で弾かれる
+              {
+                region: "kanagawa",
+                facility_name: "軟式野球場",
+                date_raw: "2026/05/30",
+                date_iso: "2026-05-30",
+                time_range: "15:00-18:00",
+                status: "空き",
+                raw: "",
+              },
+              // 土曜 09-12 の体育館 → facility_pattern で弾かれる
+              {
+                region: "kanagawa",
+                facility_name: "体育館",
+                date_raw: "2026/05/30",
+                date_iso: "2026-05-30",
+                time_range: "09:00-12:00",
+                status: "空き",
+                raw: "",
+              },
+            ],
+            errors: [],
+          },
+        ],
+      };
+      writeFileSync(
+        mockBin,
+        `#!/usr/bin/env bash\ncat <<'JSON'\n${JSON.stringify(payload)}\nJSON\n`,
+        { mode: 0o755 },
+      );
+
+      const r = runMound(
+        [
+          "ground",
+          "sync",
+          "--bin",
+          mockBin,
+          "--notify",
+          "--team",
+          team.id,
+          "--json",
+        ],
+        env,
+      );
+      expect(r.code).toBe(0);
+      const out = parseJson<{
+        new_slots: Array<{ facility_name: string; time_range: string }>;
+        notifications: Array<{ ok: boolean }>;
+      }>(r.stdout);
+
+      // new_slots は 3 件 (全部 first observed) だが、通知は filter が効いて 1 件
+      expect(out.new_slots).toHaveLength(3);
+      expect(out.notifications).toHaveLength(1);
+      // log-only sender が stderr に出した内容に「軟式野球場」09:00-12:00 が乗る
+      expect(r.stderr).toContain("軟式野球場");
+      // 弾かれた 体育館 / 15:00-18:00 は乗らない
+      expect(r.stderr).not.toContain("体育館");
+      expect(r.stderr).not.toContain("15:00-18:00");
+    });
+
+    it("watch test --team で現在の slot が watch に合致するか確認できる", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "watch test cmd", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+      // 何も watch を入れていない状態 → 全件返る
+      const r0 = runMound(["watch", "test", "--team", team.id, "--json"], env);
+      expect(r0.code).toBe(0);
+      const baseline = parseJson<{ count: number }>(r0.stdout);
+
+      // watch を登録: kanagawa の体育館だけマッチ (現状の DB には体育館 slot が無いはず)
+      runMound(
+        [
+          "watch",
+          "add",
+          "--team",
+          team.id,
+          "--source",
+          "kanagawa",
+          "--facility",
+          "体育館",
+          "--json",
+        ],
+        env,
+      );
+      const r1 = runMound(["watch", "test", "--team", team.id, "--json"], env);
+      expect(r1.code).toBe(0);
+      const filtered = parseJson<{ count: number }>(r1.stdout);
+      // watch を 1 つ入れたので絞り込みが効く → baseline 以下
+      expect(filtered.count).toBeLessThanOrEqual(baseline.count);
+    });
   });
 
   describe("notify チャネル管理のとき", () => {

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -5,6 +5,7 @@ import type {
   AuditLog,
   Game,
   GroundSlot,
+  GroundWatch,
   Member,
   MemberRsvp,
   NotificationChannel,
@@ -17,6 +18,7 @@ import type {
   AuditRepository,
   GameRepository,
   GroundSlotRepository,
+  GroundWatchRepository,
   MemberRepository,
   NotificationChannelRepository,
   NotificationSender,
@@ -195,6 +197,22 @@ function buildFake(): Fake {
     remove: async (id) => notificationStore.delete(id),
   };
 
+  const watchStore = new Map<string, GroundWatch>();
+  const groundWatches: GroundWatchRepository = {
+    insert: async (w) => {
+      watchStore.set(w.id, w);
+      return w;
+    },
+    list: async (teamId) =>
+      Array.from(watchStore.values()).filter((w) => w.team_id === teamId),
+    listEnabled: async (teamId) =>
+      Array.from(watchStore.values()).filter(
+        (w) => w.team_id === teamId && w.enabled,
+      ),
+    get: async (id) => watchStore.get(id) ?? null,
+    remove: async (id) => watchStore.delete(id),
+  };
+
   return {
     teamStore,
     memberStore,
@@ -212,6 +230,7 @@ function buildFake(): Fake {
       audit,
       groundSlots,
       notifications,
+      groundWatches,
     },
   };
 }

--- a/packages/cli/src/__tests__/usecases/ground-watch.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-watch.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from "vitest";
+import type { GroundSlot, GroundWatch, Team } from "../../domain/types";
+import type {
+  GroundWatchRepository,
+  Repositories,
+  TeamRepository,
+  UseCaseContext,
+} from "../../ports";
+import {
+  addGroundWatch,
+  filterSlotsByTeamWatches,
+  listGroundWatches,
+  removeGroundWatch,
+  slotMatchesWatch,
+} from "../../usecases/ground-watch";
+
+function buildFake(): {
+  ctx: UseCaseContext;
+  teams: Map<string, Team>;
+  watches: Map<string, GroundWatch>;
+} {
+  const teams = new Map<string, Team>();
+  const watches = new Map<string, GroundWatch>();
+  const teamRepo: TeamRepository = {
+    insert: async (t) => {
+      teams.set(t.id, t);
+      return t;
+    },
+    list: async () => Array.from(teams.values()),
+    get: async (id) => teams.get(id) ?? null,
+  };
+  const watchRepo: GroundWatchRepository = {
+    insert: async (w) => {
+      watches.set(w.id, w);
+      return w;
+    },
+    list: async (teamId) =>
+      Array.from(watches.values()).filter((w) => w.team_id === teamId),
+    listEnabled: async (teamId) =>
+      Array.from(watches.values()).filter(
+        (w) => w.team_id === teamId && w.enabled,
+      ),
+    get: async (id) => watches.get(id) ?? null,
+    remove: async (id) => watches.delete(id),
+  };
+  const stub = new Proxy({}, { get: () => async () => null }) as never;
+  const repo: Repositories = {
+    teams: teamRepo,
+    members: stub,
+    games: stub,
+    rsvps: stub,
+    audit: stub,
+    groundSlots: stub,
+    notifications: stub,
+    groundWatches: watchRepo,
+  };
+  let seq = 0;
+  const ctx: UseCaseContext = {
+    repo,
+    notifier: stub,
+    now: () => new Date("2026-05-22T10:00:00.000Z"),
+    newId: () => `w-${++seq}`,
+  };
+  return { ctx, teams, watches };
+}
+
+function slot(overrides: Partial<GroundSlot>): GroundSlot {
+  return {
+    id: "s",
+    slot_key: "k",
+    source: "kanagawa",
+    facility_name: "軟式野球場",
+    date_iso: "2026-05-30", // Saturday
+    date_raw: "2026/05/30",
+    time_range: "09:00-12:00",
+    status: "空き",
+    raw: "",
+    scraped_at: "x",
+    first_seen_at: "x",
+    ingested_at: "x",
+    ...overrides,
+  };
+}
+
+function watch(overrides: Partial<GroundWatch>): GroundWatch {
+  return {
+    id: "w",
+    team_id: "t",
+    label: null,
+    source: null,
+    facility_pattern: null,
+    weekdays: null,
+    time_from: null,
+    time_to: null,
+    enabled: true,
+    created_at: "x",
+    updated_at: "x",
+    ...overrides,
+  };
+}
+
+describe("slotMatchesWatch", () => {
+  describe("条件が全部 null のとき", () => {
+    it("どんな slot にもマッチする (全通し)", () => {
+      expect(slotMatchesWatch(slot({}), watch({}))).toBe(true);
+    });
+  });
+
+  describe("source が一致しないとき", () => {
+    it("マッチしない", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ source: "kanagawa" }),
+          watch({ source: "yokohama" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("facility_pattern が LIKE のとき", () => {
+    it("% は任意の文字列にマッチする", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ facility_name: "田端スポーツ公園野球場" }),
+          watch({ facility_pattern: "%野球場%" }),
+        ),
+      ).toBe(true);
+    });
+
+    it("接頭辞でも _ でも当たる", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ facility_name: "保土ケ谷球場" }),
+          watch({ facility_pattern: "保土ケ谷%" }),
+        ),
+      ).toBe(true);
+      expect(
+        slotMatchesWatch(
+          slot({ facility_name: "ABCD" }),
+          watch({ facility_pattern: "A__D" }),
+        ),
+      ).toBe(true);
+    });
+
+    it("マッチしないものは弾く", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ facility_name: "体育館" }),
+          watch({ facility_pattern: "%野球場%" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("weekdays のとき", () => {
+    it("2026-05-30 は土曜なので sat が含まれていれば通る", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ date_iso: "2026-05-30" }),
+          watch({ weekdays: "sat,sun" }),
+        ),
+      ).toBe(true);
+    });
+
+    it("2026-05-25 は月曜なので sat,sun だけだと弾かれる", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ date_iso: "2026-05-25" }),
+          watch({ weekdays: "sat,sun" }),
+        ),
+      ).toBe(false);
+    });
+
+    it("date_iso が無い slot は weekdays 指定があれば弾く", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ date_iso: null }),
+          watch({ weekdays: "sat,sun" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("time_from / time_to のとき", () => {
+    it("time_from <= slot 開始時刻なら通る", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ time_range: "09:00-12:00" }),
+          watch({ time_from: "09:00" }),
+        ),
+      ).toBe(true);
+      expect(
+        slotMatchesWatch(
+          slot({ time_range: "08:00-10:00" }),
+          watch({ time_from: "09:00" }),
+        ),
+      ).toBe(false);
+    });
+
+    it("time_to >= slot 終了時刻なら通る", () => {
+      expect(
+        slotMatchesWatch(
+          slot({ time_range: "09:00-12:00" }),
+          watch({ time_to: "12:00" }),
+        ),
+      ).toBe(true);
+      expect(
+        slotMatchesWatch(
+          slot({ time_range: "09:00-13:00" }),
+          watch({ time_to: "12:00" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("複数条件 AND のとき", () => {
+    it("全条件を満たさないと弾く", () => {
+      expect(
+        slotMatchesWatch(
+          slot({
+            source: "kanagawa",
+            facility_name: "軟式野球場",
+            date_iso: "2026-05-30",
+            time_range: "09:00-12:00",
+          }),
+          watch({
+            source: "kanagawa",
+            facility_pattern: "%野球場%",
+            weekdays: "sat,sun",
+            time_from: "09:00",
+            time_to: "12:00",
+          }),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("enabled=false の watch のとき", () => {
+    it("マッチしない", () => {
+      expect(slotMatchesWatch(slot({}), watch({ enabled: false }))).toBe(false);
+    });
+  });
+});
+
+describe("filterSlotsByTeamWatches", () => {
+  describe("team に watch が 1 つも無いとき", () => {
+    it("全 slot を通す (後方互換)", async () => {
+      const fake = buildFake();
+      await fake.ctx.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const slots = [slot({ id: "a" }), slot({ id: "b", source: "yokohama" })];
+      const result = await filterSlotsByTeamWatches(fake.ctx, "t", slots);
+      expect(result).toEqual(slots);
+    });
+  });
+
+  describe("watch が複数あるとき (OR 評価)", () => {
+    it("どれか 1 つに当たれば通す", async () => {
+      const fake = buildFake();
+      await fake.ctx.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await addGroundWatch(fake.ctx, {
+        teamId: "t",
+        label: "kanagawa 軟式",
+        source: "kanagawa",
+        facilityPattern: "軟式野球場",
+        weekdays: null,
+        timeFrom: null,
+        timeTo: null,
+      });
+      await addGroundWatch(fake.ctx, {
+        teamId: "t",
+        label: "yokohama 全部",
+        source: "yokohama",
+        facilityPattern: null,
+        weekdays: null,
+        timeFrom: null,
+        timeTo: null,
+      });
+
+      const result = await filterSlotsByTeamWatches(fake.ctx, "t", [
+        slot({ id: "k1", source: "kanagawa", facility_name: "軟式野球場" }),
+        slot({ id: "y1", source: "yokohama", facility_name: "こども自然公園" }),
+        slot({
+          id: "s1",
+          source: "samukawa",
+          facility_name: "田端スポーツ公園野球場",
+        }),
+      ]);
+      const ids = result.map((s) => s.id).sort();
+      expect(ids).toEqual(["k1", "y1"]);
+    });
+  });
+
+  describe("enabled=false の watch しか無いとき", () => {
+    it("listEnabled が空配列なので、後方互換で全 slot を通す", async () => {
+      const fake = buildFake();
+      await fake.ctx.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const w = await addGroundWatch(fake.ctx, {
+        teamId: "t",
+        label: null,
+        source: "kanagawa",
+        facilityPattern: null,
+        weekdays: null,
+        timeFrom: null,
+        timeTo: null,
+      });
+      // 直接 store を書き換えて enabled を落とす (CRUD update API は無いので)
+      const stored = fake.watches.get(w.id);
+      if (stored) fake.watches.set(w.id, { ...stored, enabled: false });
+
+      const slots = [slot({ id: "s1" })];
+      const result = await filterSlotsByTeamWatches(fake.ctx, "t", slots);
+      expect(result).toEqual(slots);
+    });
+  });
+});
+
+describe("addGroundWatch / listGroundWatches / removeGroundWatch", () => {
+  it("CRUD のひと通りができる", async () => {
+    const fake = buildFake();
+    await fake.ctx.repo.teams.insert({
+      id: "t",
+      name: "T",
+      home_area: null,
+      created_at: "x",
+      updated_at: "x",
+    });
+    const w = await addGroundWatch(fake.ctx, {
+      teamId: "t",
+      label: "週末野球場",
+      source: null,
+      facilityPattern: "%野球場%",
+      weekdays: "sat,sun",
+      timeFrom: "09:00",
+      timeTo: "17:00",
+    });
+    expect(w.id).toBe("w-1");
+    expect(w.enabled).toBe(true);
+
+    const list = await listGroundWatches(fake.ctx, "t");
+    expect(list).toHaveLength(1);
+
+    expect(await removeGroundWatch(fake.ctx, w.id)).toBe(true);
+    expect(await removeGroundWatch(fake.ctx, w.id)).toBe(false);
+    expect(await listGroundWatches(fake.ctx, "t")).toEqual([]);
+  });
+
+  it("team が無いと TeamNotFoundError", async () => {
+    const fake = buildFake();
+    await expect(
+      addGroundWatch(fake.ctx, {
+        teamId: "ghost",
+        label: null,
+        source: null,
+        facilityPattern: null,
+        weekdays: null,
+        timeFrom: null,
+        timeTo: null,
+      }),
+    ).rejects.toThrow(/team が存在しません/);
+  });
+});

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -56,6 +56,7 @@ function buildCtx(opts: { now: Date; idSeed?: number }): {
     audit: stub,
     groundSlots,
     notifications: stub,
+    groundWatches: stub,
   };
   const notifier = {
     send: async () => ({

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -67,6 +67,16 @@ function buildFake(opts?: { senderError?: Error }): Fake {
   // GroundSlotRepository だけは型を埋めるためのスタブ。本テストでは使わない。
   const groundSlots: GroundSlotRepository = stub;
 
+  // groundWatches は filterSlotsByTeamWatches が listEnabled の戻り値の .length を
+  // 触るため、Proxy の "全部 null を返す" stub では落ちる。明示的に空配列を返す。
+  const emptyWatches = {
+    insert: async (w: never) => w,
+    list: async () => [],
+    listEnabled: async () => [],
+    get: async () => null,
+    remove: async () => false,
+  } as never;
+
   const repo: Repositories = {
     teams: teamRepo,
     members: stub,
@@ -75,6 +85,7 @@ function buildFake(opts?: { senderError?: Error }): Fake {
     audit: stub,
     groundSlots,
     notifications: notificationRepo,
+    groundWatches: emptyWatches,
   };
 
   const notifier: NotificationSender = {

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -32,6 +32,7 @@ import { runMember } from "./commands/member";
 import { runNotify } from "./commands/notify";
 import { runRsvp } from "./commands/rsvp";
 import { runTeam } from "./commands/team";
+import { runWatch } from "./commands/watch";
 import { composeContext } from "./compose";
 import { HELP, VERSION, findCommandHelp } from "./help";
 import {
@@ -118,6 +119,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "notify":
         await runNotify(subArgs, ctx, renderOpts);
+        return 0;
+      case "watch":
+        await runWatch(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/commands/watch.ts
+++ b/packages/cli/src/adapters/cli/commands/watch.ts
@@ -1,0 +1,161 @@
+import { z } from "zod";
+import type { UseCaseContext } from "../../../ports";
+import { listGroundSlots } from "../../../usecases/ground";
+import {
+  addGroundWatch,
+  filterSlotsByTeamWatches,
+  listGroundWatches,
+  removeGroundWatch,
+} from "../../../usecases/ground-watch";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const TIME_RE = /^([01]?\d|2[0-3]):[0-5]\d$/;
+const WEEKDAY_VALUES = [
+  "sun",
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+] as const;
+
+const addInput = z.object({
+  teamId: z.string().min(1),
+  label: z.string().max(80).optional(),
+  source: z.string().min(1).max(40).optional(),
+  facilityPattern: z.string().max(200).optional(),
+  weekdays: z
+    .string()
+    .regex(/^[a-z,]+$/, "weekdays は CSV (例: sat,sun)")
+    .optional()
+    .refine(
+      (v) =>
+        v === undefined ||
+        v
+          .split(",")
+          .every((d) => (WEEKDAY_VALUES as readonly string[]).includes(d)),
+      "weekdays は sun,mon,tue,wed,thu,fri,sat の組み合わせ",
+    ),
+  timeFrom: z.string().regex(TIME_RE, "time-from は HH:MM").optional(),
+  timeTo: z.string().regex(TIME_RE, "time-to は HH:MM").optional(),
+});
+
+export async function runWatch(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound watch <add|list|remove|test>");
+  if (sub === "add") return addCmd(args, ctx, opts);
+  if (sub === "list") return listCmd(args, ctx, opts);
+  if (sub === "remove") return removeCmd(args, ctx, opts);
+  if (sub === "test") return testCmd(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: watch ${sub}`);
+}
+
+async function addCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(addInput, {
+    teamId: requireFlag(args.flags, "team"),
+    label: optionalFlag(args.flags, "label"),
+    source: optionalFlag(args.flags, "source"),
+    facilityPattern: optionalFlag(args.flags, "facility"),
+    weekdays: optionalFlag(args.flags, "weekdays"),
+    timeFrom: optionalFlag(args.flags, "time-from"),
+    timeTo: optionalFlag(args.flags, "time-to"),
+  });
+  const watch = await addGroundWatch(ctx, {
+    teamId: data.teamId,
+    label: data.label ?? null,
+    source: data.source ?? null,
+    facilityPattern: data.facilityPattern ?? null,
+    weekdays: data.weekdays ?? null,
+    timeFrom: data.timeFrom ?? null,
+    timeTo: data.timeTo ?? null,
+  });
+  emit(
+    watch,
+    `watch を追加しました: ${watch.id} (${watch.label ?? "(無名)"})`,
+    opts,
+  );
+}
+
+async function listCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const watches = await listGroundWatches(ctx, teamId);
+  emit(
+    watches,
+    formatRows(watches, [
+      "id",
+      "label",
+      "source",
+      "facility_pattern",
+      "weekdays",
+      "time_from",
+      "time_to",
+      "enabled",
+    ]),
+    opts,
+  );
+}
+
+async function removeCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id) throw new UsageError("使い方: mound watch remove <ID>");
+  const removed = await removeGroundWatch(ctx, id);
+  emit(
+    { ok: removed, id },
+    removed
+      ? `watch を削除しました: ${id}`
+      : `該当する watch が見つかりません: ${id}`,
+    opts,
+  );
+}
+
+async function testCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  // 全 ground_slots に対して team の watches を適用する。
+  // 大規模 DB では遅い可能性があるが、Phase 1 のスコープでは現実的。
+  const slots = await listGroundSlots(ctx, {});
+  const matched = await filterSlotsByTeamWatches(ctx, teamId, slots);
+  emit(
+    { count: matched.length, slots: matched },
+    matched.length === 0
+      ? "現在登録されている watch に合致する slot はありません"
+      : [
+          `${matched.length} 件マッチ`,
+          formatRows(matched, [
+            "source",
+            "facility_name",
+            "date_iso",
+            "time_range",
+            "status",
+          ]),
+        ].join("\n"),
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -26,6 +26,10 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   notify list --team <ID>
   notify remove <ID>
   notify test <ID> [--message TEXT]
+  watch add --team <ID> [--source S] [--facility PATTERN] [--weekdays sat,sun] [--time-from HH:MM] [--time-to HH:MM] [--label L]
+  watch list --team <ID>
+  watch remove <ID>
+  watch test --team <ID>
 
 環境変数 (追加):
   MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
@@ -469,6 +473,84 @@ JSON 出力:
 
 JSON 出力:
   NotificationDeliveryResult { channel_id, channel_kind, ok, status_code, error }
+`,
+
+  watch: `mound watch — チームごとの「気になるグラウンド条件」
+
+サブコマンド:
+  watch add    --team <ID> [--source S] [--facility PATTERN] [--weekdays sat,sun] \\
+               [--time-from HH:MM] [--time-to HH:MM] [--label L] [--json]
+  watch list   --team <ID> [--json]
+  watch remove <ID> [--json]
+  watch test   --team <ID> [--json]   # 現在の ground_slots と watch を照合して可視化
+
+挙動:
+  - team に watch が 1 件も無ければ ground sync --notify は従来どおり全 new_slots を送る
+  - watch が 1 件以上あるとき: どれかにマッチ (OR) した new_slots だけ通知に乗る
+  - 各 watch 内: source / facility_pattern / weekdays / time_from / time_to は AND
+  - facility_pattern は SQL LIKE (% = 任意の文字列, _ = 任意の 1 文字)
+`,
+
+  "watch add": `mound watch add — チームに「気になるグラウンド条件」を 1 件登録
+
+使い方:
+  mound watch add --team <TEAM_ID> \\
+    [--source <SOURCE>] \\
+    [--facility <LIKE_PATTERN>] \\
+    [--weekdays sat,sun] \\
+    [--time-from HH:MM] [--time-to HH:MM] \\
+    [--label <NAME>] [--json]
+
+フラグ:
+  --team       (必須) チーム ID
+  --source     (任意) yokohama / hiratsuka / kanagawa / kamakura / fujisawa / samukawa / ayase
+  --facility   (任意) facility_name の SQL LIKE パターン (例: '%野球場%' / '田端%')
+  --weekdays   (任意) sun,mon,tue,wed,thu,fri,sat の CSV
+  --time-from  (任意) slot の開始がこれ以降 (HH:MM)
+  --time-to    (任意) slot の終了がこれ以前 (HH:MM)
+  --label      (任意) 表示名
+
+例:
+  土日午前の野球場を全自治体から:
+    mound watch add --team T --facility '%野球場%' --weekdays sat,sun --time-to 12:00 --label 'weekend AM'
+  kanagawa の軟式野球場 (夕方限定):
+    mound watch add --team T --source kanagawa --facility '軟式野球場' --time-from 16:00 --label '夕方'
+
+JSON 出力:
+  GroundWatch { id, team_id, label, source, facility_pattern, weekdays,
+                time_from, time_to, enabled, created_at, updated_at }
+`,
+
+  "watch list": `mound watch list — team の watch 一覧
+
+使い方:
+  mound watch list --team <TEAM_ID> [--json]
+
+JSON 出力:
+  GroundWatch[]
+`,
+
+  "watch remove": `mound watch remove — watch を 1 件削除
+
+使い方:
+  mound watch remove <ID> [--json]
+
+JSON 出力:
+  { "ok": boolean, "id": string }
+`,
+
+  "watch test": `mound watch test — 登録 watch と現在の ground_slots を照合
+
+使い方:
+  mound watch test --team <TEAM_ID> [--json]
+
+挙動:
+  team の enabled watch を使って、現在 mound に取り込まれている全 slot の
+  うちマッチするものを返す。エージェント / 人間が watch の挙動を確認する
+  デバッグ用。
+
+JSON 出力:
+  { "count": number, "slots": GroundSlot[] }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -4,6 +4,7 @@ import type {
   Game,
   GameStatus,
   GroundSlot,
+  GroundWatch,
   Member,
   MemberRsvp,
   NotificationChannel,
@@ -18,6 +19,7 @@ import type {
   GroundSlotDiffFilter,
   GroundSlotFilter,
   GroundSlotRepository,
+  GroundWatchRepository,
   MemberRepository,
   NotificationChannelRepository,
   Repositories,
@@ -29,6 +31,7 @@ import {
   rowToAuditLog,
   rowToGame,
   rowToGroundSlot,
+  rowToGroundWatch,
   rowToMember,
   rowToMemberRsvp,
   rowToNotificationChannel,
@@ -457,6 +460,66 @@ class LibsqlNotificationChannelRepository
   }
 }
 
+class LibsqlGroundWatchRepository implements GroundWatchRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(watch: GroundWatch): Promise<GroundWatch> {
+    await this.db.execute({
+      sql: `INSERT INTO ground_watches (
+              id, team_id, label, source, facility_pattern, weekdays,
+              time_from, time_to, enabled, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        watch.id,
+        watch.team_id,
+        watch.label,
+        watch.source,
+        watch.facility_pattern,
+        watch.weekdays,
+        watch.time_from,
+        watch.time_to,
+        watch.enabled ? 1 : 0,
+        watch.created_at,
+        watch.updated_at,
+      ],
+    });
+    return watch;
+  }
+
+  async list(teamId: string): Promise<GroundWatch[]> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM ground_watches WHERE team_id = ? ORDER BY created_at ASC",
+      args: [teamId],
+    });
+    return r.rows.map(rowToGroundWatch);
+  }
+
+  async listEnabled(teamId: string): Promise<GroundWatch[]> {
+    const r = await this.db.execute({
+      sql: `SELECT * FROM ground_watches WHERE team_id = ? AND enabled <> 0
+            ORDER BY created_at ASC`,
+      args: [teamId],
+    });
+    return r.rows.map(rowToGroundWatch);
+  }
+
+  async get(id: string): Promise<GroundWatch | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM ground_watches WHERE id = ?",
+      args: [id],
+    });
+    return r.rows[0] ? rowToGroundWatch(r.rows[0]) : null;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const r = await this.db.execute({
+      sql: "DELETE FROM ground_watches WHERE id = ?",
+      args: [id],
+    });
+    return r.rowsAffected > 0;
+  }
+}
+
 export function buildRepositories(db: DbClient): Repositories {
   return {
     teams: new LibsqlTeamRepository(db),
@@ -466,5 +529,6 @@ export function buildRepositories(db: DbClient): Repositories {
     audit: new LibsqlAuditRepository(db),
     groundSlots: new LibsqlGroundSlotRepository(db),
     notifications: new LibsqlNotificationChannelRepository(db),
+    groundWatches: new LibsqlGroundWatchRepository(db),
   };
 }

--- a/packages/cli/src/adapters/libsql/row-mappers.ts
+++ b/packages/cli/src/adapters/libsql/row-mappers.ts
@@ -9,6 +9,7 @@ import type {
   AuditLog,
   Game,
   GroundSlot,
+  GroundWatch,
   Member,
   MemberRsvp,
   NotificationChannel,
@@ -101,6 +102,22 @@ export function rowToNotificationChannel(row: Row): NotificationChannel {
     secret: nullable(row.secret),
     target: nullable(row.target),
     label: nullable(row.label),
+    enabled: Number(row.enabled) !== 0,
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToGroundWatch(row: Row): GroundWatch {
+  return {
+    id: str(row.id),
+    team_id: str(row.team_id),
+    label: nullable(row.label),
+    source: nullable(row.source),
+    facility_pattern: nullable(row.facility_pattern),
+    weekdays: nullable(row.weekdays),
+    time_from: nullable(row.time_from),
+    time_to: nullable(row.time_to),
     enabled: Number(row.enabled) !== 0,
     created_at: str(row.created_at),
     updated_at: str(row.updated_at),

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 3;
+export const SCHEMA_VERSION = 4;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS teams (
@@ -97,4 +97,21 @@ CREATE TABLE IF NOT EXISTS notification_channels (
   updated_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_notif_channels_team ON notification_channels(team_id);
+
+-- チームごとの「気になるグラウンド条件」。各フィールド null は任意 (フィルタしない)。
+-- 同じ team の watch は OR で評価する。
+CREATE TABLE IF NOT EXISTS ground_watches (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  label TEXT,
+  source TEXT,
+  facility_pattern TEXT,
+  weekdays TEXT,
+  time_from TEXT,
+  time_to TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ground_watches_team ON ground_watches(team_id);
 `;

--- a/packages/cli/src/domain/types.ts
+++ b/packages/cli/src/domain/types.ts
@@ -115,6 +115,35 @@ export interface NotificationChannel {
   updated_at: string;
 }
 
+// 曜日コード (ISO weekday の小文字 3 文字)。watch.weekdays は CSV で持つ。
+export const WEEKDAY_CODES = [
+  "sun",
+  "mon",
+  "tue",
+  "wed",
+  "thu",
+  "fri",
+  "sat",
+] as const;
+export type WeekdayCode = (typeof WEEKDAY_CODES)[number];
+
+// チームが「気になるグラウンド条件」を 1 件表す。
+// 各フィールドは null なら任意 (= フィルタしない) 扱い。複数フィールドは AND。
+// 同じ team に複数 watch があれば OR (どれか 1 つにマッチしたら通す)。
+export interface GroundWatch {
+  id: string;
+  team_id: string;
+  label: string | null;
+  source: string | null;
+  facility_pattern: string | null; // SQL LIKE パターン (例: '%野球場%')
+  weekdays: string | null; // CSV 'sat,sun' / null=任意
+  time_from: string | null; // 'HH:MM' / null=任意 (slot の開始がこれ以降)
+  time_to: string | null; // 'HH:MM' / null=任意 (slot の終了がこれ以前)
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 // 外部スクレイパ (ground-reservation 等) から ingest した 1 件の空き枠。
 // slot_key = source|facility_name|date_iso|time_range (UNIQUE)
 //   ingest 時にこのキーで upsert する。

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -5,6 +5,7 @@ import type {
   Game,
   GameStatus,
   GroundSlot,
+  GroundWatch,
   Member,
   MemberRsvp,
   NotificationChannel,
@@ -68,6 +69,14 @@ export interface GroundSlotRepository {
   getByKey(slotKey: string): Promise<GroundSlot | null>;
 }
 
+export interface GroundWatchRepository {
+  insert(watch: GroundWatch): Promise<GroundWatch>;
+  list(teamId: string): Promise<GroundWatch[]>;
+  listEnabled(teamId: string): Promise<GroundWatch[]>;
+  get(id: string): Promise<GroundWatch | null>;
+  remove(id: string): Promise<boolean>;
+}
+
 export interface NotificationChannelRepository {
   insert(channel: NotificationChannel): Promise<NotificationChannel>;
   list(teamId: string): Promise<NotificationChannel[]>;
@@ -101,6 +110,7 @@ export interface Repositories {
   audit: AuditRepository;
   groundSlots: GroundSlotRepository;
   notifications: NotificationChannelRepository;
+  groundWatches: GroundWatchRepository;
 }
 
 export interface Clock {

--- a/packages/cli/src/usecases/ground-watch.ts
+++ b/packages/cli/src/usecases/ground-watch.ts
@@ -1,0 +1,136 @@
+import {
+  type GroundSlot,
+  type GroundWatch,
+  WEEKDAY_CODES,
+  type WeekdayCode,
+} from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { TeamNotFoundError } from "./errors";
+
+export interface AddGroundWatchInput {
+  teamId: string;
+  label: string | null;
+  source: string | null;
+  facilityPattern: string | null;
+  weekdays: string | null; // 'sat,sun' / null
+  timeFrom: string | null;
+  timeTo: string | null;
+}
+
+export async function addGroundWatch(
+  ctx: UseCaseContext,
+  input: AddGroundWatchInput,
+): Promise<GroundWatch> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const now = ctx.now().toISOString();
+  const watch: GroundWatch = {
+    id: ctx.newId(),
+    team_id: team.id,
+    label: input.label,
+    source: input.source,
+    facility_pattern: input.facilityPattern,
+    weekdays: input.weekdays,
+    time_from: input.timeFrom,
+    time_to: input.timeTo,
+    enabled: true,
+    created_at: now,
+    updated_at: now,
+  };
+  return ctx.repo.groundWatches.insert(watch);
+}
+
+export async function listGroundWatches(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<GroundWatch[]> {
+  return ctx.repo.groundWatches.list(teamId);
+}
+
+export async function removeGroundWatch(
+  ctx: UseCaseContext,
+  id: string,
+): Promise<boolean> {
+  return ctx.repo.groundWatches.remove(id);
+}
+
+// LIKE パターン (% = 任意の文字列, _ = 任意の 1 文字) を JS regex に変換して一致判定する。
+// SQL LIKE 互換だが、本実装ではメモリ上で評価する。
+function likeMatches(text: string, pattern: string): boolean {
+  // 正規表現メタ文字を escape したうえで % と _ をワイルドカードに展開
+  const escaped = pattern.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+  const regexSrc = `^${escaped.replace(/%/g, ".*").replace(/_/g, ".")}$`;
+  return new RegExp(regexSrc).test(text);
+}
+
+function parseWeekdayCsv(csv: string): WeekdayCode[] {
+  const valid = new Set<string>(WEEKDAY_CODES);
+  return csv
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s): s is WeekdayCode => valid.has(s));
+}
+
+function weekdayOf(dateIso: string): WeekdayCode | null {
+  const d = new Date(`${dateIso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  // getUTCDay: 0=Sun..6=Sat ↔ WEEKDAY_CODES[0]=sun..[6]=sat の順で揃えてある
+  return WEEKDAY_CODES[d.getUTCDay()] ?? null;
+}
+
+function timeRangeStart(timeRange: string | null): string | null {
+  if (!timeRange) return null;
+  const [start] = timeRange.split("-");
+  return start ?? null;
+}
+
+function timeRangeEnd(timeRange: string | null): string | null {
+  if (!timeRange) return null;
+  const parts = timeRange.split("-");
+  return parts[1] ?? null;
+}
+
+// 1 つの watch に 1 つの slot がマッチするか。
+// 各条件は null なら任意、値ありなら AND 評価。
+export function slotMatchesWatch(
+  slot: GroundSlot,
+  watch: GroundWatch,
+): boolean {
+  if (!watch.enabled) return false;
+  if (watch.source && slot.source !== watch.source) return false;
+  if (
+    watch.facility_pattern &&
+    !likeMatches(slot.facility_name, watch.facility_pattern)
+  ) {
+    return false;
+  }
+  if (watch.weekdays) {
+    if (!slot.date_iso) return false;
+    const days = parseWeekdayCsv(watch.weekdays);
+    if (days.length === 0) return false; // CSV 全部不正値なら何も通さない
+    const dow = weekdayOf(slot.date_iso);
+    if (!dow || !days.includes(dow)) return false;
+  }
+  if (watch.time_from) {
+    const start = timeRangeStart(slot.time_range);
+    if (!start || start < watch.time_from) return false;
+  }
+  if (watch.time_to) {
+    const end = timeRangeEnd(slot.time_range);
+    if (!end || end > watch.time_to) return false;
+  }
+  return true;
+}
+
+// team の watches で slot をフィルタする。
+//   - watch 0 件 → 全件通す (後方互換)
+//   - watch 複数 → どれか 1 つにマッチで通す (OR)
+export async function filterSlotsByTeamWatches(
+  ctx: UseCaseContext,
+  teamId: string,
+  slots: GroundSlot[],
+): Promise<GroundSlot[]> {
+  const watches = await ctx.repo.groundWatches.listEnabled(teamId);
+  if (watches.length === 0) return slots;
+  return slots.filter((s) => watches.some((w) => slotMatchesWatch(s, w)));
+}

--- a/packages/cli/src/usecases/notification.ts
+++ b/packages/cli/src/usecases/notification.ts
@@ -7,6 +7,7 @@ import type {
 } from "../domain/types";
 import type { NotificationDeliveryResult, UseCaseContext } from "../ports";
 import { TeamNotFoundError } from "./errors";
+import { filterSlotsByTeamWatches } from "./ground-watch";
 
 export interface AddChannelInput {
   teamId: string;
@@ -128,6 +129,10 @@ export async function notifyGroundCancellation(
   slots: GroundSlot[],
 ): Promise<NotificationDeliveryResult[]> {
   if (slots.length === 0) return [];
-  const message = formatGroundCancellationMessage(slots);
+  // team に watch が登録されていれば、マッチするものだけに絞る (OR 評価)。
+  // watch が 0 件のチームは従来どおり全件通知 (後方互換)。
+  const matched = await filterSlotsByTeamWatches(ctx, teamId, slots);
+  if (matched.length === 0) return [];
+  const message = formatGroundCancellationMessage(matched);
   return dispatch(ctx, teamId, message);
 }


### PR DESCRIPTION
Closes #176.

## Summary

team ごとに「気になるグラウンド条件」を登録し、\`mound ground sync --notify --team T\` で **マッチした new_slots だけ** が通知に乗るようにする。エージェントが団体のニーズに合わせて絞り込みをプログラム的に積める。

### 使い方

\`\`\`bash
# 週末午前の野球場すべて
mound watch add --team \$TEAM --facility '%野球場%' --weekdays sat,sun --time-to 12:00 --label '週末午前' --json

# kanagawa の軟式野球場の夕方限定
mound watch add --team \$TEAM --source kanagawa --facility '軟式野球場' --time-from 16:00 --label '夕方' --json

# 現状の DB と watch を照合 (デバッグ用)
mound watch test --team \$TEAM --json

# 一覧 / 削除
mound watch list --team \$TEAM --json
mound watch remove <ID> --json

# あとは sync するだけ。watch にマッチした new_slots だけ Discord/Slack/LINE に飛ぶ
mound ground sync --notify --team \$TEAM --json
\`\`\`

### マッチング規則

| 条件 | 動作 |
| --- | --- |
| 各フィールド null | 任意 (フィルタしない) |
| source / facility_pattern / weekdays / time_from / time_to | 1 つの watch 内では **AND** |
| 同じ team の複数 watch | **OR** (どれか 1 つに当たれば通る) |
| facility_pattern | SQL LIKE 互換 (\`%\` = 任意の文字列, \`_\` = 任意の 1 文字) |
| weekdays | CSV (\`sat,sun\` 等) |
| time_from / time_to | slot の time_range の開始 / 終了と比較 |
| enabled=false | 該当 watch はスキップ |
| team に watch 0 件 | **後方互換**: 全 new_slots を通知 |

### スコープ

- **domain**: \`GroundWatch\` 型 + \`WEEKDAY_CODES\`
- **ports**: \`GroundWatchRepository\` (CRUD)
- **libsql**: \`SCHEMA_VERSION\` 3→4, \`ground_watches\` テーブル + idx (lazy migration が走るので既存 DB も無痛)
- **usecase**: \`addGroundWatch\` / \`listGroundWatches\` / \`removeGroundWatch\` / \`slotMatchesWatch\` / \`filterSlotsByTeamWatches\`
- **統合**: \`notifyGroundCancellation\` の dispatch 前に filter を挟む
- **CLI**: \`mound watch add/list/remove/test\` + サブコマンド別 \`--help\`

## Test plan

- [x] \`make check\` (lint + typecheck + test) 緑 — 117 passed (新規 19)
- [x] ローカル e2e: 3 slot 中 1 だけ watch にマッチ → \`notifications: 1\` (3 ではない) を確認
- [x] LIKE パターン (\`%野球場%\`, prefix, \`_\` ワイルドカード) のユニットテスト
- [x] 曜日 / 時間フィルタ / AND / OR / enabled=false / 後方互換 (watch 0 件) を usecase テストで網羅
- [ ] CI 緑を確認

## 受け入れ条件 (#176 より)

- [x] team に watch が無い場合 ground sync --notify --team T は従来どおり全 new_slots を送る (回帰なし)
- [x] watch を 1 つ足すと、それにマッチした new_slots だけが notifications に乗る
- [x] facility_pattern に SQL LIKE (\`%野球場%\` 等) が効く
- [x] weekdays が \`sat,sun\` の watch は土日のみマッチ
- [x] time_from/time_to が slot の time_range と整合してフィルタされる
- [x] mound watch test --team T --json で「いま登録されている watch に合致する slot」を取れる
- [x] BDD テスト + e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)