### PR TITLE
feat(ground): match ground_slots to a game by date + ground_name

### DIFF
--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -735,6 +735,100 @@ JSON
       expect(r.stderr).not.toContain("15:00-18:00");
     });
 
+    it("ground match --game で試合の date/会場に合う slot を取れる + game show にも載る", () => {
+      const tR = runMound(
+        ["team", "create", "--name", "match team", "--json"],
+        env,
+      );
+      const team = parseJson<{ id: string }>(tR.stdout);
+
+      // 試合を作る (date と ground_name 込み)
+      const gR = runMound(
+        [
+          "game",
+          "create",
+          "--team",
+          team.id,
+          "--title",
+          "match試合",
+          "--date",
+          "2026-07-15",
+          "--ground",
+          "三ツ沢",
+          "--json",
+        ],
+        env,
+      );
+      const game = parseJson<{ id: string }>(gR.stdout);
+
+      // 同日 + 名前部分一致の slot を 1 つ、不一致を 2 つ import
+      const payload = {
+        schema_version: 1,
+        scraped_at: "2026-05-22T20:00:00+09:00",
+        regions: [
+          {
+            region: "yokohama",
+            records: [
+              {
+                region: "yokohama",
+                facility_name: "三ツ沢公園球技場",
+                date_raw: "2026/07/15",
+                date_iso: "2026-07-15",
+                time_range: "09:00-12:00",
+                status: null,
+                raw: "",
+              },
+              {
+                region: "yokohama",
+                facility_name: "三ツ沢公園球技場",
+                date_raw: "2026/07/16",
+                date_iso: "2026-07-16",
+                time_range: "09:00-12:00",
+                status: null,
+                raw: "",
+              },
+              {
+                region: "yokohama",
+                facility_name: "岸根公園球技場",
+                date_raw: "2026/07/15",
+                date_iso: "2026-07-15",
+                time_range: "09:00-12:00",
+                status: null,
+                raw: "",
+              },
+            ],
+            errors: [],
+          },
+        ],
+      };
+      const path = join(dbDir, "match-payload.json");
+      writeFileSync(path, JSON.stringify(payload));
+      runMound(["ground", "import", "--file", path, "--json"], env);
+
+      // mound ground match
+      const mR = runMound(
+        ["ground", "match", "--game", game.id, "--json"],
+        env,
+      );
+      expect(mR.code).toBe(0);
+      const m = parseJson<{
+        count: number;
+        matching_slots: Array<{ facility_name: string }>;
+      }>(mR.stdout);
+      expect(m.count).toBe(1);
+      expect(m.matching_slots[0]?.facility_name).toBe("三ツ沢公園球技場");
+
+      // game show にも matching_ground_slots が乗る
+      const sR = runMound(["game", "show", game.id, "--json"], env);
+      const detail = parseJson<{
+        matching_ground_slots: Array<{ facility_name: string }>;
+      }>(sR.stdout);
+      expect(detail.matching_ground_slots).toHaveLength(1);
+      expect(detail.matching_ground_slots[0]?.facility_name).toBe(
+        "三ツ沢公園球技場",
+      );
+    });
+
     it("watch test --team で現在の slot が watch に合致するか確認できる", () => {
       const tR = runMound(
         ["team", "create", "--name", "watch test cmd", "--json"],

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -496,6 +496,122 @@ describe("showGame use case", () => {
     });
   });
 
+  describe("game_date と ground_name が揃っているとき", () => {
+    it("matching_ground_slots に同日 + ground_name 部分一致の slot だけ載る", async () => {
+      const { ctx, fake } = createCtx();
+      await fake.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await fake.repo.games.insert({
+        id: "g",
+        team_id: "t",
+        title: "練習試合",
+        status: "CONFIRMED",
+        game_date: "2026-06-01",
+        ground_name: "三ツ沢",
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      // 取り込み済み slot を 3 件入れて、うち 1 件だけマッチさせる
+      const baseSlot = {
+        source: "yokohama",
+        date_iso: "2026-06-01",
+        date_raw: "x",
+        time_range: "09:00-12:00",
+        status: null,
+        raw: "",
+        scraped_at: "x",
+        first_seen_at: "x",
+        ingested_at: "x",
+      };
+      await fake.repo.groundSlots.upsert({
+        id: "s1",
+        slot_key: "k1",
+        ...baseSlot,
+        facility_name: "三ツ沢公園球技場",
+      });
+      // 別日付なので除外
+      await fake.repo.groundSlots.upsert({
+        id: "s2",
+        slot_key: "k2",
+        ...baseSlot,
+        date_iso: "2026-06-02",
+        facility_name: "三ツ沢公園球技場",
+      });
+      // 名前不一致なので除外
+      await fake.repo.groundSlots.upsert({
+        id: "s3",
+        slot_key: "k3",
+        ...baseSlot,
+        facility_name: "岸根公園球技場",
+      });
+
+      const detail = await showGame(ctx, "g");
+      expect(detail.matching_ground_slots).toHaveLength(1);
+      expect(detail.matching_ground_slots[0]?.id).toBe("s1");
+    });
+  });
+
+  describe("game_date が null のとき", () => {
+    it("matching_ground_slots は空配列", async () => {
+      const { ctx, fake } = createCtx();
+      await fake.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await fake.repo.games.insert({
+        id: "g",
+        team_id: "t",
+        title: "x",
+        status: "DRAFT",
+        game_date: null,
+        ground_name: "三ツ沢",
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const detail = await showGame(ctx, "g");
+      expect(detail.matching_ground_slots).toEqual([]);
+    });
+  });
+
+  describe("ground_name が null のとき", () => {
+    it("matching_ground_slots は空配列", async () => {
+      const { ctx, fake } = createCtx();
+      await fake.repo.teams.insert({
+        id: "t",
+        name: "T",
+        home_area: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      await fake.repo.games.insert({
+        id: "g",
+        team_id: "t",
+        title: "x",
+        status: "CONFIRMED",
+        game_date: "2026-06-01",
+        ground_name: null,
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const detail = await showGame(ctx, "g");
+      expect(detail.matching_ground_slots).toEqual([]);
+    });
+  });
+
   describe("終端 (SETTLED) のとき", () => {
     it("available_transitions は空配列", async () => {
       const { ctx, fake } = createCtx();

--- a/packages/cli/src/adapters/cli/commands/game.ts
+++ b/packages/cli/src/adapters/cli/commands/game.ts
@@ -106,6 +106,16 @@ async function show(
     detail.available_transitions.length === 0
       ? "(終端)"
       : detail.available_transitions.join(" | ");
+  const matchingText =
+    detail.matching_ground_slots.length === 0
+      ? "整合する空き枠: (なし — 取り込み済み slot に同日同会場のものなし)"
+      : [
+          `整合する空き枠: ${detail.matching_ground_slots.length} 件`,
+          ...detail.matching_ground_slots.map(
+            (slot) =>
+              `  - ${slot.source} ${slot.facility_name} ${slot.time_range ?? ""} ${slot.status ?? ""}`,
+          ),
+        ].join("\n");
   const text = [
     `${game.title} [${game.status}]`,
     `id: ${game.id}`,
@@ -120,6 +130,7 @@ async function show(
     `  未定:     ${names(b.maybe)}`,
     `  未回答:   ${names(b.no_response)}`,
     `次の遷移: ${transitions}`,
+    matchingText,
   ].join("\n");
   emit(detail, text, opts);
 }

--- a/packages/cli/src/adapters/cli/commands/ground.ts
+++ b/packages/cli/src/adapters/cli/commands/ground.ts
@@ -2,13 +2,21 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 import type { UseCaseContext } from "../../../ports";
+import { GameNotFoundError } from "../../../usecases/errors";
 import {
   detectNewSlots,
+  findSlotsMatchingGame,
   importGroundAvailability,
   listGroundSlots,
 } from "../../../usecases/ground";
 import { notifyGroundCancellation } from "../../../usecases/notification";
-import { type ParsedArgs, UsageError, boolFlag, optionalFlag } from "../args";
+import {
+  type ParsedArgs,
+  UsageError,
+  boolFlag,
+  optionalFlag,
+  requireFlag,
+} from "../args";
 import { type RenderOptions, emit, formatRows } from "../output";
 import { parseOrUsage } from "../zod-helper";
 
@@ -19,12 +27,39 @@ export async function runGround(
 ): Promise<void> {
   const sub = args.positional[0];
   if (!sub)
-    throw new UsageError("使い方: mound ground <import|list|diff|sync>");
+    throw new UsageError("使い方: mound ground <import|list|diff|sync|match>");
   if (sub === "import") return importCommand(args, ctx, opts);
   if (sub === "list") return listCommand(args, ctx, opts);
   if (sub === "diff") return diffCommand(args, ctx, opts);
   if (sub === "sync") return syncCommand(args, ctx, opts);
+  if (sub === "match") return matchCommand(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: ground ${sub}`);
+}
+
+async function matchCommand(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const gameId = requireFlag(args.flags, "game");
+  const game = await ctx.repo.games.get(gameId);
+  if (!game) throw new GameNotFoundError(gameId);
+  const slots = await findSlotsMatchingGame(ctx, game);
+  const out = { game, count: slots.length, matching_slots: slots };
+  const text =
+    slots.length === 0
+      ? `${game.title} (${game.game_date ?? "日付未定"} / ${game.ground_name ?? "会場未定"}) に整合する slot はありません`
+      : [
+          `${game.title} (${game.game_date} / ${game.ground_name}) に整合する slot: ${slots.length} 件`,
+          formatRows(slots, [
+            "source",
+            "facility_name",
+            "time_range",
+            "status",
+            "first_seen_at",
+          ]),
+        ].join("\n");
+  emit(out, text, opts);
 }
 
 async function readPayload(args: ParsedArgs): Promise<unknown> {

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -22,6 +22,7 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   ground list [--source S] [--date YYYY-MM-DD]
   ground diff [--since ISO | --minutes N] [--source S] [--game-date YYYY-MM-DD]
   ground sync [--region R] [--bin PATH] [--timeout-ms N] [--notify --team T]
+  ground match --game <GAME_ID>              試合の date+会場に合う空きを列挙
   notify add --team <ID> --kind DISCORD|SLACK|LINE --webhook <URL> [--secret S] [--target T] [--label L]
   notify list --team <ID>
   notify remove <ID>
@@ -307,12 +308,14 @@ JSON 出力:
   ground list   [--source S] [--date YYYY-MM-DD] [--json]
   ground diff   [--since ISO | --minutes N] [--source S] [--game-date YYYY-MM-DD] [--json]
   ground sync   [--region R] [--bin PATH] [--timeout-ms N] [--notify --team T] [--json]
+  ground match  --game <GAME_ID> [--json]
 
 詳細:
   mound ground import --help
   mound ground list --help
   mound ground diff --help
   mound ground sync --help
+  mound ground match --help
 `,
 
   "ground import": `mound ground import — 外部スクレイパの JSON を取り込む
@@ -373,6 +376,28 @@ JSON 出力:
     "new_slots": GroundSlot[],
     "notifications"?: NotificationDeliveryResult[]
   }
+`,
+
+  "ground match": `mound ground match — 試合の日付・会場に整合する空き枠を列挙
+
+使い方:
+  mound ground match --game <GAME_ID> [--json]
+
+挙動:
+  game.game_date と game.ground_name を使い、同日かつ facility_name に
+  ground_name を部分文字列として含む ground_slots を返す。どちらかが
+  null の場合は空配列。
+
+JSON 出力:
+  {
+    "game": Game,
+    "count": number,
+    "matching_slots": GroundSlot[]
+  }
+
+エラー:
+  - GameNotFoundError: 該当 game なし (exit 2)
+  - UsageError: --game 未指定 (exit 2)
 `,
 
   "ground diff": `mound ground diff — 直近キャンセル候補 (新規観測 slot) を抽出

--- a/packages/cli/src/usecases/game.ts
+++ b/packages/cli/src/usecases/game.ts
@@ -1,5 +1,10 @@
 import { checkGuard, getAvailableTransitions } from "../domain/state-machine";
-import type { Game, GameStatus, RsvpBreakdown } from "../domain/types";
+import type {
+  Game,
+  GameStatus,
+  GroundSlot,
+  RsvpBreakdown,
+} from "../domain/types";
 import type { UseCaseContext } from "../ports";
 import { writeAuditLog } from "./audit";
 import {
@@ -7,6 +12,7 @@ import {
   TeamNotFoundError,
   TransitionDeniedError,
 } from "./errors";
+import { findSlotsMatchingGame } from "./ground";
 import { notifyGameTransition } from "./notification";
 
 export interface CreateGameInput {
@@ -69,6 +75,9 @@ export interface GameDetail {
   };
   rsvp_breakdown: RsvpBreakdown;
   available_transitions: GameStatus[];
+  // game.game_date と game.ground_name に一致する取り込み済み ground_slots。
+  // どちらかが null なら空配列。詳細は usecases/ground.ts:findSlotsMatchingGame
+  matching_ground_slots: GroundSlot[];
 }
 
 export async function showGame(
@@ -78,6 +87,7 @@ export async function showGame(
   const game = await ctx.repo.games.get(id);
   if (!game) throw new GameNotFoundError(id);
   const breakdown = await ctx.repo.rsvps.breakdown(game.id, game.team_id);
+  const matching = await findSlotsMatchingGame(ctx, game);
   return {
     game,
     rsvp_summary: {
@@ -88,6 +98,7 @@ export async function showGame(
     },
     rsvp_breakdown: breakdown,
     available_transitions: getAvailableTransitions(game.status),
+    matching_ground_slots: matching,
   };
 }
 

--- a/packages/cli/src/usecases/ground.ts
+++ b/packages/cli/src/usecases/ground.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { GroundSlot } from "../domain/types";
+import type { Game, GroundSlot } from "../domain/types";
 import type {
   GroundSlotDiffFilter,
   GroundSlotFilter,
@@ -125,4 +125,21 @@ export async function detectNewSlots(
   filter: GroundSlotDiffFilter,
 ): Promise<GroundSlot[]> {
   return ctx.repo.groundSlots.listNewerThan(filter);
+}
+
+// 指定 game の game_date と ground_name に整合する ground_slots を返す。
+// マッチング規則:
+//   - game.game_date / game.ground_name のどちらか欠けたら空配列
+//   - 同日 (date_iso === game.game_date) かつ
+//     facility_name に game.ground_name を部分文字列として含む slot
+// substring 一致は表記揺れには弱いが、Phase 1 では "公園" と打てば
+// "三ツ沢公園球技場" まで拾える緩めの挙動を狙う。
+export async function findSlotsMatchingGame(
+  ctx: UseCaseContext,
+  game: Game,
+): Promise<GroundSlot[]> {
+  if (!game.game_date || !game.ground_name) return [];
+  const slots = await ctx.repo.groundSlots.list({ dateIso: game.game_date });
+  const needle = game.ground_name;
+  return slots.filter((s) => s.facility_name.includes(needle));
 }


### PR DESCRIPTION
Closes #178.

## Summary

team の試合 (\`mound game\`) と取り込み済みグラウンド空き (\`mound ground\`) を **date + 会場名** で接続して、「この試合の会場にキャンセルが出てる」を 1 コマンドで取れるようにする。

### 使い方

\`\`\`bash
# 試合の会場で空きが出ているか確認
mound ground match --game \$GAME_ID --json

# game show にも matching_ground_slots が乗る
mound game show \$GAME_ID --json | jq .matching_ground_slots
\`\`\`

### マッチング規則

| 条件 | 動作 |
| --- | --- |
| \`game.game_date\` が null | 空配列 |
| \`game.ground_name\` が null | 空配列 |
| date と name が揃う | \`date_iso === game.game_date\` AND \`facility_name.includes(game.ground_name)\` |
| 表記揺れ吸収 | substring なので \`"公園"\` と書いたら \`"三ツ沢公園球技場"\` も拾う |

## 変更

- **usecase** \`findSlotsMatchingGame(ctx, game)\` を \`usecases/ground.ts\` に追加
- **GameDetail** に \`matching_ground_slots: GroundSlot[]\` を追加、\`showGame\` で埋める
- **CLI** \`mound ground match --game <ID> [--json]\` 新設
- **CLI** \`mound game show <ID>\` のテキスト出力に matching slots を表示
- **help** ルート help + サブコマンド別 help を追加

## Test plan

- [x] \`make check\` (lint + typecheck + test) 緑 — 121 passed (新規 4)
- [x] usecase テスト: date+name 一致 / date 一致のみ / name 一致のみ で 1 件返る/弾く挙動
- [x] usecase テスト: game_date null / ground_name null で空配列を確認
- [x] e2e: 同日 + 名前部分一致の slot を 1 件 + 不一致 2 件 import → \`ground match\` で 1 件、\`game show --json\` の matching_ground_slots も 1 件
- [ ] CI 緑を確認

## 受け入れ条件 (#178 より)

- [x] \`mound ground match --game <ID>\` で game_date と ground_name に合致した slot だけ返る
- [x] \`game.game_date\` か \`game.ground_name\` のどちらかが null なら空配列
- [x] facility_name 部分一致 (\`%ground_name%\`) で当たる
- [x] \`mound game show <ID> --json\` の出力に \`matching_ground_slots\` 配列がある
- [x] BDD テスト + e2e
- [x] サブコマンド別 \`mound ground match --help\` も追加

## 動線

エージェントの典型シナリオ:

\`\`\`
mound ground sync                       # 新規 slot 取り込み
mound ground match --game <ID> --json   # upcoming game の会場マッチ確認
# →「あなたの 7/15 の試合の会場でキャンセル出ました」と人間に伝える
\`\`\`

## 後続

- sync → 自動「会場マッチ通知」(別 Issue, 通常の broadcast と分離した文面)
- 表記揺れ吸収 (球場 / 野球場 / グラウンド)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ground match --game` command to identify ground slots that match a game's date and facility name criteria
  * `game show` command now displays a list of matching ground slots in its output

* **Tests**
  * Added comprehensive end-to-end and unit tests for the ground matching functionality

* **Documentation**
  * Updated CLI help and documentation with details on the new `ground match` command and its usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/susumutomita/mound/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->