### PR TITLE
feat: チーム運用自動化 — 記憶層 / learn / autopilot / PayPay 精算

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -50,6 +50,32 @@ memory には書かず、必ずここに書き戻してください。
 セッション開始時は `mound knowledge list --team T --json` と `mound observe list --team T --json`
 を読めば、そのチームの決め事・知見をまるごと引き継げます。
 
+#### 使うほど賢くなる: `mound learn`
+
+`mound learn --team T` は過去の試合・出欠から **default_ground / default_weekday /
+メンバー出席率** を確信度付きで再導出し、`--apply` で Gold に LEARNED として書き戻します
+(`origin=HUMAN` の決め事はピン留めされ触られません)。定期的に回すほどチームの「いつもの」が
+育ちます。Hermes は試合が一区切りした (`SETTLED`/`COMPLETED`) タイミングや日次で実行すると良いです。
+
+#### 自律運用: `mound auto` + cron
+
+`mound auto run --team T --apply` は現在状態 (agenda) から打つべき手を算出し、**安全な手は自動実行・
+チームを拘束する手は提案**に分けます。
+
+- SAFE (自動): `PUBLISH` (DRAFT→COLLECTING) / `COMPLETE` (試合日経過→COMPLETED) / 出欠・精算リマインド通知
+- NEEDS_APPROVAL (提案のみ): `CONFIRM` (人数充足→CONFIRMED。チームを拘束するので人が決める)
+
+cron/launchd で定期実行すれば**人手ゼロで回り続けます**。Hermes が運用ループを担う場合は
+`mound auto plan --json` を読み、SAFE は自動で `auto run --apply`、`proposed` の NEEDS_APPROVAL は
+ユーザに確認してから個別に `mound game transition` を叩く、という分担が綺麗です。
+
+```bash
+# 例: 30 分おきに球場同期 + 自律運用 (SAFE のみ自動)
+*/30 * * * * mound ground sync --region all --notify --team "$TEAM" --json >/dev/null
+0    8 * * * mound auto run --team "$TEAM" --apply --json >>~/.mound/auto.log
+0    9 * * 1 mound learn --team "$TEAM" --apply --json >>~/.mound/learn.log
+```
+
 **会話で発見した情報は、書ける所があるなら必ず書く。書けない情報があれば §9 の「現在書けないこと」に該当するので、Hermes はそれを **未解決 task として TODO 化** してユーザに告知してください**。
 
 ### ステップ 0: 新しいチームに初めて触れたとき
@@ -218,6 +244,9 @@ Hermes は以下を **必ず守ること**:
 | `knowledge list` | `--team [--category --member --key]` | `TeamKnowledge[]` |
 | `knowledge get` | `--team --key [--member]` | `TeamKnowledge \| {found:false}` |
 | `knowledge forget` | `<id>` | `{ok, id}` |
+| `learn` | `--team [--apply]` | `LearnResult` (履歴から決め事を学習) |
+| `auto plan` | `--team [--horizon-days]` | `AutoPlan` (打つべき手, read-only) |
+| `auto run` | `--team [--apply --horizon-days]` | `AutoRunResult` (SAFE は自動・要承認は提案) |
 
 サブコマンドの詳細は `mound <command> [sub] --help` で取れます (実装は `packages/cli/src/adapters/cli/help.ts`)。
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -247,6 +247,10 @@ Hermes は以下を **必ず守ること**:
 | `learn` | `--team [--apply]` | `LearnResult` (履歴から決め事を学習) |
 | `auto plan` | `--team [--horizon-days]` | `AutoPlan` (打つべき手, read-only) |
 | `auto run` | `--team [--apply --horizon-days]` | `AutoRunResult` (SAFE は自動・要承認は提案) |
+| `settle open` | `--game --amount [--link --label --note --members]` | `SettlementView` (PayPay 割り勘を作成) |
+| `settle show` | `--game` | `SettlementView \| {found:false}` |
+| `settle pay` | `--game --member [--unpaid]` | `SettlementView` (全額で自動 SETTLED) |
+| `settle remind` | `--game` | `{message, deliveries}` (PayPay 催促を通知) |
 
 サブコマンドの詳細は `mound <command> [sub] --help` で取れます (実装は `packages/cli/src/adapters/cli/help.ts`)。
 
@@ -543,7 +547,7 @@ mound に永続化したいのに「書く場所が無い」情報は、Hermes �
 | ~~メンバー単位の自由メモ (背番号 / ポジション / 連絡時間帯 / 助っ人かレギュラーか 等)~~ | **解消済** → `mound knowledge set --member <ID> --category ROSTER` | — |
 | 既存 game の `note` を後から更新する API | (なし — 新規時のみ。暫定で `mound observe add --kind NOTE` に逃がせる) | 未起票 |
 | 対戦相手チームの情報 (連絡先 / 過去戦績 / 信頼度) | (なし) | Phase 2 想定 |
-| 試合の精算 / 会計 | (なし) | Phase 1 範囲外 |
+| ~~試合の精算 / 会計~~ | **解消済** → `mound settle`(PayPay 割り勘: 割り勘計算・未払い把握・催促・自動 SETTLED)。PayPay 個人割り勘に公開 API は無いためリンクは人が貼り入金は人が消し込む | — |
 | 自然言語入力の直接受付 (`mound parse "土曜 9 時から練習試合"`) | (なし — Hermes の責務) | 未起票 |
 
 これらが必要になった場合、Hermes は次のいずれかをすべきです:

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -26,8 +26,29 @@ Hermes はユーザとの会話で **チームの運営に関する知見** を�
 | 試合の状態が変わった (公開 / 確定 / 中止 / 完了 / 精算) | `Game.status` | `mound game transition --to <STATUS>` |
 | 通知したいチャネルを教わった (Discord/Slack/LINE) | `NotificationChannel` | `mound notify add --team --kind --webhook` |
 | 「土日午前の野球場だけ通知して」「軟式野球場の夕方だけ」など監視条件 | `GroundWatch` | `mound watch add --team [--source --facility --weekdays --time-from --time-to --label]` |
+| チームの**決め事** (いつもの会場/曜日/最低人数/会費/リマインド何日前) | `TeamKnowledge` (🥇 Gold) | `mound knowledge set --team --key <K> --value <V> [--category PREFERENCE]` |
+| メンバー固有の知識 (背番号/ポジション/常連か/連絡時間帯) | `TeamKnowledge` (🥇 Gold) | `mound knowledge set --team --member <ID> --category ROSTER --key <K> --value <V>` |
+| 会話で得た**生の知見** (「土曜の朝が動きやすい」「鈴木は隔週」「三ツ沢は取りやすい」) | `Observation` (🥉 Bronze) | `mound observe add --team --kind <KIND> --body <TEXT> [--member --source]` |
 | 試合に関する自由メモ (例: 「対戦相手は連絡待ち」「会場 OK 取れたら note 更新」) | `Game.note` | `mound game create` の `--note` (新規時) — 既存 game への note 更新 API は未実装、後述 |
 | グラウンド予約システムの空き状況 | `GroundSlot` | `mound ground sync --region all` で自動取り込み |
+
+#### チーム記憶レイヤ — 「使うほど賢くなる」決め事ストア (Medallion)
+
+`observe` / `knowledge` は **チームのコンテキストを学習して貯める層** です。状態は mound
+(libSQL/SQLite) に永続化されるので、**駆動するエージェントを Hermes → Codex → Claude と
+差し替えても、同じチーム文脈から再開できます** (これがチーム OS の肝)。エージェント固有の
+memory には書かず、必ずここに書き戻してください。
+
+- 🥉 **Bronze = `observe`**: 構造を決めず**まず書き留める**生の観測。`kind` は
+  `PREFERENCE_HINT / ROSTER_FACT / VENUE / RULE / OPPONENT / NOTE`。
+- 🥇 **Gold = `knowledge`**: `(team, member, key)` で一意な**確信度付きの決め事**。
+  autopilot や Hermes が「いつもの会場・曜日・最低人数」を**人に聞かずに**埋めるために読む層。
+  - `origin=HUMAN` (人が明示) は `origin=LEARNED` (実績から学習) に**上書きされない** = 人の決め事をピン留め
+  - `LEARNED` 同士は `confidence` が高い方が値を握る
+  - 観測のたび `evidence_count` が加算される (= 使うほど裏付けが厚くなる)
+
+セッション開始時は `mound knowledge list --team T --json` と `mound observe list --team T --json`
+を読めば、そのチームの決め事・知見をまるごと引き継げます。
 
 **会話で発見した情報は、書ける所があるなら必ず書く。書けない情報があれば §9 の「現在書けないこと」に該当するので、Hermes はそれを **未解決 task として TODO 化** してユーザに告知してください**。
 
@@ -191,6 +212,12 @@ Hermes は以下を **必ず守ること**:
 | `watch list` | `--team` | `GroundWatch[]` |
 | `watch remove` | `<id>` | `{ok, id}` |
 | `watch test` | `--team` | `{count, slots}` |
+| `observe add` | `--team --kind --body [--member --subject --source]` | `Observation` |
+| `observe list` | `--team [--kind --member]` | `Observation[]` |
+| `knowledge set` | `--team --key --value [--category --member --origin --confidence --source]` | `TeamKnowledge` |
+| `knowledge list` | `--team [--category --member --key]` | `TeamKnowledge[]` |
+| `knowledge get` | `--team --key [--member]` | `TeamKnowledge \| {found:false}` |
+| `knowledge forget` | `<id>` | `{ok, id}` |
 
 サブコマンドの詳細は `mound <command> [sub] --help` で取れます (実装は `packages/cli/src/adapters/cli/help.ts`)。
 
@@ -483,9 +510,9 @@ mound に永続化したいのに「書く場所が無い」情報は、Hermes �
 
 | 書けないこと | 暫定の置き場 | 追跡 Issue |
 | --- | --- | --- |
-| チーム単位の自由メモ (チーム規約 / 連絡網 / 来季の方針 等) | (なし) | 未起票。Hermes が見つけたら起票する |
-| メンバー単位の自由メモ (背番号 / ポジション / 連絡時間帯 / 助っ人かレギュラーか 等) | (なし) | 未起票 |
-| 既存 game の `note` を後から更新する API | (なし — 新規時のみ) | 未起票 |
+| ~~チーム単位の自由メモ (チーム規約 / 連絡網 / 来季の方針 等)~~ | **解消済** → `mound knowledge set --category RULE/NOTE` / `mound observe add` | — |
+| ~~メンバー単位の自由メモ (背番号 / ポジション / 連絡時間帯 / 助っ人かレギュラーか 等)~~ | **解消済** → `mound knowledge set --member <ID> --category ROSTER` | — |
+| 既存 game の `note` を後から更新する API | (なし — 新規時のみ。暫定で `mound observe add --kind NOTE` に逃がせる) | 未起票 |
 | 対戦相手チームの情報 (連絡先 / 過去戦績 / 信頼度) | (なし) | Phase 2 想定 |
 | 試合の精算 / 会計 | (なし) | Phase 1 範囲外 |
 | 自然言語入力の直接受付 (`mound parse "土曜 9 時から練習試合"`) | (なし — Hermes の責務) | 未起票 |

--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -109,7 +109,11 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
       );
       expect(parseJson<unknown[]>(listR.stdout)).toHaveLength(10);
 
-      // 試合を DRAFT で作成
+      // 試合を DRAFT で作成。日付は実時計基準の未来日にする
+      // (固定日だと wall-clock が過ぎた瞬間 agenda.upcoming から外れて落ちるため)。
+      const gameDate = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
       const gameR = runMound(
         [
           "game",
@@ -119,7 +123,7 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
           "--title",
           "練習試合",
           "--date",
-          "2026-06-01",
+          gameDate,
           "--ground",
           "公園グラウンド",
           "--min-players",

--- a/packages/cli/src/__tests__/usecases/autopilot.test.ts
+++ b/packages/cli/src/__tests__/usecases/autopilot.test.ts
@@ -1,0 +1,154 @@
+// autopilot のテスト。安全な手の自動実行と、拘束する手の提案据え置きを確認する。
+import { describe, expect, it } from "vitest";
+import type { GameStatus } from "../../domain/types";
+import type { UseCaseContext } from "../../ports";
+import { planAutopilot, runAutopilot } from "../../usecases/autopilot";
+import { buildFakeContext } from "./memory-fakes";
+
+// 実時計に依存しないよう now を固定して fake を作る。
+function ctxAt(now: string): {
+  ctx: UseCaseContext;
+  stores: ReturnType<typeof buildFakeContext>["stores"];
+} {
+  return buildFakeContext(now);
+}
+
+async function seedTeam(ctx: UseCaseContext): Promise<void> {
+  await ctx.repo.teams.insert({
+    id: "t",
+    name: "T",
+    home_area: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+let gid = 0;
+async function addGame(
+  ctx: UseCaseContext,
+  status: GameStatus,
+  date: string | null,
+): Promise<string> {
+  const id = `g${++gid}`;
+  await ctx.repo.games.insert({
+    id,
+    team_id: "t",
+    title: `試合${id}`,
+    status,
+    game_date: date,
+    ground_name: null,
+    min_players: 1,
+    note: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+  return id;
+}
+
+describe("planAutopilot use case", () => {
+  describe("各状態の試合が混在するとき", () => {
+    it("DRAFT→PUBLISH(SAFE) / 過去CONFIRMED→COMPLETE(SAFE) / COMPLETED→精算リマインド(SAFE) を出す", async () => {
+      const { ctx } = ctxAt("2026-06-10T00:00:00.000Z");
+      await seedTeam(ctx);
+      await addGame(ctx, "DRAFT", "2026-06-20");
+      await addGame(ctx, "CONFIRMED", "2026-06-01"); // 過去 → 完了対象
+      await addGame(ctx, "COMPLETED", "2026-06-01"); // 精算待ち
+
+      const plan = await planAutopilot(ctx, { teamId: "t", horizonDays: 30 });
+      const kinds = plan.actions.map((a) => a.kind);
+      expect(kinds).toContain("PUBLISH");
+      expect(kinds).toContain("COMPLETE");
+      expect(kinds).toContain("REMIND_SETTLEMENT");
+      expect(plan.actions.every((a) => a.risk === "SAFE")).toBe(true);
+    });
+  });
+
+  describe("人数が充足した COLLECTING があるとき", () => {
+    it("CONFIRM を NEEDS_APPROVAL として提案する", async () => {
+      const { ctx } = ctxAt("2026-06-10T00:00:00.000Z");
+      await seedTeam(ctx);
+      await ctx.repo.members.insert({
+        id: "m1",
+        team_id: "t",
+        name: "山田",
+        email: null,
+        role: "MEMBER",
+        created_at: "x",
+        updated_at: "x",
+      });
+      const g = await addGame(ctx, "COLLECTING", "2026-06-20"); // min_players=1
+      await ctx.repo.rsvps.upsert({
+        id: "r1",
+        game_id: g,
+        member_id: "m1",
+        response: "AVAILABLE",
+        responded_at: "x",
+        created_at: "x",
+        updated_at: "x",
+      });
+      const plan = await planAutopilot(ctx, { teamId: "t", horizonDays: 30 });
+      const confirm = plan.actions.find((a) => a.kind === "CONFIRM");
+      expect(confirm?.risk).toBe("NEEDS_APPROVAL");
+    });
+  });
+});
+
+describe("runAutopilot use case", () => {
+  describe("--apply のとき", () => {
+    it("SAFE な PUBLISH を実行し、CONFIRM は提案に据え置く", async () => {
+      const { ctx, stores } = ctxAt("2026-06-10T00:00:00.000Z");
+      await seedTeam(ctx);
+      const draft = await addGame(ctx, "DRAFT", "2026-06-20");
+      // 充足した COLLECTING (CONFIRM は要承認)
+      await ctx.repo.members.insert({
+        id: "m1",
+        team_id: "t",
+        name: "山田",
+        email: null,
+        role: "MEMBER",
+        created_at: "x",
+        updated_at: "x",
+      });
+      const g = await addGame(ctx, "COLLECTING", "2026-06-20");
+      await ctx.repo.rsvps.upsert({
+        id: "r1",
+        game_id: g,
+        member_id: "m1",
+        response: "AVAILABLE",
+        responded_at: "x",
+        created_at: "x",
+        updated_at: "x",
+      });
+
+      const result = await runAutopilot(ctx, {
+        teamId: "t",
+        horizonDays: 30,
+        apply: true,
+      });
+      // PUBLISH が実行され、対象 DRAFT は COLLECTING になった
+      expect(
+        result.executed.some((e) => e.action.kind === "PUBLISH" && e.ok),
+      ).toBe(true);
+      expect(stores.games.get(draft)?.status).toBe("COLLECTING");
+      // CONFIRM は実行せず提案のまま、対象は COLLECTING のまま
+      expect(result.proposed.some((a) => a.kind === "CONFIRM")).toBe(true);
+      expect(stores.games.get(g)?.status).toBe("COLLECTING");
+    });
+  });
+
+  describe("dry-run (--apply なし) のとき", () => {
+    it("何も実行せず全て proposed に入る", async () => {
+      const { ctx, stores } = ctxAt("2026-06-10T00:00:00.000Z");
+      await seedTeam(ctx);
+      const draft = await addGame(ctx, "DRAFT", "2026-06-20");
+      const result = await runAutopilot(ctx, {
+        teamId: "t",
+        horizonDays: 30,
+        apply: false,
+      });
+      expect(result.executed).toHaveLength(0);
+      expect(result.proposed.length).toBeGreaterThan(0);
+      expect(stores.games.get(draft)?.status).toBe("DRAFT");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -30,6 +30,7 @@ import type {
 
 import { TransitionDeniedError } from "../../usecases/errors";
 import { createGame, showGame, transitionGame } from "../../usecases/game";
+import { buildKnowledgeRepo, buildObservationRepo } from "./memory-fakes";
 
 interface Fake {
   teamStore: Map<string, Team>;
@@ -231,6 +232,8 @@ function buildFake(): Fake {
       groundSlots,
       notifications,
       groundWatches,
+      observations: buildObservationRepo().repo,
+      knowledge: buildKnowledgeRepo().repo,
     },
   };
 }

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -30,7 +30,11 @@ import type {
 
 import { TransitionDeniedError } from "../../usecases/errors";
 import { createGame, showGame, transitionGame } from "../../usecases/game";
-import { buildKnowledgeRepo, buildObservationRepo } from "./memory-fakes";
+import {
+  buildKnowledgeRepo,
+  buildObservationRepo,
+  buildSettlementRepo,
+} from "./memory-fakes";
 
 interface Fake {
   teamStore: Map<string, Team>;
@@ -234,6 +238,7 @@ function buildFake(): Fake {
       groundWatches,
       observations: buildObservationRepo().repo,
       knowledge: buildKnowledgeRepo().repo,
+      settlements: buildSettlementRepo().repo,
     },
   };
 }

--- a/packages/cli/src/__tests__/usecases/ground-watch.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-watch.test.ts
@@ -53,6 +53,8 @@ function buildFake(): {
     groundSlots: stub,
     notifications: stub,
     groundWatches: watchRepo,
+    observations: stub,
+    knowledge: stub,
   };
   let seq = 0;
   const ctx: UseCaseContext = {

--- a/packages/cli/src/__tests__/usecases/ground-watch.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-watch.test.ts
@@ -55,6 +55,7 @@ function buildFake(): {
     groundWatches: watchRepo,
     observations: stub,
     knowledge: stub,
+    settlements: stub,
   };
   let seq = 0;
   const ctx: UseCaseContext = {

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -59,6 +59,7 @@ function buildCtx(opts: { now: Date; idSeed?: number }): {
     groundWatches: stub,
     observations: stub,
     knowledge: stub,
+    settlements: stub,
   };
   const notifier = {
     send: async () => ({

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -57,6 +57,8 @@ function buildCtx(opts: { now: Date; idSeed?: number }): {
     groundSlots,
     notifications: stub,
     groundWatches: stub,
+    observations: stub,
+    knowledge: stub,
   };
   const notifier = {
     send: async () => ({

--- a/packages/cli/src/__tests__/usecases/knowledge.test.ts
+++ b/packages/cli/src/__tests__/usecases/knowledge.test.ts
@@ -1,0 +1,260 @@
+// Gold 層 (チームの決め事) のテスト。「使うほど賢くなる」マージ規則を網羅する。
+import { describe, expect, it } from "vitest";
+import type { Member, Team } from "../../domain/types";
+import type { UseCaseContext } from "../../ports";
+import {
+  forgetKnowledge,
+  getTeamPreferences,
+  recordKnowledge,
+} from "../../usecases/knowledge";
+import { buildFakeContext } from "./memory-fakes";
+
+async function seedTeam(ctx: UseCaseContext): Promise<Team> {
+  return ctx.repo.teams.insert({
+    id: "t",
+    name: "横浜BB",
+    home_area: "横浜",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+async function seedMember(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<Member> {
+  return ctx.repo.members.insert({
+    id: "m",
+    team_id: teamId,
+    name: "鈴木",
+    email: null,
+    role: "MEMBER",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+const base = {
+  category: "PREFERENCE" as const,
+  memberId: null,
+  source: null,
+};
+
+describe("recordKnowledge use case", () => {
+  describe("新規キーのとき", () => {
+    it("INSERT し evidence_count=1 と監査 KNOWLEDGE_SET を残す", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      const entry = await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_ground",
+        value: "三ツ沢公園野球場",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      expect(entry.value).toBe("三ツ沢公園野球場");
+      expect(entry.evidence_count).toBe(1);
+      expect(entry.origin).toBe("HUMAN");
+      expect(
+        stores.audit.find((l) => l.action === "KNOWLEDGE_SET"),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("人の決め事 (HUMAN) に学習値 (LEARNED) が来たとき", () => {
+    it("値は上書きされずピン留めされるが evidence_count は加算される", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_ground",
+        value: "三ツ沢公園野球場",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      const updated = await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_ground",
+        value: "別の会場",
+        origin: "LEARNED",
+        confidence: 0.4,
+      });
+      expect(updated.value).toBe("三ツ沢公園野球場"); // ピン留め
+      expect(updated.origin).toBe("HUMAN");
+      expect(updated.confidence).toBe(1);
+      expect(updated.evidence_count).toBe(2); // 裏付けは厚くなる
+      expect(
+        stores.audit.find((l) => l.action === "KNOWLEDGE_UPDATED"),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("学習値 (LEARNED) 同士のとき", () => {
+    it("confidence が高い方が値を握り、低い再観測では据え置く", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_weekday",
+        value: "sat",
+        origin: "LEARNED",
+        confidence: 0.5,
+      });
+      const higher = await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_weekday",
+        value: "sun",
+        origin: "LEARNED",
+        confidence: 0.7,
+      });
+      expect(higher.value).toBe("sun");
+      expect(higher.confidence).toBe(0.7);
+      expect(higher.evidence_count).toBe(2);
+
+      const lower = await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_weekday",
+        value: "mon",
+        origin: "LEARNED",
+        confidence: 0.6,
+      });
+      expect(lower.value).toBe("sun"); // 据え置き
+      expect(lower.confidence).toBe(0.7);
+      expect(lower.evidence_count).toBe(3);
+    });
+  });
+
+  describe("チームが存在しないとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await expect(
+        recordKnowledge(ctx, {
+          ...base,
+          teamId: "nope",
+          key: "k",
+          value: "v",
+          origin: "HUMAN",
+          confidence: 1,
+        }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+
+  describe("member 指定が別チームのとき", () => {
+    it("MemberNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await expect(
+        recordKnowledge(ctx, {
+          ...base,
+          teamId: "t",
+          memberId: "ghost",
+          key: "position",
+          value: "P",
+          origin: "HUMAN",
+          confidence: 1,
+        }),
+      ).rejects.toThrow(/member が存在しません/);
+    });
+  });
+
+  describe("メンバー固有の決め事のとき", () => {
+    it("同じ key でもチーム既定値とは別行として共存する", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await seedMember(ctx, "t");
+      await recordKnowledge(ctx, {
+        ...base,
+        category: "ROSTER",
+        teamId: "t",
+        memberId: "m",
+        key: "note",
+        value: "隔週で来る",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      const teamLevel = await recordKnowledge(ctx, {
+        ...base,
+        category: "NOTE",
+        teamId: "t",
+        memberId: null,
+        key: "note",
+        value: "連絡網は LINE",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      expect(teamLevel.evidence_count).toBe(1); // 別行なので初回扱い
+    });
+  });
+});
+
+describe("getTeamPreferences use case", () => {
+  describe("PREFERENCE とそれ以外が混在するとき", () => {
+    it("category=PREFERENCE かつメンバー非依存の決め事だけを返す", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await seedMember(ctx, "t");
+      await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "default_ground",
+        value: "三ツ沢",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      await recordKnowledge(ctx, {
+        ...base,
+        category: "RULE",
+        teamId: "t",
+        key: "fee",
+        value: "500",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      await recordKnowledge(ctx, {
+        ...base,
+        category: "PREFERENCE",
+        teamId: "t",
+        memberId: "m",
+        key: "default_ground",
+        value: "個人用",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      const prefs = await getTeamPreferences(ctx, "t");
+      expect(prefs).toEqual([
+        {
+          key: "default_ground",
+          value: "三ツ沢",
+          confidence: 1,
+          origin: "HUMAN",
+        },
+      ]);
+    });
+  });
+});
+
+describe("forgetKnowledge use case", () => {
+  describe("既存 ID を渡したとき", () => {
+    it("削除して true を返す", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      const entry = await recordKnowledge(ctx, {
+        ...base,
+        teamId: "t",
+        key: "k",
+        value: "v",
+        origin: "HUMAN",
+        confidence: 1,
+      });
+      expect(await forgetKnowledge(ctx, entry.id)).toBe(true);
+      expect(await forgetKnowledge(ctx, entry.id)).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/learn.test.ts
+++ b/packages/cli/src/__tests__/usecases/learn.test.ts
@@ -1,0 +1,168 @@
+// Silver→Gold 学習エンジンのテスト。履歴からの導出と、人の決め事ピン留めを確認する。
+import { describe, expect, it } from "vitest";
+import type { GameStatus } from "../../domain/types";
+import type { UseCaseContext } from "../../ports";
+import { recordKnowledge } from "../../usecases/knowledge";
+import { computeLearnedFacts, learnTeam } from "../../usecases/learn";
+import { buildFakeContext } from "./memory-fakes";
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+async function seedTeam(ctx: UseCaseContext): Promise<void> {
+  await ctx.repo.teams.insert({
+    id: "t",
+    name: "横浜BB",
+    home_area: "横浜",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+let gid = 0;
+async function addGame(
+  ctx: UseCaseContext,
+  date: string | null,
+  ground: string | null,
+  status: GameStatus = "COMPLETED",
+): Promise<string> {
+  const id = `g${++gid}`;
+  await ctx.repo.games.insert({
+    id,
+    team_id: "t",
+    title: "試合",
+    status,
+    game_date: date,
+    ground_name: ground,
+    min_players: 9,
+    note: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+  return id;
+}
+
+async function addMember(ctx: UseCaseContext, id: string): Promise<void> {
+  await ctx.repo.members.insert({
+    id,
+    team_id: "t",
+    name: id,
+    email: null,
+    role: "MEMBER",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+describe("computeLearnedFacts use case", () => {
+  describe("会場と曜日に偏りがあるとき", () => {
+    it("default_ground と default_weekday を最頻値で導出する", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      // 2026-06-06 と 2026-06-13 は土曜
+      await addGame(ctx, "2026-06-06", "三ツ沢公園野球場");
+      await addGame(ctx, "2026-06-13", "三ツ沢公園野球場");
+      await addGame(ctx, "2026-06-07", "岸根公園"); // 日曜・別会場
+
+      const facts = await computeLearnedFacts(ctx, "t");
+      const ground = facts.find((f) => f.key === "default_ground");
+      const weekday = facts.find((f) => f.key === "default_weekday");
+      expect(ground?.value).toBe("三ツ沢公園野球場");
+      expect(ground?.evidence_count).toBe(2);
+      expect(ground?.confidence).toBe(round2(2 / 3));
+      expect(weekday?.value).toBe("sat");
+    });
+  });
+
+  describe("裏付けが 1 件しかないとき", () => {
+    it("「いつもの」とは見なさず導出しない", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx, "2026-06-06", "三ツ沢公園野球場");
+      const facts = await computeLearnedFacts(ctx, "t");
+      expect(facts.find((f) => f.key === "default_ground")).toBeUndefined();
+    });
+  });
+
+  describe("メンバーの出欠履歴があるとき", () => {
+    it("出席率を導出する (回答試合のうち AVAILABLE の割合)", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await addMember(ctx, "m1");
+      const g1 = await addGame(ctx, "2026-06-06", "三ツ沢");
+      const g2 = await addGame(ctx, "2026-06-13", "三ツ沢");
+      for (const [g, resp] of [
+        [g1, "AVAILABLE"],
+        [g2, "UNAVAILABLE"],
+      ] as const) {
+        await ctx.repo.rsvps.upsert({
+          id: `${g}:m1`,
+          game_id: g,
+          member_id: "m1",
+          response: resp,
+          responded_at: "x",
+          created_at: "x",
+          updated_at: "x",
+        });
+      }
+      const facts = await computeLearnedFacts(ctx, "t");
+      const att = facts.find((f) => f.member_id === "m1");
+      expect(att?.value).toBe("0.5 (1/2)");
+      expect(att?.evidence_count).toBe(2);
+    });
+  });
+});
+
+describe("learnTeam use case", () => {
+  describe("--apply のとき", () => {
+    it("学習値を Gold に書き、人の決め事 (HUMAN) はピン留めしてスキップする", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      // 人が default_ground を明示済み
+      await recordKnowledge(ctx, {
+        teamId: "t",
+        memberId: null,
+        category: "PREFERENCE",
+        key: "default_ground",
+        value: "市営球場",
+        origin: "HUMAN",
+        confidence: 1,
+        source: null,
+      });
+      // 履歴上は三ツ沢が最頻
+      await addGame(ctx, "2026-06-06", "三ツ沢公園野球場");
+      await addGame(ctx, "2026-06-13", "三ツ沢公園野球場");
+
+      const result = await learnTeam(ctx, { teamId: "t", apply: true });
+      expect(result.applied).toBe(true);
+      expect(result.pinned_skips).toContain("default_ground");
+      // Gold の値は人の決め事のまま (学習で上書きされない)
+      const stored = Array.from(stores.knowledge.values()).find(
+        (k) => k.key === "default_ground",
+      );
+      expect(stored?.value).toBe("市営球場");
+      expect(stored?.origin).toBe("HUMAN");
+    });
+  });
+
+  describe("dry-run (--apply なし) のとき", () => {
+    it("Gold には書かず提案だけ返す", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx, "2026-06-06", "三ツ沢");
+      await addGame(ctx, "2026-06-13", "三ツ沢");
+      const result = await learnTeam(ctx, { teamId: "t", apply: false });
+      expect(result.applied).toBe(false);
+      expect(result.facts.length).toBeGreaterThan(0);
+      expect(stores.knowledge.size).toBe(0);
+    });
+  });
+
+  describe("チームが存在しないとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await expect(
+        learnTeam(ctx, { teamId: "nope", apply: false }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/memory-fakes.ts
+++ b/packages/cli/src/__tests__/usecases/memory-fakes.ts
@@ -1,0 +1,269 @@
+// usecase テスト用の in-memory ポート実装 (fake)。Clean Architecture の境界を
+// 守るため、usecase は DB ではなくこの fake に対してテストする。
+//
+// - buildObservationRepo / buildKnowledgeRepo: チーム記憶レイヤの 2 repo だけが
+//   欲しい既存テスト向け (型を満たすための最小実装)。
+// - buildFakeContext: 全 Repositories を備えた UseCaseContext を返す (新規テスト向け)。
+import type {
+  AuditLog,
+  Game,
+  GroundSlot,
+  GroundWatch,
+  Member,
+  MemberRsvp,
+  NotificationChannel,
+  Observation,
+  Rsvp,
+  RsvpBreakdown,
+  Team,
+  TeamKnowledge,
+} from "../../domain/types";
+import type {
+  NotificationSender,
+  ObservationRepository,
+  Repositories,
+  TeamKnowledgeRepository,
+  UseCaseContext,
+} from "../../ports";
+
+export function buildObservationRepo(
+  store: Map<string, Observation> = new Map(),
+): { store: Map<string, Observation>; repo: ObservationRepository } {
+  const repo: ObservationRepository = {
+    insert: async (o) => {
+      store.set(o.id, o);
+      return o;
+    },
+    list: async (f) =>
+      Array.from(store.values())
+        .filter(
+          (o) =>
+            o.team_id === f.teamId &&
+            (!f.kind || o.kind === f.kind) &&
+            (!f.memberId || o.member_id === f.memberId),
+        )
+        .sort((a, b) => (a.observed_at < b.observed_at ? 1 : -1)),
+  };
+  return { store, repo };
+}
+
+export function buildKnowledgeRepo(
+  store: Map<string, TeamKnowledge> = new Map(),
+): { store: Map<string, TeamKnowledge>; repo: TeamKnowledgeRepository } {
+  const repo: TeamKnowledgeRepository = {
+    insert: async (k) => {
+      store.set(k.id, k);
+      return k;
+    },
+    update: async (k) => {
+      store.set(k.id, k);
+      return k;
+    },
+    getByKey: async (teamId, memberId, key) =>
+      Array.from(store.values()).find(
+        (k) =>
+          k.team_id === teamId && k.member_id === memberId && k.key === key,
+      ) ?? null,
+    list: async (f) =>
+      Array.from(store.values()).filter(
+        (k) =>
+          k.team_id === f.teamId &&
+          (!f.category || k.category === f.category) &&
+          (!f.memberId || k.member_id === f.memberId) &&
+          (!f.key || k.key === f.key),
+      ),
+    remove: async (id) => store.delete(id),
+  };
+  return { store, repo };
+}
+
+export interface FakeStores {
+  teams: Map<string, Team>;
+  members: Map<string, Member>;
+  games: Map<string, Game>;
+  rsvps: Map<string, Rsvp>;
+  audit: AuditLog[];
+  observations: Map<string, Observation>;
+  knowledge: Map<string, TeamKnowledge>;
+  notifierCalls: Array<{ channel: NotificationChannel; message: string }>;
+}
+
+export interface FakeContext {
+  ctx: UseCaseContext;
+  stores: FakeStores;
+}
+
+// 全 Repositories を備えた最小 fake。記憶レイヤのテストで主に使うのは
+// teams / members / audit / observations / knowledge。残りは型を満たす最小実装。
+export function buildFakeContext(
+  now = "2026-06-03T09:00:00.000Z",
+): FakeContext {
+  const teams = new Map<string, Team>();
+  const members = new Map<string, Member>();
+  const games = new Map<string, Game>();
+  const rsvps = new Map<string, Rsvp>();
+  const audit: AuditLog[] = [];
+  const { store: observations, repo: observationRepo } = buildObservationRepo();
+  const { store: knowledge, repo: knowledgeRepo } = buildKnowledgeRepo();
+  const notifierCalls: Array<{
+    channel: NotificationChannel;
+    message: string;
+  }> = [];
+
+  const breakdown = async (
+    gameId: string,
+    teamId: string,
+  ): Promise<RsvpBreakdown> => {
+    const rows: MemberRsvp[] = Array.from(members.values())
+      .filter((m) => m.team_id === teamId)
+      .map((m) => {
+        const r = rsvps.get(`${gameId}:${m.id}`);
+        return {
+          member_id: m.id,
+          member_name: m.name,
+          member_role: m.role,
+          response: r?.response ?? "NO_RESPONSE",
+          responded_at: r?.responded_at ?? null,
+        };
+      });
+    const out: RsvpBreakdown = {
+      available: [],
+      unavailable: [],
+      maybe: [],
+      no_response: [],
+    };
+    for (const r of rows) {
+      if (r.response === "AVAILABLE") out.available.push(r);
+      else if (r.response === "UNAVAILABLE") out.unavailable.push(r);
+      else if (r.response === "MAYBE") out.maybe.push(r);
+      else out.no_response.push(r);
+    }
+    return out;
+  };
+
+  const repo: Repositories = {
+    teams: {
+      insert: async (t) => {
+        teams.set(t.id, t);
+        return t;
+      },
+      list: async () => Array.from(teams.values()),
+      get: async (id) => teams.get(id) ?? null,
+    },
+    members: {
+      insert: async (m) => {
+        members.set(m.id, m);
+        return m;
+      },
+      list: async (teamId) =>
+        Array.from(members.values()).filter((m) => m.team_id === teamId),
+      get: async (id) => members.get(id) ?? null,
+    },
+    games: {
+      insert: async (g) => {
+        games.set(g.id, g);
+        return g;
+      },
+      list: async (filter) =>
+        Array.from(games.values()).filter(
+          (g) =>
+            (!filter.teamId || g.team_id === filter.teamId) &&
+            (!filter.status || g.status === filter.status),
+        ),
+      get: async (id) => games.get(id) ?? null,
+      updateStatus: async (id, status, updatedAt) => {
+        const g = games.get(id);
+        if (g) games.set(id, { ...g, status, updated_at: updatedAt });
+      },
+    },
+    rsvps: {
+      upsert: async (r) => {
+        rsvps.set(`${r.game_id}:${r.member_id}`, r);
+        return r;
+      },
+      list: async (gameId) =>
+        Array.from(rsvps.values()).filter((r) => r.game_id === gameId),
+      listWithMembers: async (gameId, teamId) => {
+        const b = await breakdown(gameId, teamId);
+        return [...b.available, ...b.unavailable, ...b.maybe, ...b.no_response];
+      },
+      breakdown,
+      summarize: async (gameId, teamId) => {
+        const b = await breakdown(gameId, teamId);
+        return {
+          available: b.available.length,
+          unavailable: b.unavailable.length,
+          maybe: b.maybe.length,
+          no_response: b.no_response.length,
+        };
+      },
+    },
+    audit: {
+      insert: async (l) => {
+        audit.push(l);
+        return l;
+      },
+      list: async (targetType, targetId) =>
+        audit.filter(
+          (l) => l.target_type === targetType && l.target_id === targetId,
+        ),
+    },
+    groundSlots: {
+      upsert: async (s: GroundSlot) => s,
+      list: async () => [],
+      listNewerThan: async () => [],
+      getByKey: async () => null,
+    },
+    notifications: {
+      insert: async (c: NotificationChannel) => c,
+      list: async () => [],
+      listEnabled: async () => [],
+      get: async () => null,
+      remove: async () => false,
+    },
+    groundWatches: {
+      insert: async (w: GroundWatch) => w,
+      list: async () => [],
+      listEnabled: async () => [],
+      get: async () => null,
+      remove: async () => false,
+    },
+    observations: observationRepo,
+    knowledge: knowledgeRepo,
+  };
+
+  const notifier: NotificationSender = {
+    send: async (channel, message) => {
+      notifierCalls.push({ channel, message });
+      return {
+        channel_id: channel.id,
+        channel_kind: channel.kind,
+        ok: true,
+        status_code: null,
+        error: null,
+      };
+    },
+  };
+
+  let counter = 0;
+  const ctx: UseCaseContext = {
+    repo,
+    notifier,
+    now: () => new Date(now),
+    newId: () => `id-${++counter}`,
+  };
+
+  return {
+    ctx,
+    stores: {
+      teams,
+      members,
+      games,
+      rsvps,
+      audit,
+      observations,
+      knowledge,
+      notifierCalls,
+    },
+  };
+}

--- a/packages/cli/src/__tests__/usecases/memory-fakes.ts
+++ b/packages/cli/src/__tests__/usecases/memory-fakes.ts
@@ -15,6 +15,8 @@ import type {
   Observation,
   Rsvp,
   RsvpBreakdown,
+  Settlement,
+  SettlementShare,
   Team,
   TeamKnowledge,
 } from "../../domain/types";
@@ -22,6 +24,7 @@ import type {
   NotificationSender,
   ObservationRepository,
   Repositories,
+  SettlementRepository,
   TeamKnowledgeRepository,
   UseCaseContext,
 } from "../../ports";
@@ -75,6 +78,53 @@ export function buildKnowledgeRepo(
     remove: async (id) => store.delete(id),
   };
   return { store, repo };
+}
+
+export function buildSettlementRepo(
+  settlements: Map<string, Settlement> = new Map(),
+  shares: Map<string, SettlementShare> = new Map(),
+): {
+  settlements: Map<string, Settlement>;
+  shares: Map<string, SettlementShare>;
+  repo: SettlementRepository;
+} {
+  const repo: SettlementRepository = {
+    insert: async (s) => {
+      settlements.set(s.id, s);
+      return s;
+    },
+    getByGame: async (gameId) =>
+      Array.from(settlements.values()).find((s) => s.game_id === gameId) ??
+      null,
+    updateStatus: async (id, status, updatedAt) => {
+      const s = settlements.get(id);
+      if (s) settlements.set(id, { ...s, status, updated_at: updatedAt });
+    },
+    insertShare: async (sh) => {
+      shares.set(sh.id, sh);
+      return sh;
+    },
+    listShares: async (settlementId) =>
+      Array.from(shares.values()).filter(
+        (sh) => sh.settlement_id === settlementId,
+      ),
+    getShare: async (settlementId, memberId) =>
+      Array.from(shares.values()).find(
+        (sh) => sh.settlement_id === settlementId && sh.member_id === memberId,
+      ) ?? null,
+    updateSharePaid: async (id, paid, paidAt, updatedAt) => {
+      const sh = shares.get(id);
+      if (sh) {
+        shares.set(id, {
+          ...sh,
+          paid,
+          paid_at: paidAt,
+          updated_at: updatedAt,
+        });
+      }
+    },
+  };
+  return { settlements, shares, repo };
 }
 
 export interface FakeStores {
@@ -230,6 +280,7 @@ export function buildFakeContext(
     },
     observations: observationRepo,
     knowledge: knowledgeRepo,
+    settlements: buildSettlementRepo().repo,
   };
 
   const notifier: NotificationSender = {

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -86,6 +86,8 @@ function buildFake(opts?: { senderError?: Error }): Fake {
     groundSlots,
     notifications: notificationRepo,
     groundWatches: emptyWatches,
+    observations: stub,
+    knowledge: stub,
   };
 
   const notifier: NotificationSender = {

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -88,6 +88,7 @@ function buildFake(opts?: { senderError?: Error }): Fake {
     groundWatches: emptyWatches,
     observations: stub,
     knowledge: stub,
+    settlements: stub,
   };
 
   const notifier: NotificationSender = {

--- a/packages/cli/src/__tests__/usecases/observation.test.ts
+++ b/packages/cli/src/__tests__/usecases/observation.test.ts
@@ -1,0 +1,106 @@
+// Bronze 層 (生の観測) のテスト。追記専用・フィルタ・監査を確認する。
+import { describe, expect, it } from "vitest";
+import type { Team } from "../../domain/types";
+import type { UseCaseContext } from "../../ports";
+import {
+  listObservations,
+  recordObservation,
+} from "../../usecases/observation";
+import { buildFakeContext } from "./memory-fakes";
+
+async function seedTeam(ctx: UseCaseContext): Promise<Team> {
+  return ctx.repo.teams.insert({
+    id: "t",
+    name: "横浜BB",
+    home_area: "横浜",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+describe("recordObservation use case", () => {
+  describe("チームが存在するとき", () => {
+    it("観測を追記し監査 OBSERVATION_RECORDED を残す", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      const obs = await recordObservation(ctx, {
+        teamId: "t",
+        kind: "ROSTER_FACT",
+        body: "鈴木は隔週で来る",
+        subject: null,
+        memberId: null,
+        source: "会話 2026-06-03",
+      });
+      expect(obs.kind).toBe("ROSTER_FACT");
+      expect(obs.body).toBe("鈴木は隔週で来る");
+      expect(stores.observations.get(obs.id)).toBeTruthy();
+      expect(
+        stores.audit.find((l) => l.action === "OBSERVATION_RECORDED"),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("チームが存在しないとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await expect(
+        recordObservation(ctx, {
+          teamId: "nope",
+          kind: "NOTE",
+          body: "x",
+          subject: null,
+          memberId: null,
+          source: null,
+        }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+
+  describe("member 指定が別チームのとき", () => {
+    it("MemberNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await expect(
+        recordObservation(ctx, {
+          teamId: "t",
+          kind: "ROSTER_FACT",
+          body: "x",
+          subject: null,
+          memberId: "ghost",
+          source: null,
+        }),
+      ).rejects.toThrow(/member が存在しません/);
+    });
+  });
+});
+
+describe("listObservations use case", () => {
+  describe("kind フィルタを与えたとき", () => {
+    it("一致する観測だけを返す", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await recordObservation(ctx, {
+        teamId: "t",
+        kind: "VENUE",
+        body: "三ツ沢は取りやすい",
+        subject: null,
+        memberId: null,
+        source: null,
+      });
+      await recordObservation(ctx, {
+        teamId: "t",
+        kind: "NOTE",
+        body: "来季は人数増やす",
+        subject: null,
+        memberId: null,
+        source: null,
+      });
+      const venues = await listObservations(ctx, {
+        teamId: "t",
+        kind: "VENUE",
+      });
+      expect(venues).toHaveLength(1);
+      expect(venues[0]?.body).toBe("三ツ沢は取りやすい");
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/settlement.test.ts
+++ b/packages/cli/src/__tests__/usecases/settlement.test.ts
@@ -1,0 +1,182 @@
+// 精算 (PayPay 割り勘) のテスト。割り勘計算・未払い把握・全額消し込みで自動 SETTLED を確認する。
+import { describe, expect, it } from "vitest";
+import type { GameStatus } from "../../domain/types";
+import type { UseCaseContext } from "../../ports";
+import {
+  createSettlement,
+  getSettlement,
+  markPaid,
+  splitEvenly,
+} from "../../usecases/settlement";
+import { buildFakeContext } from "./memory-fakes";
+
+async function seedTeam(ctx: UseCaseContext): Promise<void> {
+  await ctx.repo.teams.insert({
+    id: "t",
+    name: "T",
+    home_area: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+async function addGame(
+  ctx: UseCaseContext,
+  status: GameStatus = "COMPLETED",
+): Promise<string> {
+  await ctx.repo.games.insert({
+    id: "g",
+    team_id: "t",
+    title: "練習試合",
+    status,
+    game_date: "2026-06-01",
+    ground_name: "三ツ沢",
+    min_players: 1,
+    note: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+  return "g";
+}
+
+async function addMemberWithRsvp(
+  ctx: UseCaseContext,
+  id: string,
+  response: "AVAILABLE" | "UNAVAILABLE",
+): Promise<void> {
+  await ctx.repo.members.insert({
+    id,
+    team_id: "t",
+    name: id,
+    email: null,
+    role: "MEMBER",
+    created_at: "x",
+    updated_at: "x",
+  });
+  await ctx.repo.rsvps.upsert({
+    id: `g:${id}`,
+    game_id: "g",
+    member_id: id,
+    response,
+    responded_at: "x",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+describe("splitEvenly", () => {
+  describe("割り切れないとき", () => {
+    it("端数を先頭から 1 円ずつ載せて合計を一致させる", () => {
+      const parts = splitEvenly(1000, 3);
+      expect(parts).toEqual([334, 333, 333]);
+      expect(parts.reduce((a, b) => a + b, 0)).toBe(1000);
+    });
+  });
+});
+
+describe("createSettlement use case", () => {
+  describe("AVAILABLE の参加者がいるとき", () => {
+    it("AVAILABLE のメンバーで割り勘し share を作る", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx);
+      await addMemberWithRsvp(ctx, "m1", "AVAILABLE");
+      await addMemberWithRsvp(ctx, "m2", "AVAILABLE");
+      await addMemberWithRsvp(ctx, "m3", "UNAVAILABLE"); // 不参加は割り勘に入らない
+
+      await createSettlement(ctx, {
+        gameId: "g",
+        totalAmount: 3000,
+        paymentLink: "https://pay.paypay.ne.jp/xxxx",
+        paymentLabel: "PayPay: 田中宛",
+        note: null,
+        participantMemberIds: null,
+      });
+      const view = await getSettlement(ctx, "g");
+      expect(view?.summary.participants).toBe(2);
+      expect(view?.shares.map((s) => s.amount)).toEqual([1500, 1500]);
+      expect(view?.summary.outstanding).toBe(3000);
+    });
+  });
+
+  describe("参加者がいないとき", () => {
+    it("SettlementError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx);
+      await expect(
+        createSettlement(ctx, {
+          gameId: "g",
+          totalAmount: 3000,
+          paymentLink: null,
+          paymentLabel: null,
+          note: null,
+          participantMemberIds: null,
+        }),
+      ).rejects.toThrow(/参加者がいません/);
+    });
+  });
+
+  describe("既に精算があるとき", () => {
+    it("二重作成を SettlementError で拒否する", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx);
+      await addMemberWithRsvp(ctx, "m1", "AVAILABLE");
+      const input = {
+        gameId: "g",
+        totalAmount: 1000,
+        paymentLink: null,
+        paymentLabel: null,
+        note: null,
+        participantMemberIds: null,
+      };
+      await createSettlement(ctx, input);
+      await expect(createSettlement(ctx, input)).rejects.toThrow(/既に存在/);
+    });
+  });
+});
+
+describe("markPaid use case", () => {
+  describe("全員が支払ったとき", () => {
+    it("settlement=SETTLED になり COMPLETED の試合も SETTLED へ進む", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx, "COMPLETED");
+      await addMemberWithRsvp(ctx, "m1", "AVAILABLE");
+      await addMemberWithRsvp(ctx, "m2", "AVAILABLE");
+      await createSettlement(ctx, {
+        gameId: "g",
+        totalAmount: 2000,
+        paymentLink: null,
+        paymentLabel: null,
+        note: null,
+        participantMemberIds: null,
+      });
+
+      await markPaid(ctx, { gameId: "g", memberId: "m1", paid: true });
+      const mid = await getSettlement(ctx, "g");
+      expect(mid?.settlement.status).toBe("OPEN"); // まだ 1 人
+
+      const view = await markPaid(ctx, {
+        gameId: "g",
+        memberId: "m2",
+        paid: true,
+      });
+      expect(view.settlement.status).toBe("SETTLED");
+      expect(view.summary.outstanding).toBe(0);
+      expect(stores.games.get("g")?.status).toBe("SETTLED");
+    });
+  });
+
+  describe("精算が無い試合のとき", () => {
+    it("SettlementError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await addGame(ctx);
+      await expect(
+        markPaid(ctx, { gameId: "g", memberId: "m1", paid: true }),
+      ).rejects.toThrow(/精算がありません/);
+    });
+  });
+});

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -28,8 +28,10 @@ import { runAudit } from "./commands/audit";
 import { runGame } from "./commands/game";
 import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
+import { runKnowledge } from "./commands/knowledge";
 import { runMember } from "./commands/member";
 import { runNotify } from "./commands/notify";
+import { runObserve } from "./commands/observe";
 import { runRsvp } from "./commands/rsvp";
 import { runTeam } from "./commands/team";
 import { runWatch } from "./commands/watch";
@@ -122,6 +124,12 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "watch":
         await runWatch(subArgs, ctx, renderOpts);
+        return 0;
+      case "observe":
+        await runObserve(subArgs, ctx, renderOpts);
+        return 0;
+      case "knowledge":
+        await runKnowledge(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -14,6 +14,7 @@ const USER_ERROR_NAMES = new Set([
   "GameNotFoundError",
   "MemberNotFoundError",
   "CrossTeamRsvpError",
+  "SettlementError",
 ]);
 
 function isUserError(e: unknown): boolean {
@@ -35,6 +36,7 @@ import { runMember } from "./commands/member";
 import { runNotify } from "./commands/notify";
 import { runObserve } from "./commands/observe";
 import { runRsvp } from "./commands/rsvp";
+import { runSettle } from "./commands/settle";
 import { runTeam } from "./commands/team";
 import { runWatch } from "./commands/watch";
 import { composeContext } from "./compose";
@@ -138,6 +140,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "auto":
         await runAuto(subArgs, ctx, renderOpts);
+        return 0;
+      case "settle":
+        await runSettle(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -25,6 +25,7 @@ import type { NotificationSender } from "../../ports";
 import { TransitionDeniedError } from "../../usecases/errors";
 import { runAgenda } from "./commands/agenda";
 import { runAudit } from "./commands/audit";
+import { runAuto } from "./commands/auto";
 import { runGame } from "./commands/game";
 import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
@@ -134,6 +135,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "learn":
         await runLearn(subArgs, ctx, renderOpts);
+        return 0;
+      case "auto":
+        await runAuto(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -29,6 +29,7 @@ import { runGame } from "./commands/game";
 import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
 import { runKnowledge } from "./commands/knowledge";
+import { runLearn } from "./commands/learn";
 import { runMember } from "./commands/member";
 import { runNotify } from "./commands/notify";
 import { runObserve } from "./commands/observe";
@@ -130,6 +131,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "knowledge":
         await runKnowledge(subArgs, ctx, renderOpts);
+        return 0;
+      case "learn":
+        await runLearn(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/commands/auto.ts
+++ b/packages/cli/src/adapters/cli/commands/auto.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { UseCaseContext } from "../../../ports";
+import { planAutopilot, runAutopilot } from "../../../usecases/autopilot";
+import {
+  type ParsedArgs,
+  UsageError,
+  boolFlag,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const horizonSchema = z.coerce.number().int().min(0).max(365).default(7);
+
+export async function runAuto(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound auto <plan|run>");
+  if (sub === "plan") return planCmd(args, ctx, opts);
+  if (sub === "run") return runCmd(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: auto ${sub}`);
+}
+
+function horizonDays(args: ParsedArgs): number {
+  return parseOrUsage(horizonSchema, optionalFlag(args.flags, "horizon-days"));
+}
+
+async function planCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const plan = await planAutopilot(ctx, {
+    teamId,
+    horizonDays: horizonDays(args),
+  });
+  const text = [
+    `打つべき手 ${plan.actions.length} 件 (SAFE=自動実行可 / NEEDS_APPROVAL=要承認)`,
+    formatRows(plan.actions, ["kind", "risk", "game_title", "reason"]),
+  ].join("\n");
+  emit(plan, text, opts);
+}
+
+async function runCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const apply = boolFlag(args.flags, "apply");
+  const result = await runAutopilot(ctx, {
+    teamId,
+    horizonDays: horizonDays(args),
+    apply,
+  });
+  const head = apply
+    ? `自動実行 ${result.executed.length} 件 / 要承認・保留 ${result.proposed.length} 件`
+    : `dry-run: 自動実行候補 ${result.actions.filter((a) => a.risk === "SAFE").length} 件 / 要承認 ${result.proposed.filter((a) => a.risk === "NEEDS_APPROVAL").length} 件 (実行するには --apply)`;
+  const lines = [head];
+  if (result.executed.length) {
+    lines.push(
+      "--- 実行 ---",
+      formatRows(
+        result.executed.map((e) => ({
+          kind: e.action.kind,
+          game: e.action.game_title,
+          ok: e.ok,
+          error: e.error ?? "",
+        })),
+        ["kind", "game", "ok", "error"],
+      ),
+    );
+  }
+  if (result.proposed.length) {
+    lines.push(
+      "--- 提案 (人が決める) ---",
+      formatRows(result.proposed, ["kind", "risk", "game_title", "reason"]),
+    );
+  }
+  emit(result, lines.join("\n"), opts);
+}

--- a/packages/cli/src/adapters/cli/commands/knowledge.ts
+++ b/packages/cli/src/adapters/cli/commands/knowledge.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import { KNOWLEDGE_CATEGORIES, KNOWLEDGE_ORIGINS } from "../../../domain/types";
+import type { UseCaseContext } from "../../../ports";
+import {
+  forgetKnowledge,
+  getKnowledge,
+  listKnowledge,
+  recordKnowledge,
+} from "../../../usecases/knowledge";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const setInput = z.object({
+  teamId: z.string().min(1),
+  key: z.string().min(1, "--key は必須です"),
+  value: z.string().min(1, "--value は必須です"),
+  category: z.enum(KNOWLEDGE_CATEGORIES).default("NOTE"),
+  memberId: z.string().min(1).optional(),
+  origin: z.enum(KNOWLEDGE_ORIGINS).default("HUMAN"),
+  confidence: z.coerce
+    .number()
+    .min(0, "--confidence は 0–1")
+    .max(1, "--confidence は 0–1")
+    .default(1),
+  source: z.string().max(120).optional(),
+});
+
+export async function runKnowledge(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub)
+    throw new UsageError("使い方: mound knowledge <set|list|get|forget>");
+  if (sub === "set") return setCmd(args, ctx, opts);
+  if (sub === "list") return listCmd(args, ctx, opts);
+  if (sub === "get") return getCmd(args, ctx, opts);
+  if (sub === "forget") return forgetCmd(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: knowledge ${sub}`);
+}
+
+async function setCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(setInput, {
+    teamId: requireFlag(args.flags, "team"),
+    key: requireFlag(args.flags, "key"),
+    value: requireFlag(args.flags, "value"),
+    category: optionalFlag(args.flags, "category"),
+    memberId: optionalFlag(args.flags, "member"),
+    origin: optionalFlag(args.flags, "origin"),
+    confidence: optionalFlag(args.flags, "confidence"),
+    source: optionalFlag(args.flags, "source"),
+  });
+  const entry = await recordKnowledge(ctx, {
+    teamId: data.teamId,
+    key: data.key,
+    value: data.value,
+    category: data.category,
+    memberId: data.memberId ?? null,
+    origin: data.origin,
+    confidence: data.confidence,
+    source: data.source ?? null,
+  });
+  emit(
+    entry,
+    `決め事を記録: ${entry.key} = ${entry.value} ` +
+      `(origin=${entry.origin}, confidence=${entry.confidence}, evidence=${entry.evidence_count})`,
+    opts,
+  );
+}
+
+async function listCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const category = optionalFlag(args.flags, "category");
+  const memberId = optionalFlag(args.flags, "member");
+  const key = optionalFlag(args.flags, "key");
+  const entries = await listKnowledge(ctx, {
+    teamId,
+    ...(category
+      ? { category: parseOrUsage(z.enum(KNOWLEDGE_CATEGORIES), category) }
+      : {}),
+    ...(memberId ? { memberId } : {}),
+    ...(key ? { key } : {}),
+  });
+  emit(
+    entries,
+    formatRows(entries, [
+      "category",
+      "key",
+      "value",
+      "origin",
+      "confidence",
+      "evidence_count",
+      "member_id",
+    ]),
+    opts,
+  );
+}
+
+async function getCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const key = requireFlag(args.flags, "key");
+  const memberId = optionalFlag(args.flags, "member") ?? null;
+  const entry = await getKnowledge(ctx, teamId, key, memberId);
+  if (!entry) {
+    emit({ found: false, team_id: teamId, key }, `該当なし: ${key}`, opts);
+    return;
+  }
+  emit(entry, `${entry.key} = ${entry.value}`, opts);
+}
+
+async function forgetCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id) throw new UsageError("使い方: mound knowledge forget <ID>");
+  const removed = await forgetKnowledge(ctx, id);
+  emit(
+    { ok: removed, id },
+    removed
+      ? `決め事を削除しました: ${id}`
+      : `該当する決め事が見つかりません: ${id}`,
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/commands/learn.ts
+++ b/packages/cli/src/adapters/cli/commands/learn.ts
@@ -1,0 +1,37 @@
+import type { UseCaseContext } from "../../../ports";
+import { learnTeam } from "../../../usecases/learn";
+import { type ParsedArgs, boolFlag, requireFlag } from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+
+// mound learn — 過去の試合・出欠からチームの決め事を学習する。
+// 既定は dry-run (提案のみ)。--apply で Gold (team_knowledge) に反映。
+export async function runLearn(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const apply = boolFlag(args.flags, "apply");
+  const result = await learnTeam(ctx, { teamId, apply });
+
+  const header = apply
+    ? `学習結果を反映しました (${result.facts.length} 件${
+        result.pinned_skips.length
+          ? `, 人の決め事を尊重してスキップ ${result.pinned_skips.length} 件`
+          : ""
+      })`
+    : `学習候補 (${result.facts.length} 件) — 反映するには --apply`;
+  const text = [
+    header,
+    formatRows(result.facts, [
+      "category",
+      "key",
+      "value",
+      "confidence",
+      "evidence_count",
+      "member_name",
+      "rationale",
+    ]),
+  ].join("\n");
+  emit(result, text, opts);
+}

--- a/packages/cli/src/adapters/cli/commands/observe.ts
+++ b/packages/cli/src/adapters/cli/commands/observe.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { OBSERVATION_KINDS } from "../../../domain/types";
+import type { UseCaseContext } from "../../../ports";
+import {
+  listObservations,
+  recordObservation,
+} from "../../../usecases/observation";
+import {
+  type ParsedArgs,
+  UsageError,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const addInput = z.object({
+  teamId: z.string().min(1),
+  kind: z.enum(OBSERVATION_KINDS),
+  body: z.string().min(1, "--body は必須です"),
+  subject: z.string().max(120).optional(),
+  memberId: z.string().min(1).optional(),
+  source: z.string().max(120).optional(),
+});
+
+export async function runObserve(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound observe <add|list>");
+  if (sub === "add") return addCmd(args, ctx, opts);
+  if (sub === "list") return listCmd(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: observe ${sub}`);
+}
+
+async function addCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(addInput, {
+    teamId: requireFlag(args.flags, "team"),
+    kind: requireFlag(args.flags, "kind"),
+    body: requireFlag(args.flags, "body"),
+    subject: optionalFlag(args.flags, "subject"),
+    memberId: optionalFlag(args.flags, "member"),
+    source: optionalFlag(args.flags, "source"),
+  });
+  const observation = await recordObservation(ctx, {
+    teamId: data.teamId,
+    kind: data.kind,
+    body: data.body,
+    subject: data.subject ?? null,
+    memberId: data.memberId ?? null,
+    source: data.source ?? null,
+  });
+  emit(
+    observation,
+    `観測を記録しました: ${observation.id} (${observation.kind})`,
+    opts,
+  );
+}
+
+async function listCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const kind = optionalFlag(args.flags, "kind");
+  const memberId = optionalFlag(args.flags, "member");
+  const observations = await listObservations(ctx, {
+    teamId,
+    ...(kind ? { kind: parseOrUsage(z.enum(OBSERVATION_KINDS), kind) } : {}),
+    ...(memberId ? { memberId } : {}),
+  });
+  emit(
+    observations,
+    formatRows(observations, [
+      "kind",
+      "subject",
+      "body",
+      "member_id",
+      "source",
+      "observed_at",
+    ]),
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/commands/settle.ts
+++ b/packages/cli/src/adapters/cli/commands/settle.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import type { UseCaseContext } from "../../../ports";
+import { notifyTeam } from "../../../usecases/notification";
+import {
+  createSettlement,
+  formatSettlementMessage,
+  getSettlement,
+  markPaid,
+} from "../../../usecases/settlement";
+import {
+  type ParsedArgs,
+  UsageError,
+  boolFlag,
+  optionalFlag,
+  requireFlag,
+} from "../args";
+import { type RenderOptions, emit, formatRows } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const openInput = z.object({
+  gameId: z.string().min(1),
+  totalAmount: z.coerce
+    .number()
+    .int()
+    .positive("--amount は 1 以上の整数 (円)"),
+  paymentLink: z.string().min(1).optional(),
+  paymentLabel: z.string().max(80).optional(),
+  note: z.string().max(200).optional(),
+  members: z.string().min(1).optional(), // CSV で参加者を明示
+});
+
+export async function runSettle(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0];
+  if (!sub) throw new UsageError("使い方: mound settle <open|show|pay|remind>");
+  if (sub === "open") return openCmd(args, ctx, opts);
+  if (sub === "show") return showCmd(args, ctx, opts);
+  if (sub === "pay") return payCmd(args, ctx, opts);
+  if (sub === "remind") return remindCmd(args, ctx, opts);
+  throw new UsageError(`未知のサブコマンド: settle ${sub}`);
+}
+
+function viewText(
+  title: string,
+  view: NonNullable<Awaited<ReturnType<typeof getSettlement>>>,
+): string {
+  const s = view.summary;
+  return [
+    `${title} — 合計 ¥${s.total} / ${s.participants}人 / 回収 ¥${s.collected} / 未回収 ¥${s.outstanding} (未払い ${s.unpaid_count}人)`,
+    formatRows(view.shares, ["member_name", "amount", "paid", "paid_at"]),
+  ].join("\n");
+}
+
+async function openCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const data = parseOrUsage(openInput, {
+    gameId: requireFlag(args.flags, "game"),
+    totalAmount: requireFlag(args.flags, "amount"),
+    paymentLink: optionalFlag(args.flags, "link"),
+    paymentLabel: optionalFlag(args.flags, "label"),
+    note: optionalFlag(args.flags, "note"),
+    members: optionalFlag(args.flags, "members"),
+  });
+  await createSettlement(ctx, {
+    gameId: data.gameId,
+    totalAmount: data.totalAmount,
+    paymentLink: data.paymentLink ?? null,
+    paymentLabel: data.paymentLabel ?? null,
+    note: data.note ?? null,
+    participantMemberIds: data.members
+      ? data.members
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : null,
+  });
+  const view = await getSettlement(ctx, data.gameId);
+  if (!view) throw new UsageError("精算の作成に失敗しました");
+  emit(view, viewText("精算を作成しました", view), opts);
+}
+
+async function showCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const gameId = requireFlag(args.flags, "game");
+  const view = await getSettlement(ctx, gameId);
+  if (!view) {
+    emit({ found: false, game_id: gameId }, `精算なし: ${gameId}`, opts);
+    return;
+  }
+  emit(view, viewText("精算", view), opts);
+}
+
+async function payCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const gameId = requireFlag(args.flags, "game");
+  const memberId = requireFlag(args.flags, "member");
+  const paid = !boolFlag(args.flags, "unpaid");
+  const view = await markPaid(ctx, { gameId, memberId, paid });
+  emit(
+    view,
+    viewText(paid ? "支払いを記録しました" : "未払いに戻しました", view),
+    opts,
+  );
+}
+
+async function remindCmd(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const gameId = requireFlag(args.flags, "game");
+  const view = await getSettlement(ctx, gameId);
+  if (!view) throw new UsageError(`この試合の精算がありません: ${gameId}`);
+  const game = await ctx.repo.games.get(gameId);
+  const message = formatSettlementMessage(game?.title ?? "試合", view);
+  const deliveries = await notifyTeam(ctx, view.settlement.team_id, message);
+  emit({ message, deliveries }, `催促を送信しました\n${message}`, opts);
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -37,6 +37,7 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   knowledge list --team <ID> [--category C] [--member ID] [--key K]
   knowledge get --team <ID> --key <K> [--member ID]
   knowledge forget <ID>
+  learn --team <ID> [--apply]                過去の試合・出欠から決め事を学習
 
 環境変数 (追加):
   MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
@@ -633,6 +634,35 @@ JSON 出力:
 
 エラー:
   - TeamNotFoundError / MemberNotFoundError (exit 2)
+`,
+
+  learn: `mound learn — 過去の試合・出欠からチームの決め事を学習 (Silver→Gold)
+
+使い方:
+  mound learn --team <TEAM_ID> [--apply] [--json]
+
+フラグ:
+  --team    (必須) チーム ID
+  --apply   (任意) Gold (team_knowledge) に反映する。未指定は dry-run (提案のみ)
+
+学習する決め事:
+  - default_ground   : よく使う会場 (ground_name の最頻値)
+  - default_weekday  : よくやる曜日 (game_date の曜日の最頻値)
+  - attendance_rate  : メンバーごとの出席率 (回答試合中 AVAILABLE の割合)
+
+挙動:
+  - 毎回その時点の履歴から再計算する (傾向が変われば値も入れ替わる = 降格も効く)
+  - origin=HUMAN の決め事は touch しない (ピン留め)。pinned_skips で報告
+  - 最低 2 件の裏付けがある決め事だけを出す
+
+JSON 出力:
+  {
+    "team_id": string,
+    "generated_at": ISO8601,
+    "applied": boolean,
+    "facts": [{ category, key, value, confidence, evidence_count, member_id, member_name, rationale }],
+    "pinned_skips": string[]
+  }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -40,6 +40,10 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   learn --team <ID> [--apply]                過去の試合・出欠から決め事を学習
   auto plan --team <ID> [--horizon-days N]    いま打つべき手を算出 (read-only)
   auto run --team <ID> [--apply] [--horizon-days N]  安全な手は自動・拘束する手は提案
+  settle open --game <ID> --amount <YEN> [--link URL] [--label L] [--note N] [--members CSV]
+  settle show --game <ID>
+  settle pay --game <ID> --member <ID> [--unpaid]
+  settle remind --game <ID>                   PayPay 割り勘の催促を通知
 
 環境変数 (追加):
   MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
@@ -665,6 +669,37 @@ JSON 出力:
     "facts": [{ category, key, value, confidence, evidence_count, member_id, member_name, rationale }],
     "pinned_skips": string[]
   }
+`,
+
+  settle: `mound settle — 精算 (PayPay 割り勘): 割り勘計算・未払い把握・催促・自動完了
+
+サブコマンド:
+  settle open   --game <ID> --amount <YEN> [--link URL] [--label L] [--note N] [--members CSV] [--json]
+  settle show   --game <ID> [--json]
+  settle pay    --game <ID> --member <ID> [--unpaid] [--json]
+  settle remind --game <ID> [--json]
+
+挙動:
+  - open: 合計金額を参加者 (既定: RSVP=AVAILABLE のメンバー / --members で明示) で割り勘し、
+          端数は先頭から 1 円ずつ調整して合計を一致させる。試合 1 件につき 1 精算。
+  - pay:  支払いを消し込む。全員払うと settlement=SETTLED になり、COMPLETED の試合は
+          自動で SETTLED へ進む (--unpaid で取り消し)。
+  - remind: PayPay リンク + 1人あたり + 未払い者を催促文にしてチームの通知チャネルへ送信。
+
+備考:
+  PayPay 個人割り勘に公開 API は無いため、リンクは人が貼り、入金は人が消し込む。
+  mound は割り勘額の計算・未払いの把握・催促文の生成・精算完了の自動遷移を担う。
+
+JSON 出力 (open/show/pay):
+  {
+    "settlement": { id, game_id, team_id, total_amount, payment_link, payment_label, note, status, ... },
+    "shares": [{ member_id, member_name, amount, paid, paid_at, ... }],
+    "summary": { participants, paid_count, unpaid_count, collected, outstanding, total }
+  }
+
+エラー:
+  - GameNotFoundError (exit 2)
+  - SettlementError: 参加者ゼロ / 精算二重作成 / 精算未作成 / 金額不正 (exit 2)
 `,
 
   auto: `mound auto — autopilot: いま打つべき手を算出し、安全な手は自動・拘束する手は提案

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -31,6 +31,12 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   watch list --team <ID>
   watch remove <ID>
   watch test --team <ID>
+  observe add --team <ID> --kind <KIND> --body <TEXT> [--member <ID>] [--subject S] [--source S]
+  observe list --team <ID> [--kind <KIND>] [--member <ID>]
+  knowledge set --team <ID> --key <K> --value <V> [--category C] [--member ID] [--origin HUMAN|LEARNED] [--confidence 0..1] [--source S]
+  knowledge list --team <ID> [--category C] [--member ID] [--key K]
+  knowledge get --team <ID> --key <K> [--member ID]
+  knowledge forget <ID>
 
 環境変数 (追加):
   MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
@@ -576,6 +582,57 @@ JSON 出力:
 
 JSON 出力:
   { "count": number, "slots": GroundSlot[] }
+`,
+
+  observe: `mound observe — チームの記憶 (Bronze): 会話で得た生の観測を追記
+
+サブコマンド:
+  observe add  --team <ID> --kind <KIND> --body <TEXT> [--member <ID>] [--subject S] [--source S] [--json]
+  observe list --team <ID> [--kind <KIND>] [--member <ID>] [--json]
+
+KIND:
+  PREFERENCE_HINT | ROSTER_FACT | VENUE | RULE | OPPONENT | NOTE
+
+狙い:
+  「土曜の朝が動きやすい」「鈴木は隔週で来る」など、構造を決めずまず書き留める層。
+  状態は mound (libSQL/SQLite) に永続化されるので、駆動エージェント (Hermes/Codex/Claude)
+  を差し替えても同じチーム文脈から再開できる。型付きの決め事は knowledge set へ昇格。
+
+JSON 出力:
+  Observation { id, team_id, member_id, kind, subject, body, source, observed_at, created_at }
+
+エラー:
+  - TeamNotFoundError / MemberNotFoundError (exit 2)
+`,
+
+  knowledge: `mound knowledge — チームの記憶 (Gold): 確信度付きの「決め事」
+
+サブコマンド:
+  knowledge set    --team <ID> --key <K> --value <V> [--category C] [--member ID] \\
+                   [--origin HUMAN|LEARNED] [--confidence 0..1] [--source S] [--json]
+  knowledge list   --team <ID> [--category C] [--member ID] [--key K] [--json]
+  knowledge get    --team <ID> --key <K> [--member ID] [--json]
+  knowledge forget <ID> [--json]
+
+category: PREFERENCE | RULE | ROSTER | VENUE | OPPONENT | NOTE (既定: NOTE)
+origin:   HUMAN (人が明示, 既定) | LEARNED (実績から学習)
+
+マージ規則 ((team, member, key) で upsert):
+  - HUMAN は LEARNED に上書きされない (人の決め事をピン留め)
+  - LEARNED 同士は confidence が高い方が値を握る
+  - 観測のたび evidence_count を加算 (使うほど裏付けが厚くなる)
+
+代表的な key (PREFERENCE):
+  default_ground / default_weekday / default_time / default_min_players /
+  reminder_lead_days / fee_per_person
+
+JSON 出力:
+  TeamKnowledge { id, team_id, member_id, category, key, value, origin,
+                  confidence, evidence_count, source, last_observed_at,
+                  created_at, updated_at }
+
+エラー:
+  - TeamNotFoundError / MemberNotFoundError (exit 2)
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -38,6 +38,8 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   knowledge get --team <ID> --key <K> [--member ID]
   knowledge forget <ID>
   learn --team <ID> [--apply]                過去の試合・出欠から決め事を学習
+  auto plan --team <ID> [--horizon-days N]    いま打つべき手を算出 (read-only)
+  auto run --team <ID> [--apply] [--horizon-days N]  安全な手は自動・拘束する手は提案
 
 環境変数 (追加):
   MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
@@ -663,6 +665,37 @@ JSON 出力:
     "facts": [{ category, key, value, confidence, evidence_count, member_id, member_name, rationale }],
     "pinned_skips": string[]
   }
+`,
+
+  auto: `mound auto — autopilot: いま打つべき手を算出し、安全な手は自動・拘束する手は提案
+
+サブコマンド:
+  auto plan --team <ID> [--horizon-days N] [--json]            read-only。打つべき手の一覧
+  auto run  --team <ID> [--apply] [--horizon-days N] [--json]  SAFE な手を自動実行 (--apply 時)
+
+原則「AI は提案する。人が最後に決める」:
+  - SAFE          … --apply で自動実行
+      PUBLISH            DRAFT → COLLECTING (出欠回収を開始)
+      COMPLETE          CONFIRMED → COMPLETED (試合日が経過)
+      REMIND_COLLECTING 出欠が足りない試合へリマインド通知
+      REMIND_SETTLEMENT 精算待ちへリマインド通知
+  - NEEDS_APPROVAL … 常に提案のみ (人が実行)
+      CONFIRM           COLLECTING → CONFIRMED (人数充足、チームを拘束する確定)
+
+挙動:
+  - agenda (現在状態) を読んで手を導出する
+  - 遷移は既存の game transition を呼ぶ (ガード・監査・通知が自動で効く)
+  - cron で定期実行すれば人手ゼロで回り続ける。駆動は Hermes/Codex/Claude でも可
+
+JSON 出力 (auto run):
+  {
+    "team_id": string, "generated_at": ISO8601, "horizon_days": number,
+    "applied": boolean,
+    "actions": AutoAction[],
+    "executed": [{ action, ok, error, deliveries? }],
+    "proposed": AutoAction[]
+  }
+  AutoAction = { kind, risk, game_id, game_title, reason, transition_to, message }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -8,10 +8,12 @@ import type {
   Member,
   MemberRsvp,
   NotificationChannel,
+  Observation,
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
   Team,
+  TeamKnowledge,
 } from "../../domain/types";
 import type {
   AuditRepository,
@@ -20,10 +22,14 @@ import type {
   GroundSlotFilter,
   GroundSlotRepository,
   GroundWatchRepository,
+  KnowledgeFilter,
   MemberRepository,
   NotificationChannelRepository,
+  ObservationFilter,
+  ObservationRepository,
   Repositories,
   RsvpRepository,
+  TeamKnowledgeRepository,
   TeamRepository,
 } from "../../ports";
 import type { DbClient } from "./client";
@@ -35,8 +41,10 @@ import {
   rowToMember,
   rowToMemberRsvp,
   rowToNotificationChannel,
+  rowToObservation,
   rowToRsvp,
   rowToTeam,
+  rowToTeamKnowledge,
 } from "./row-mappers";
 
 class LibsqlTeamRepository implements TeamRepository {
@@ -520,6 +528,150 @@ class LibsqlGroundWatchRepository implements GroundWatchRepository {
   }
 }
 
+class LibsqlObservationRepository implements ObservationRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(observation: Observation): Promise<Observation> {
+    await this.db.execute({
+      sql: `INSERT INTO observations (
+              id, team_id, member_id, kind, subject, body, source,
+              observed_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        observation.id,
+        observation.team_id,
+        observation.member_id,
+        observation.kind,
+        observation.subject,
+        observation.body,
+        observation.source,
+        observation.observed_at,
+        observation.created_at,
+      ],
+    });
+    return observation;
+  }
+
+  async list(filter: ObservationFilter): Promise<Observation[]> {
+    const where: string[] = ["team_id = ?"];
+    const args: InValue[] = [filter.teamId];
+    if (filter.kind) {
+      where.push("kind = ?");
+      args.push(filter.kind);
+    }
+    if (filter.memberId) {
+      where.push("member_id = ?");
+      args.push(filter.memberId);
+    }
+    const r = await this.db.execute({
+      sql: `SELECT * FROM observations WHERE ${where.join(" AND ")}
+            ORDER BY observed_at DESC`,
+      args,
+    });
+    return r.rows.map(rowToObservation);
+  }
+}
+
+class LibsqlTeamKnowledgeRepository implements TeamKnowledgeRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(entry: TeamKnowledge): Promise<TeamKnowledge> {
+    await this.db.execute({
+      sql: `INSERT INTO team_knowledge (
+              id, team_id, member_id, category, key, value, origin,
+              confidence, evidence_count, source, last_observed_at,
+              created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        entry.id,
+        entry.team_id,
+        entry.member_id,
+        entry.category,
+        entry.key,
+        entry.value,
+        entry.origin,
+        entry.confidence,
+        entry.evidence_count,
+        entry.source,
+        entry.last_observed_at,
+        entry.created_at,
+        entry.updated_at,
+      ],
+    });
+    return entry;
+  }
+
+  async update(entry: TeamKnowledge): Promise<TeamKnowledge> {
+    await this.db.execute({
+      sql: `UPDATE team_knowledge SET
+              category = ?, value = ?, origin = ?, confidence = ?,
+              evidence_count = ?, source = ?, last_observed_at = ?, updated_at = ?
+            WHERE id = ?`,
+      args: [
+        entry.category,
+        entry.value,
+        entry.origin,
+        entry.confidence,
+        entry.evidence_count,
+        entry.source,
+        entry.last_observed_at,
+        entry.updated_at,
+        entry.id,
+      ],
+    });
+    return entry;
+  }
+
+  async getByKey(
+    teamId: string,
+    memberId: string | null,
+    key: string,
+  ): Promise<TeamKnowledge | null> {
+    // member_id は NULL を含むため = ではなく IS NULL で分岐する。
+    const memberClause =
+      memberId === null ? "member_id IS NULL" : "member_id = ?";
+    const args: InValue[] =
+      memberId === null ? [teamId, key] : [teamId, memberId, key];
+    const r = await this.db.execute({
+      sql: `SELECT * FROM team_knowledge
+            WHERE team_id = ? AND ${memberClause} AND key = ?`,
+      args,
+    });
+    return r.rows[0] ? rowToTeamKnowledge(r.rows[0]) : null;
+  }
+
+  async list(filter: KnowledgeFilter): Promise<TeamKnowledge[]> {
+    const where: string[] = ["team_id = ?"];
+    const args: InValue[] = [filter.teamId];
+    if (filter.category) {
+      where.push("category = ?");
+      args.push(filter.category);
+    }
+    if (filter.memberId) {
+      where.push("member_id = ?");
+      args.push(filter.memberId);
+    }
+    if (filter.key) {
+      where.push("key = ?");
+      args.push(filter.key);
+    }
+    const r = await this.db.execute({
+      sql: `SELECT * FROM team_knowledge WHERE ${where.join(" AND ")}
+            ORDER BY category ASC, key ASC, created_at ASC`,
+      args,
+    });
+    return r.rows.map(rowToTeamKnowledge);
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const r = await this.db.execute({
+      sql: "DELETE FROM team_knowledge WHERE id = ?",
+      args: [id],
+    });
+    return r.rowsAffected > 0;
+  }
+}
+
 export function buildRepositories(db: DbClient): Repositories {
   return {
     teams: new LibsqlTeamRepository(db),
@@ -530,5 +682,7 @@ export function buildRepositories(db: DbClient): Repositories {
     groundSlots: new LibsqlGroundSlotRepository(db),
     notifications: new LibsqlNotificationChannelRepository(db),
     groundWatches: new LibsqlGroundWatchRepository(db),
+    observations: new LibsqlObservationRepository(db),
+    knowledge: new LibsqlTeamKnowledgeRepository(db),
   };
 }

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -12,6 +12,9 @@ import type {
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
+  Settlement,
+  SettlementShare,
+  SettlementStatus,
   Team,
   TeamKnowledge,
 } from "../../domain/types";
@@ -29,6 +32,7 @@ import type {
   ObservationRepository,
   Repositories,
   RsvpRepository,
+  SettlementRepository,
   TeamKnowledgeRepository,
   TeamRepository,
 } from "../../ports";
@@ -43,6 +47,8 @@ import {
   rowToNotificationChannel,
   rowToObservation,
   rowToRsvp,
+  rowToSettlement,
+  rowToSettlementShare,
   rowToTeam,
   rowToTeamKnowledge,
 } from "./row-mappers";
@@ -672,6 +678,103 @@ class LibsqlTeamKnowledgeRepository implements TeamKnowledgeRepository {
   }
 }
 
+class LibsqlSettlementRepository implements SettlementRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async insert(settlement: Settlement): Promise<Settlement> {
+    await this.db.execute({
+      sql: `INSERT INTO settlements (
+              id, game_id, team_id, total_amount, payment_link, payment_label,
+              note, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        settlement.id,
+        settlement.game_id,
+        settlement.team_id,
+        settlement.total_amount,
+        settlement.payment_link,
+        settlement.payment_label,
+        settlement.note,
+        settlement.status,
+        settlement.created_at,
+        settlement.updated_at,
+      ],
+    });
+    return settlement;
+  }
+
+  async getByGame(gameId: string): Promise<Settlement | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM settlements WHERE game_id = ?",
+      args: [gameId],
+    });
+    return r.rows[0] ? rowToSettlement(r.rows[0]) : null;
+  }
+
+  async updateStatus(
+    id: string,
+    status: SettlementStatus,
+    updatedAt: string,
+  ): Promise<void> {
+    await this.db.execute({
+      sql: "UPDATE settlements SET status = ?, updated_at = ? WHERE id = ?",
+      args: [status, updatedAt, id],
+    });
+  }
+
+  async insertShare(share: SettlementShare): Promise<SettlementShare> {
+    await this.db.execute({
+      sql: `INSERT INTO settlement_shares (
+              id, settlement_id, member_id, amount, paid, paid_at,
+              created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        share.id,
+        share.settlement_id,
+        share.member_id,
+        share.amount,
+        share.paid ? 1 : 0,
+        share.paid_at,
+        share.created_at,
+        share.updated_at,
+      ],
+    });
+    return share;
+  }
+
+  async listShares(settlementId: string): Promise<SettlementShare[]> {
+    const r = await this.db.execute({
+      sql: `SELECT * FROM settlement_shares WHERE settlement_id = ?
+            ORDER BY created_at ASC`,
+      args: [settlementId],
+    });
+    return r.rows.map(rowToSettlementShare);
+  }
+
+  async getShare(
+    settlementId: string,
+    memberId: string,
+  ): Promise<SettlementShare | null> {
+    const r = await this.db.execute({
+      sql: "SELECT * FROM settlement_shares WHERE settlement_id = ? AND member_id = ?",
+      args: [settlementId, memberId],
+    });
+    return r.rows[0] ? rowToSettlementShare(r.rows[0]) : null;
+  }
+
+  async updateSharePaid(
+    id: string,
+    paid: boolean,
+    paidAt: string | null,
+    updatedAt: string,
+  ): Promise<void> {
+    await this.db.execute({
+      sql: "UPDATE settlement_shares SET paid = ?, paid_at = ?, updated_at = ? WHERE id = ?",
+      args: [paid ? 1 : 0, paidAt, updatedAt, id],
+    });
+  }
+}
+
 export function buildRepositories(db: DbClient): Repositories {
   return {
     teams: new LibsqlTeamRepository(db),
@@ -684,5 +787,6 @@ export function buildRepositories(db: DbClient): Repositories {
     groundWatches: new LibsqlGroundWatchRepository(db),
     observations: new LibsqlObservationRepository(db),
     knowledge: new LibsqlTeamKnowledgeRepository(db),
+    settlements: new LibsqlSettlementRepository(db),
   };
 }

--- a/packages/cli/src/adapters/libsql/row-mappers.ts
+++ b/packages/cli/src/adapters/libsql/row-mappers.ts
@@ -1,8 +1,11 @@
 import type { InValue, Row } from "@libsql/client";
 import {
   assertGameStatus,
+  assertKnowledgeCategory,
+  assertKnowledgeOrigin,
   assertMemberRole,
   assertNotificationKind,
+  assertObservationKind,
   assertRsvpResponse,
 } from "../../domain/guards";
 import type {
@@ -13,8 +16,10 @@ import type {
   Member,
   MemberRsvp,
   NotificationChannel,
+  Observation,
   Rsvp,
   Team,
+  TeamKnowledge,
 } from "../../domain/types";
 
 export const str = (v: InValue): string => String(v);
@@ -119,6 +124,38 @@ export function rowToGroundWatch(row: Row): GroundWatch {
     time_from: nullable(row.time_from),
     time_to: nullable(row.time_to),
     enabled: Number(row.enabled) !== 0,
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToObservation(row: Row): Observation {
+  return {
+    id: str(row.id),
+    team_id: str(row.team_id),
+    member_id: nullable(row.member_id),
+    kind: assertObservationKind(str(row.kind)),
+    subject: nullable(row.subject),
+    body: str(row.body),
+    source: nullable(row.source),
+    observed_at: str(row.observed_at),
+    created_at: str(row.created_at),
+  };
+}
+
+export function rowToTeamKnowledge(row: Row): TeamKnowledge {
+  return {
+    id: str(row.id),
+    team_id: str(row.team_id),
+    member_id: nullable(row.member_id),
+    category: assertKnowledgeCategory(str(row.category)),
+    key: str(row.key),
+    value: str(row.value),
+    origin: assertKnowledgeOrigin(str(row.origin)),
+    confidence: Number(row.confidence),
+    evidence_count: Number(row.evidence_count),
+    source: nullable(row.source),
+    last_observed_at: nullable(row.last_observed_at),
     created_at: str(row.created_at),
     updated_at: str(row.updated_at),
   };

--- a/packages/cli/src/adapters/libsql/row-mappers.ts
+++ b/packages/cli/src/adapters/libsql/row-mappers.ts
@@ -7,6 +7,7 @@ import {
   assertNotificationKind,
   assertObservationKind,
   assertRsvpResponse,
+  assertSettlementStatus,
 } from "../../domain/guards";
 import type {
   AuditLog,
@@ -18,6 +19,8 @@ import type {
   NotificationChannel,
   Observation,
   Rsvp,
+  Settlement,
+  SettlementShare,
   Team,
   TeamKnowledge,
 } from "../../domain/types";
@@ -156,6 +159,34 @@ export function rowToTeamKnowledge(row: Row): TeamKnowledge {
     evidence_count: Number(row.evidence_count),
     source: nullable(row.source),
     last_observed_at: nullable(row.last_observed_at),
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToSettlement(row: Row): Settlement {
+  return {
+    id: str(row.id),
+    game_id: str(row.game_id),
+    team_id: str(row.team_id),
+    total_amount: Number(row.total_amount),
+    payment_link: nullable(row.payment_link),
+    payment_label: nullable(row.payment_label),
+    note: nullable(row.note),
+    status: assertSettlementStatus(str(row.status)),
+    created_at: str(row.created_at),
+    updated_at: str(row.updated_at),
+  };
+}
+
+export function rowToSettlementShare(row: Row): SettlementShare {
+  return {
+    id: str(row.id),
+    settlement_id: str(row.settlement_id),
+    member_id: str(row.member_id),
+    amount: Number(row.amount),
+    paid: Number(row.paid) !== 0,
+    paid_at: nullable(row.paid_at),
     created_at: str(row.created_at),
     updated_at: str(row.updated_at),
   };

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 5;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS teams (
@@ -114,4 +114,38 @@ CREATE TABLE IF NOT EXISTS ground_watches (
   updated_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_ground_watches_team ON ground_watches(team_id);
+
+-- 🥉 Bronze: チームの記憶。エージェントが会話で得た「生の観測」。追記専用・不変。
+CREATE TABLE IF NOT EXISTS observations (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  member_id TEXT REFERENCES members(id) ON DELETE SET NULL,
+  kind TEXT NOT NULL,
+  subject TEXT,
+  body TEXT NOT NULL,
+  source TEXT,
+  observed_at TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_observations_team ON observations(team_id);
+
+-- 🥇 Gold: 確信度付きの「チームの決め事」。(team_id, member_id, key) で一意。
+-- origin=HUMAN は LEARNED に上書きされない。evidence_count は裏付けの累積回数。
+CREATE TABLE IF NOT EXISTS team_knowledge (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  member_id TEXT REFERENCES members(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  origin TEXT NOT NULL CHECK (origin IN ('HUMAN', 'LEARNED')),
+  confidence REAL NOT NULL,
+  evidence_count INTEGER NOT NULL DEFAULT 1,
+  source TEXT,
+  last_observed_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(team_id, member_id, key)
+);
+CREATE INDEX IF NOT EXISTS idx_team_knowledge_team ON team_knowledge(team_id);
 `;

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 5;
+export const SCHEMA_VERSION = 6;
 
 export const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS teams (
@@ -148,4 +148,33 @@ CREATE TABLE IF NOT EXISTS team_knowledge (
   UNIQUE(team_id, member_id, key)
 );
 CREATE INDEX IF NOT EXISTS idx_team_knowledge_team ON team_knowledge(team_id);
+
+-- 精算 (PayPay 割り勘)。試合 1 件につき 1 件。
+CREATE TABLE IF NOT EXISTS settlements (
+  id TEXT PRIMARY KEY,
+  game_id TEXT NOT NULL UNIQUE REFERENCES games(id) ON DELETE CASCADE,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  total_amount INTEGER NOT NULL,
+  payment_link TEXT,
+  payment_label TEXT,
+  note TEXT,
+  status TEXT NOT NULL CHECK (status IN ('OPEN', 'SETTLED')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_settlements_team ON settlements(team_id);
+
+-- 割り勘の参加者ごとの負担額と支払状況。
+CREATE TABLE IF NOT EXISTS settlement_shares (
+  id TEXT PRIMARY KEY,
+  settlement_id TEXT NOT NULL REFERENCES settlements(id) ON DELETE CASCADE,
+  member_id TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  amount INTEGER NOT NULL,
+  paid INTEGER NOT NULL DEFAULT 0,
+  paid_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(settlement_id, member_id)
+);
+CREATE INDEX IF NOT EXISTS idx_settlement_shares_settlement ON settlement_shares(settlement_id);
 `;

--- a/packages/cli/src/domain/guards.ts
+++ b/packages/cli/src/domain/guards.ts
@@ -13,6 +13,8 @@ import {
   type ObservationKind,
   RSVP_RESPONSES,
   type RsvpResponse,
+  SETTLEMENT_STATUSES,
+  type SettlementStatus,
 } from "./types";
 
 export function isGameStatus(value: unknown): value is GameStatus {
@@ -120,6 +122,20 @@ export function isKnowledgeOrigin(value: unknown): value is KnowledgeOrigin {
 export function assertKnowledgeOrigin(value: unknown): KnowledgeOrigin {
   if (!isKnowledgeOrigin(value)) {
     throw new DomainInvariantError(`不正な KnowledgeOrigin: ${String(value)}`);
+  }
+  return value;
+}
+
+export function isSettlementStatus(value: unknown): value is SettlementStatus {
+  return (
+    typeof value === "string" &&
+    (SETTLEMENT_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+export function assertSettlementStatus(value: unknown): SettlementStatus {
+  if (!isSettlementStatus(value)) {
+    throw new DomainInvariantError(`不正な SettlementStatus: ${String(value)}`);
   }
   return value;
 }

--- a/packages/cli/src/domain/guards.ts
+++ b/packages/cli/src/domain/guards.ts
@@ -1,10 +1,16 @@
 import {
   GAME_STATUSES,
   type GameStatus,
+  KNOWLEDGE_CATEGORIES,
+  KNOWLEDGE_ORIGINS,
+  type KnowledgeCategory,
+  type KnowledgeOrigin,
   MEMBER_ROLES,
   type MemberRole,
   NOTIFICATION_KINDS,
   type NotificationKind,
+  OBSERVATION_KINDS,
+  type ObservationKind,
   RSVP_RESPONSES,
   type RsvpResponse,
 } from "./types";
@@ -68,6 +74,52 @@ export function isNotificationKind(value: unknown): value is NotificationKind {
 export function assertNotificationKind(value: unknown): NotificationKind {
   if (!isNotificationKind(value)) {
     throw new DomainInvariantError(`不正な NotificationKind: ${String(value)}`);
+  }
+  return value;
+}
+
+export function isObservationKind(value: unknown): value is ObservationKind {
+  return (
+    typeof value === "string" &&
+    (OBSERVATION_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function assertObservationKind(value: unknown): ObservationKind {
+  if (!isObservationKind(value)) {
+    throw new DomainInvariantError(`不正な ObservationKind: ${String(value)}`);
+  }
+  return value;
+}
+
+export function isKnowledgeCategory(
+  value: unknown,
+): value is KnowledgeCategory {
+  return (
+    typeof value === "string" &&
+    (KNOWLEDGE_CATEGORIES as readonly string[]).includes(value)
+  );
+}
+
+export function assertKnowledgeCategory(value: unknown): KnowledgeCategory {
+  if (!isKnowledgeCategory(value)) {
+    throw new DomainInvariantError(
+      `不正な KnowledgeCategory: ${String(value)}`,
+    );
+  }
+  return value;
+}
+
+export function isKnowledgeOrigin(value: unknown): value is KnowledgeOrigin {
+  return (
+    typeof value === "string" &&
+    (KNOWLEDGE_ORIGINS as readonly string[]).includes(value)
+  );
+}
+
+export function assertKnowledgeOrigin(value: unknown): KnowledgeOrigin {
+  if (!isKnowledgeOrigin(value)) {
+    throw new DomainInvariantError(`不正な KnowledgeOrigin: ${String(value)}`);
   }
   return value;
 }

--- a/packages/cli/src/domain/types.ts
+++ b/packages/cli/src/domain/types.ts
@@ -144,6 +144,67 @@ export interface GroundWatch {
   updated_at: string;
 }
 
+// === チーム記憶レイヤ (Medallion: Bronze→Silver→Gold) ===
+// mound は「チームの記憶」。決め事を mound (libSQL/SQLite) に貯めることで、
+// 駆動するエージェント (Hermes / Codex / Claude) を差し替えても同じ文脈から動ける。
+
+// 🥉 Bronze: エージェントが会話などで得た「生の観測」。追記専用・不変。
+// 構造を決めずにまず書き留める層 (例: 「土曜の朝が動きやすい」「鈴木は隔週」)。
+export const OBSERVATION_KINDS = [
+  "PREFERENCE_HINT", // 既定値のヒント (動きやすい曜日・時間帯など)
+  "ROSTER_FACT", // メンバーに関する事実 (背番号/ポジション/常連か等)
+  "VENUE", // 会場に関する知見
+  "RULE", // 規約・会費・連絡網など
+  "OPPONENT", // 対戦相手に関する知見
+  "NOTE", // その他の自由メモ
+] as const;
+export type ObservationKind = (typeof OBSERVATION_KINDS)[number];
+
+export interface Observation {
+  id: string;
+  team_id: string;
+  member_id: string | null; // メンバー固有の観測なら紐づける
+  kind: ObservationKind;
+  subject: string | null; // 任意の見出し
+  body: string; // 観測の中身
+  source: string | null; // 出所 ("会話 2026-06-03" 等)
+  observed_at: string;
+  created_at: string;
+}
+
+// 🥇 Gold: 確信度付きの「チームの決め事」。供給用 (autopilot / 任意のエージェントが
+// 読んで行動する層)。(team_id, member_id, key) で一意 = upsert する。
+export const KNOWLEDGE_CATEGORIES = [
+  "PREFERENCE", // 既定値 (default_ground / default_weekday / fee_per_person 等)
+  "RULE", // 規約・会費ルール・ドタキャン規定
+  "ROSTER", // メンバー固有の知識
+  "VENUE", // 会場の知見
+  "OPPONENT", // 対戦相手の知見
+  "NOTE", // その他
+] as const;
+export type KnowledgeCategory = (typeof KNOWLEDGE_CATEGORIES)[number];
+
+// 決め事の出所。HUMAN = 人/エージェントが明示設定 (権威があり、学習値に上書きされない)。
+// LEARNED = 実績から学習したもの。
+export const KNOWLEDGE_ORIGINS = ["HUMAN", "LEARNED"] as const;
+export type KnowledgeOrigin = (typeof KNOWLEDGE_ORIGINS)[number];
+
+export interface TeamKnowledge {
+  id: string;
+  team_id: string;
+  member_id: string | null;
+  category: KnowledgeCategory;
+  key: string; // default_ground / fee_per_person / position 等
+  value: string;
+  origin: KnowledgeOrigin;
+  confidence: number; // 0.0–1.0
+  evidence_count: number; // 観測/裏付けの累積回数 (使うほど厚くなる)
+  source: string | null;
+  last_observed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // 外部スクレイパ (ground-reservation 等) から ingest した 1 件の空き枠。
 // slot_key = source|facility_name|date_iso|time_range (UNIQUE)
 //   ingest 時にこのキーで upsert する。

--- a/packages/cli/src/domain/types.ts
+++ b/packages/cli/src/domain/types.ts
@@ -115,6 +115,37 @@ export interface NotificationChannel {
   updated_at: string;
 }
 
+// === 精算 (PayPay 割り勘) ===
+// 試合 1 件につき精算 1 件。参加者で会場費等を割り勘し、PayPay リンクを貼って
+// 催促・消し込みする。全員払ったら status=SETTLED になり、game も SETTLED へ進む。
+// (PayPay 個人割り勘に公開 API は無いため、リンクは人が貼り入金は人が消し込む)
+export const SETTLEMENT_STATUSES = ["OPEN", "SETTLED"] as const;
+export type SettlementStatus = (typeof SETTLEMENT_STATUSES)[number];
+
+export interface Settlement {
+  id: string;
+  game_id: string;
+  team_id: string;
+  total_amount: number; // 合計 (円)
+  payment_link: string | null; // PayPay 割り勘 / 受け取りリンク
+  payment_label: string | null; // 例: "PayPay: 田中宛"
+  note: string | null;
+  status: SettlementStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SettlementShare {
+  id: string;
+  settlement_id: string;
+  member_id: string;
+  amount: number; // この人の負担 (円)。割り勘の端数も含め合計は total に一致
+  paid: boolean;
+  paid_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // 曜日コード (ISO weekday の小文字 3 文字)。watch.weekdays は CSV で持つ。
 export const WEEKDAY_CODES = [
   "sun",

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -15,6 +15,9 @@ import type {
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
+  Settlement,
+  SettlementShare,
+  SettlementStatus,
   Team,
   TeamKnowledge,
 } from "./domain/types";
@@ -114,6 +117,29 @@ export interface TeamKnowledgeRepository {
   remove(id: string): Promise<boolean>;
 }
 
+// 精算 (PayPay 割り勘)。試合 1 件につき settlement 1 件 + 参加者ごとの share。
+export interface SettlementRepository {
+  insert(settlement: Settlement): Promise<Settlement>;
+  getByGame(gameId: string): Promise<Settlement | null>;
+  updateStatus(
+    id: string,
+    status: SettlementStatus,
+    updatedAt: string,
+  ): Promise<void>;
+  insertShare(share: SettlementShare): Promise<SettlementShare>;
+  listShares(settlementId: string): Promise<SettlementShare[]>;
+  getShare(
+    settlementId: string,
+    memberId: string,
+  ): Promise<SettlementShare | null>;
+  updateSharePaid(
+    id: string,
+    paid: boolean,
+    paidAt: string | null,
+    updatedAt: string,
+  ): Promise<void>;
+}
+
 export interface NotificationChannelRepository {
   insert(channel: NotificationChannel): Promise<NotificationChannel>;
   list(teamId: string): Promise<NotificationChannel[]>;
@@ -150,6 +176,7 @@ export interface Repositories {
   groundWatches: GroundWatchRepository;
   observations: ObservationRepository;
   knowledge: TeamKnowledgeRepository;
+  settlements: SettlementRepository;
 }
 
 export interface Clock {

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -6,13 +6,17 @@ import type {
   GameStatus,
   GroundSlot,
   GroundWatch,
+  KnowledgeCategory,
   Member,
   MemberRsvp,
   NotificationChannel,
+  Observation,
+  ObservationKind,
   Rsvp,
   RsvpBreakdown,
   RsvpSummary,
   Team,
+  TeamKnowledge,
 } from "./domain/types";
 
 export interface TeamRepository {
@@ -77,6 +81,39 @@ export interface GroundWatchRepository {
   remove(id: string): Promise<boolean>;
 }
 
+// 🥉 Bronze: 生の観測。追記専用。
+export interface ObservationFilter {
+  teamId: string;
+  kind?: ObservationKind;
+  memberId?: string;
+}
+
+export interface ObservationRepository {
+  insert(observation: Observation): Promise<Observation>;
+  list(filter: ObservationFilter): Promise<Observation[]>;
+}
+
+// 🥇 Gold: 確信度付きの決め事。(teamId, memberId, key) で一意。
+// upsert は usecase 側で getByKey → insert/update を出し分ける (マージ規則のため)。
+export interface KnowledgeFilter {
+  teamId: string;
+  category?: KnowledgeCategory;
+  memberId?: string;
+  key?: string;
+}
+
+export interface TeamKnowledgeRepository {
+  insert(entry: TeamKnowledge): Promise<TeamKnowledge>;
+  update(entry: TeamKnowledge): Promise<TeamKnowledge>;
+  getByKey(
+    teamId: string,
+    memberId: string | null,
+    key: string,
+  ): Promise<TeamKnowledge | null>;
+  list(filter: KnowledgeFilter): Promise<TeamKnowledge[]>;
+  remove(id: string): Promise<boolean>;
+}
+
 export interface NotificationChannelRepository {
   insert(channel: NotificationChannel): Promise<NotificationChannel>;
   list(teamId: string): Promise<NotificationChannel[]>;
@@ -111,6 +148,8 @@ export interface Repositories {
   groundSlots: GroundSlotRepository;
   notifications: NotificationChannelRepository;
   groundWatches: GroundWatchRepository;
+  observations: ObservationRepository;
+  knowledge: TeamKnowledgeRepository;
 }
 
 export interface Clock {

--- a/packages/cli/src/usecases/autopilot.ts
+++ b/packages/cli/src/usecases/autopilot.ts
@@ -10,6 +10,7 @@ import { computeAgenda } from "./agenda";
 import { TeamNotFoundError } from "./errors";
 import { transitionGame } from "./game";
 import { notifyTeam } from "./notification";
+import { formatSettlementMessage, getSettlement } from "./settlement";
 
 export type AutoActionKind =
   | "PUBLISH" // DRAFT → COLLECTING (出欠回収を開始)
@@ -116,14 +117,21 @@ export async function planAutopilot(
   }
 
   for (const game of agenda.needs_settlement) {
+    // 精算が作成済みなら PayPay リンク + 未払い者入りの催促を、未作成なら作成を促す。
+    const view = await getSettlement(ctx, game.id);
+    const message = view
+      ? formatSettlementMessage(game.title, view)
+      : `💰 「${game.title}」の精算がまだです。mound settle open で PayPay 割り勘を作成してください。`;
     actions.push({
       kind: "REMIND_SETTLEMENT",
       risk: "SAFE",
       game_id: game.id,
       game_title: game.title,
-      reason: "完了済だが精算が未了",
+      reason: view
+        ? `未払い ${view.summary.unpaid_count}人 / 未回収 ¥${view.summary.outstanding}`
+        : "完了済だが精算が未作成",
       transition_to: null,
-      message: `💰 「${game.title}」の精算がまだ済んでいません。集金・精算をお願いします。`,
+      message,
     });
   }
 

--- a/packages/cli/src/usecases/autopilot.ts
+++ b/packages/cli/src/usecases/autopilot.ts
@@ -1,0 +1,176 @@
+// autopilot: 現在状態 (agenda) + チームの決め事 (Gold) から「いま打つべき手」を
+// 算出し、安全な手は自動実行・チームを拘束する手は提案に留める。
+//
+// 原則「AI は提案する。人が最後に決める」に従い:
+//   - SAFE          … --apply で自動実行 (公開 / 完了マーク / リマインド送信)
+//   - NEEDS_APPROVAL … 常に提案のみ (確定 / 中止 など、チームを拘束する手)
+import type { GameStatus } from "../domain/types";
+import type { NotificationDeliveryResult, UseCaseContext } from "../ports";
+import { computeAgenda } from "./agenda";
+import { TeamNotFoundError } from "./errors";
+import { transitionGame } from "./game";
+import { notifyTeam } from "./notification";
+
+export type AutoActionKind =
+  | "PUBLISH" // DRAFT → COLLECTING (出欠回収を開始)
+  | "CONFIRM" // COLLECTING → CONFIRMED (人数充足、要承認)
+  | "COMPLETE" // CONFIRMED → COMPLETED (試合日が経過)
+  | "REMIND_COLLECTING" // 出欠が足りない試合のリマインド
+  | "REMIND_SETTLEMENT"; // 精算待ちのリマインド
+
+export type AutoRisk = "SAFE" | "NEEDS_APPROVAL";
+
+export interface AutoAction {
+  kind: AutoActionKind;
+  risk: AutoRisk;
+  game_id: string;
+  game_title: string;
+  reason: string;
+  transition_to: GameStatus | null; // 遷移系アクションのみ
+  message: string | null; // リマインド系アクションのみ
+}
+
+export interface AutoPlan {
+  team_id: string;
+  generated_at: string;
+  horizon_days: number;
+  actions: AutoAction[];
+}
+
+export interface ExecutedAction {
+  action: AutoAction;
+  ok: boolean;
+  error: string | null;
+  deliveries?: NotificationDeliveryResult[];
+}
+
+export interface AutoRunResult extends AutoPlan {
+  applied: boolean;
+  executed: ExecutedAction[];
+  proposed: AutoAction[]; // 自動実行しなかった (NEEDS_APPROVAL / dry-run) 手
+}
+
+export interface AutoInput {
+  teamId: string;
+  horizonDays: number;
+}
+
+export async function planAutopilot(
+  ctx: UseCaseContext,
+  input: AutoInput,
+): Promise<AutoPlan> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const agenda = await computeAgenda(ctx, {
+    teamId: team.id,
+    horizonDays: input.horizonDays,
+  });
+  const actions: AutoAction[] = [];
+
+  for (const game of agenda.needs_publish) {
+    actions.push({
+      kind: "PUBLISH",
+      risk: "SAFE",
+      game_id: game.id,
+      game_title: game.title,
+      reason: "DRAFT のまま。公開して出欠回収を始める",
+      transition_to: "COLLECTING",
+      message: null,
+    });
+  }
+
+  for (const c of agenda.collecting) {
+    if (c.ready_to_confirm) {
+      actions.push({
+        kind: "CONFIRM",
+        risk: "NEEDS_APPROVAL",
+        game_id: c.game.id,
+        game_title: c.game.title,
+        reason: `参加可 ${c.rsvp.available} 人で最低人数を満たした。確定の最終判断は人間`,
+        transition_to: "CONFIRMED",
+        message: null,
+      });
+    } else {
+      actions.push({
+        kind: "REMIND_COLLECTING",
+        risk: "SAFE",
+        game_id: c.game.id,
+        game_title: c.game.title,
+        reason: `あと ${c.shortage} 人足りない`,
+        transition_to: null,
+        message: `⚾ 「${c.game.title}」の出欠回収中です。あと ${c.shortage} 人で成立します。出られる方は回答をお願いします！`,
+      });
+    }
+  }
+
+  for (const game of agenda.needs_completion) {
+    actions.push({
+      kind: "COMPLETE",
+      risk: "SAFE",
+      game_id: game.id,
+      game_title: game.title,
+      reason: "試合日が過ぎた。完了として記録する",
+      transition_to: "COMPLETED",
+      message: null,
+    });
+  }
+
+  for (const game of agenda.needs_settlement) {
+    actions.push({
+      kind: "REMIND_SETTLEMENT",
+      risk: "SAFE",
+      game_id: game.id,
+      game_title: game.title,
+      reason: "完了済だが精算が未了",
+      transition_to: null,
+      message: `💰 「${game.title}」の精算がまだ済んでいません。集金・精算をお願いします。`,
+    });
+  }
+
+  return {
+    team_id: team.id,
+    generated_at: ctx.now().toISOString(),
+    horizon_days: input.horizonDays,
+    actions,
+  };
+}
+
+export interface AutoRunInput extends AutoInput {
+  apply: boolean;
+}
+
+export async function runAutopilot(
+  ctx: UseCaseContext,
+  input: AutoRunInput,
+): Promise<AutoRunResult> {
+  const plan = await planAutopilot(ctx, input);
+  const executed: ExecutedAction[] = [];
+  const proposed: AutoAction[] = [];
+
+  for (const action of plan.actions) {
+    // SAFE な手だけ、--apply のときに自動実行する。
+    if (!input.apply || action.risk !== "SAFE") {
+      proposed.push(action);
+      continue;
+    }
+    try {
+      if (action.transition_to) {
+        await transitionGame(ctx, action.game_id, action.transition_to);
+        executed.push({ action, ok: true, error: null });
+      } else if (action.message) {
+        const deliveries = await notifyTeam(ctx, plan.team_id, action.message);
+        executed.push({ action, ok: true, error: null, deliveries });
+      } else {
+        executed.push({ action, ok: true, error: null });
+      }
+    } catch (e) {
+      executed.push({
+        action,
+        ok: false,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return { ...plan, applied: input.apply, executed, proposed };
+}

--- a/packages/cli/src/usecases/errors.ts
+++ b/packages/cli/src/usecases/errors.ts
@@ -35,6 +35,14 @@ export class CrossTeamRsvpError extends Error {
   }
 }
 
+// 精算ドメインの拒否 (参加者ゼロ / 精算未作成 / 二重作成 等)。CLI では exit 2。
+export class SettlementError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SettlementError";
+  }
+}
+
 export interface TransitionDeniedDetails {
   from: GameStatus;
   to: GameStatus;

--- a/packages/cli/src/usecases/knowledge.ts
+++ b/packages/cli/src/usecases/knowledge.ts
@@ -122,6 +122,81 @@ export async function forgetKnowledge(
   return ctx.repo.knowledge.remove(id);
 }
 
+export interface LearnedFactInput {
+  teamId: string;
+  memberId: string | null;
+  category: KnowledgeCategory;
+  key: string;
+  value: string;
+  confidence: number;
+  evidenceCount: number;
+  source: string | null;
+}
+
+// 学習 (mound learn) から Gold を書く専用口。recordKnowledge の「観測ごとに加算」
+// とは異なり、その時点の履歴から再導出した値で LEARNED 行を上書きする (= 降格も効く)。
+// origin=HUMAN の決め事は触らない (ピン留め)。pinned=true で「人の決め事を尊重して
+// スキップした」ことを呼び出し側に伝える。
+export async function upsertLearnedFact(
+  ctx: UseCaseContext,
+  input: LearnedFactInput,
+): Promise<{ entry: TeamKnowledge; pinned: boolean }> {
+  const now = ctx.now().toISOString();
+  const existing = await ctx.repo.knowledge.getByKey(
+    input.teamId,
+    input.memberId,
+    input.key,
+  );
+  if (existing && existing.origin === "HUMAN") {
+    return { entry: existing, pinned: true };
+  }
+  if (!existing) {
+    const entry: TeamKnowledge = {
+      id: ctx.newId(),
+      team_id: input.teamId,
+      member_id: input.memberId,
+      category: input.category,
+      key: input.key,
+      value: input.value,
+      origin: "LEARNED",
+      confidence: input.confidence,
+      evidence_count: input.evidenceCount,
+      source: input.source,
+      last_observed_at: now,
+      created_at: now,
+      updated_at: now,
+    };
+    await ctx.repo.knowledge.insert(entry);
+    await writeAuditLog(ctx, {
+      action: "KNOWLEDGE_LEARNED",
+      targetType: "team_knowledge",
+      targetId: entry.id,
+      after: entry,
+    });
+    return { entry, pinned: false };
+  }
+  const updated: TeamKnowledge = {
+    ...existing,
+    category: input.category,
+    value: input.value,
+    origin: "LEARNED",
+    confidence: input.confidence,
+    evidence_count: input.evidenceCount,
+    source: input.source,
+    last_observed_at: now,
+    updated_at: now,
+  };
+  await ctx.repo.knowledge.update(updated);
+  await writeAuditLog(ctx, {
+    action: "KNOWLEDGE_LEARNED",
+    targetType: "team_knowledge",
+    targetId: updated.id,
+    before: existing,
+    after: updated,
+  });
+  return { entry: updated, pinned: false };
+}
+
 export interface TeamPreference {
   key: string;
   value: string;

--- a/packages/cli/src/usecases/knowledge.ts
+++ b/packages/cli/src/usecases/knowledge.ts
@@ -1,0 +1,149 @@
+// 🥇 Gold 層: 確信度付きの「チームの決め事」。autopilot や任意のエージェントが
+// 読んで行動するための供給層。(team, member, key) で一意 = upsert する。
+//
+// 「使うほど賢くなる」substrate (参照: 採用実績で昇格/降格する評価機構):
+//   - HUMAN (人/エージェントが明示) は LEARNED (実績から学習) に上書きされない = ピン留め
+//   - LEARNED 同士は confidence が高い方が値を握る
+//   - 観測のたび evidence_count を加算 = 裏付けが厚くなる
+import type {
+  KnowledgeCategory,
+  KnowledgeOrigin,
+  TeamKnowledge,
+} from "../domain/types";
+import type { KnowledgeFilter, UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+import { MemberNotFoundError, TeamNotFoundError } from "./errors";
+
+export interface RecordKnowledgeInput {
+  teamId: string;
+  key: string;
+  value: string;
+  category: KnowledgeCategory;
+  memberId: string | null;
+  origin: KnowledgeOrigin;
+  confidence: number;
+  source: string | null;
+}
+
+export async function recordKnowledge(
+  ctx: UseCaseContext,
+  input: RecordKnowledgeInput,
+): Promise<TeamKnowledge> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  if (input.memberId) {
+    const member = await ctx.repo.members.get(input.memberId);
+    if (!member || member.team_id !== team.id) {
+      throw new MemberNotFoundError(input.memberId);
+    }
+  }
+  const now = ctx.now().toISOString();
+  const existing = await ctx.repo.knowledge.getByKey(
+    team.id,
+    input.memberId,
+    input.key,
+  );
+
+  if (!existing) {
+    const entry: TeamKnowledge = {
+      id: ctx.newId(),
+      team_id: team.id,
+      member_id: input.memberId,
+      category: input.category,
+      key: input.key,
+      value: input.value,
+      origin: input.origin,
+      confidence: input.confidence,
+      evidence_count: 1,
+      source: input.source,
+      last_observed_at: now,
+      created_at: now,
+      updated_at: now,
+    };
+    await ctx.repo.knowledge.insert(entry);
+    await writeAuditLog(ctx, {
+      action: "KNOWLEDGE_SET",
+      targetType: "team_knowledge",
+      targetId: entry.id,
+      after: entry,
+    });
+    return entry;
+  }
+
+  // マージ規則: 値の勝者を決める。
+  //   - 入力が HUMAN なら必ず勝つ
+  //   - 既存が HUMAN なら据え置き (LEARNED で上書きしない)
+  //   - 双方 LEARNED なら confidence が高い方 (同点は入力)
+  const incomingWins =
+    input.origin === "HUMAN" ||
+    (existing.origin !== "HUMAN" && input.confidence >= existing.confidence);
+  const updated: TeamKnowledge = {
+    ...existing,
+    category: incomingWins ? input.category : existing.category,
+    value: incomingWins ? input.value : existing.value,
+    origin: incomingWins ? input.origin : existing.origin,
+    confidence: incomingWins ? input.confidence : existing.confidence,
+    source: incomingWins ? input.source : existing.source,
+    evidence_count: existing.evidence_count + 1,
+    last_observed_at: now,
+    updated_at: now,
+  };
+  await ctx.repo.knowledge.update(updated);
+  await writeAuditLog(ctx, {
+    action: "KNOWLEDGE_UPDATED",
+    targetType: "team_knowledge",
+    targetId: updated.id,
+    before: existing,
+    after: updated,
+  });
+  return updated;
+}
+
+export async function listKnowledge(
+  ctx: UseCaseContext,
+  filter: KnowledgeFilter,
+): Promise<TeamKnowledge[]> {
+  return ctx.repo.knowledge.list(filter);
+}
+
+export async function getKnowledge(
+  ctx: UseCaseContext,
+  teamId: string,
+  key: string,
+  memberId: string | null = null,
+): Promise<TeamKnowledge | null> {
+  return ctx.repo.knowledge.getByKey(teamId, memberId, key);
+}
+
+export async function forgetKnowledge(
+  ctx: UseCaseContext,
+  id: string,
+): Promise<boolean> {
+  return ctx.repo.knowledge.remove(id);
+}
+
+export interface TeamPreference {
+  key: string;
+  value: string;
+  confidence: number;
+  origin: KnowledgeOrigin;
+}
+
+// autopilot 用: チーム既定値 (category=PREFERENCE, メンバー非依存) を materialize する。
+export async function getTeamPreferences(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<TeamPreference[]> {
+  const entries = await ctx.repo.knowledge.list({
+    teamId,
+    category: "PREFERENCE",
+  });
+  return entries
+    .filter((e) => e.member_id === null)
+    .map((e) => ({
+      key: e.key,
+      value: e.value,
+      confidence: e.confidence,
+      origin: e.origin,
+    }));
+}

--- a/packages/cli/src/usecases/learn.ts
+++ b/packages/cli/src/usecases/learn.ts
@@ -1,0 +1,170 @@
+// 🥈 Silver→🥇 Gold: 過去の試合・出欠 (Bronze/ドメイン履歴) からチームの決め事を
+// 再導出して Gold (team_knowledge) に反映する「使うほど賢くなる」エンジン。
+//
+// - 毎回その時点の履歴から再計算するので、傾向が変われば値も入れ替わる (= 降格も効く)。
+// - origin=HUMAN の決め事は触らない (ピン留め)。pinned_skips で報告する。
+// - 既定は dry-run (提案のみ)。--apply で初めて Gold に書く (AI は提案・人が決める)。
+import { type KnowledgeCategory, WEEKDAY_CODES } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { TeamNotFoundError } from "./errors";
+import { upsertLearnedFact } from "./knowledge";
+
+export interface LearnedFact {
+  category: KnowledgeCategory;
+  key: string;
+  value: string;
+  confidence: number;
+  evidence_count: number;
+  member_id: string | null;
+  member_name: string | null;
+  rationale: string;
+}
+
+export interface LearnResult {
+  team_id: string;
+  generated_at: string;
+  applied: boolean;
+  facts: LearnedFact[];
+  pinned_skips: string[]; // 人の決め事を尊重してスキップした key
+}
+
+// 「いつもの○○」と呼べるには最低この回数の裏付けが要る。
+const MIN_SAMPLE = 2;
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+function mode(
+  counts: Map<string, number>,
+): { value: string; count: number } | null {
+  let best: { value: string; count: number } | null = null;
+  for (const [value, count] of counts) {
+    if (!best || count > best.count) best = { value, count };
+  }
+  return best;
+}
+
+export async function computeLearnedFacts(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<LearnedFact[]> {
+  const games = await ctx.repo.games.list({ teamId });
+  const members = await ctx.repo.members.list(teamId);
+  const facts: LearnedFact[] = [];
+
+  // default_ground: ground_name の最頻値
+  const groundCounts = new Map<string, number>();
+  let groundTotal = 0;
+  for (const g of games) {
+    if (!g.ground_name) continue;
+    groundCounts.set(g.ground_name, (groundCounts.get(g.ground_name) ?? 0) + 1);
+    groundTotal++;
+  }
+  const groundMode = mode(groundCounts);
+  if (groundMode && groundTotal >= MIN_SAMPLE) {
+    facts.push({
+      category: "PREFERENCE",
+      key: "default_ground",
+      value: groundMode.value,
+      confidence: round2(groundMode.count / groundTotal),
+      evidence_count: groundMode.count,
+      member_id: null,
+      member_name: null,
+      rationale: `会場ありの${groundTotal}試合中${groundMode.count}試合で使用`,
+    });
+  }
+
+  // default_weekday: game_date の曜日の最頻値
+  const weekdayCounts = new Map<string, number>();
+  let weekdayTotal = 0;
+  for (const g of games) {
+    if (!g.game_date) continue;
+    const code =
+      WEEKDAY_CODES[new Date(`${g.game_date}T00:00:00Z`).getUTCDay()];
+    if (!code) continue;
+    weekdayCounts.set(code, (weekdayCounts.get(code) ?? 0) + 1);
+    weekdayTotal++;
+  }
+  const weekdayMode = mode(weekdayCounts);
+  if (weekdayMode && weekdayTotal >= MIN_SAMPLE) {
+    facts.push({
+      category: "PREFERENCE",
+      key: "default_weekday",
+      value: weekdayMode.value,
+      confidence: round2(weekdayMode.count / weekdayTotal),
+      evidence_count: weekdayMode.count,
+      member_id: null,
+      member_name: null,
+      rationale: `日付ありの${weekdayTotal}試合中${weekdayMode.count}試合がこの曜日`,
+    });
+  }
+
+  // メンバーごとの出席率 (回答した試合のうち AVAILABLE の割合)
+  const responded = new Map<string, number>();
+  const available = new Map<string, number>();
+  for (const g of games) {
+    const rows = await ctx.repo.rsvps.listWithMembers(g.id, teamId);
+    for (const row of rows) {
+      if (row.response === "NO_RESPONSE") continue;
+      responded.set(row.member_id, (responded.get(row.member_id) ?? 0) + 1);
+      if (row.response === "AVAILABLE") {
+        available.set(row.member_id, (available.get(row.member_id) ?? 0) + 1);
+      }
+    }
+  }
+  for (const m of members) {
+    const resp = responded.get(m.id) ?? 0;
+    if (resp < MIN_SAMPLE) continue;
+    const avail = available.get(m.id) ?? 0;
+    facts.push({
+      category: "ROSTER",
+      key: "attendance_rate",
+      value: `${round2(avail / resp)} (${avail}/${resp})`,
+      confidence: round2(Math.min(1, resp / 5)), // 5 試合以上の回答で満点
+      evidence_count: resp,
+      member_id: m.id,
+      member_name: m.name,
+      rationale: `回答${resp}試合中${avail}試合で参加可`,
+    });
+  }
+
+  return facts;
+}
+
+export interface LearnTeamInput {
+  teamId: string;
+  apply: boolean;
+}
+
+export async function learnTeam(
+  ctx: UseCaseContext,
+  input: LearnTeamInput,
+): Promise<LearnResult> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const facts = await computeLearnedFacts(ctx, team.id);
+  const pinnedSkips: string[] = [];
+  if (input.apply) {
+    const stamp = ctx.now().toISOString().slice(0, 10);
+    for (const f of facts) {
+      const { pinned } = await upsertLearnedFact(ctx, {
+        teamId: team.id,
+        memberId: f.member_id,
+        category: f.category,
+        key: f.key,
+        value: f.value,
+        confidence: f.confidence,
+        evidenceCount: f.evidence_count,
+        source: `learn:${stamp}`,
+      });
+      if (pinned) {
+        pinnedSkips.push(f.member_id ? `${f.key}@${f.member_id}` : f.key);
+      }
+    }
+  }
+  return {
+    team_id: team.id,
+    generated_at: ctx.now().toISOString(),
+    applied: input.apply,
+    facts,
+    pinned_skips: pinnedSkips,
+  };
+}

--- a/packages/cli/src/usecases/notification.ts
+++ b/packages/cli/src/usecases/notification.ts
@@ -85,6 +85,15 @@ async function dispatch(
   );
 }
 
+// 任意のメッセージをチームの enabled channel 全てに送る公開口 (autopilot 等が使う)。
+export async function notifyTeam(
+  ctx: UseCaseContext,
+  teamId: string,
+  message: string,
+): Promise<NotificationDeliveryResult[]> {
+  return dispatch(ctx, teamId, message);
+}
+
 function formatGameTransitionMessage(
   game: Game,
   from: GameStatus,

--- a/packages/cli/src/usecases/observation.ts
+++ b/packages/cli/src/usecases/observation.ts
@@ -1,0 +1,56 @@
+// 🥉 Bronze 層: エージェントが会話などで得た「生の観測」を追記専用で貯める。
+// 構造を決めずにまず書き留め、後で Silver/Gold へ昇格させる素材にする。
+import type { Observation, ObservationKind } from "../domain/types";
+import type { ObservationFilter, UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+import { MemberNotFoundError, TeamNotFoundError } from "./errors";
+
+export interface RecordObservationInput {
+  teamId: string;
+  kind: ObservationKind;
+  body: string;
+  subject: string | null;
+  memberId: string | null;
+  source: string | null;
+}
+
+export async function recordObservation(
+  ctx: UseCaseContext,
+  input: RecordObservationInput,
+): Promise<Observation> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  if (input.memberId) {
+    const member = await ctx.repo.members.get(input.memberId);
+    if (!member || member.team_id !== team.id) {
+      throw new MemberNotFoundError(input.memberId);
+    }
+  }
+  const now = ctx.now().toISOString();
+  const observation: Observation = {
+    id: ctx.newId(),
+    team_id: team.id,
+    member_id: input.memberId,
+    kind: input.kind,
+    subject: input.subject,
+    body: input.body,
+    source: input.source,
+    observed_at: now,
+    created_at: now,
+  };
+  await ctx.repo.observations.insert(observation);
+  await writeAuditLog(ctx, {
+    action: "OBSERVATION_RECORDED",
+    targetType: "observation",
+    targetId: observation.id,
+    after: observation,
+  });
+  return observation;
+}
+
+export async function listObservations(
+  ctx: UseCaseContext,
+  filter: ObservationFilter,
+): Promise<Observation[]> {
+  return ctx.repo.observations.list(filter);
+}

--- a/packages/cli/src/usecases/settlement.ts
+++ b/packages/cli/src/usecases/settlement.ts
@@ -1,0 +1,235 @@
+// 精算 (PayPay 割り勘)。試合の会場費等を参加者で割り勘し、PayPay リンクを貼って
+// 催促・消し込みする。全員払ったら settlement は SETTLED になり、game (COMPLETED) も
+// SETTLED へ進む。PayPay 個人割り勘に公開 API は無いため、リンクは人が貼り入金は人が
+// 消し込む。mound は「割り勘額の計算・未払いの把握・催促文の生成・精算完了の自動遷移」を担う。
+import type { Settlement, SettlementShare } from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { writeAuditLog } from "./audit";
+import { GameNotFoundError, SettlementError } from "./errors";
+import { transitionGame } from "./game";
+
+// 合計を人数で割り勘する。端数は先頭から 1 円ずつ上乗せして合計を一致させる。
+export function splitEvenly(total: number, n: number): number[] {
+  if (n <= 0) return [];
+  const base = Math.floor(total / n);
+  const remainder = total - base * n;
+  return Array.from({ length: n }, (_, i) => base + (i < remainder ? 1 : 0));
+}
+
+export interface CreateSettlementInput {
+  gameId: string;
+  totalAmount: number;
+  paymentLink: string | null;
+  paymentLabel: string | null;
+  note: string | null;
+  // 参加者を明示する場合。未指定なら RSVP が AVAILABLE のメンバーで割り勘する。
+  participantMemberIds: string[] | null;
+}
+
+export async function createSettlement(
+  ctx: UseCaseContext,
+  input: CreateSettlementInput,
+): Promise<Settlement> {
+  const game = await ctx.repo.games.get(input.gameId);
+  if (!game) throw new GameNotFoundError(input.gameId);
+  if (input.totalAmount <= 0) {
+    throw new SettlementError("合計金額は 1 円以上にしてください");
+  }
+  const existing = await ctx.repo.settlements.getByGame(game.id);
+  if (existing) {
+    throw new SettlementError(`この試合の精算は既に存在します: ${existing.id}`);
+  }
+
+  let memberIds = input.participantMemberIds;
+  if (!memberIds) {
+    const rows = await ctx.repo.rsvps.listWithMembers(game.id, game.team_id);
+    memberIds = rows
+      .filter((r) => r.response === "AVAILABLE")
+      .map((r) => r.member_id);
+  }
+  if (memberIds.length === 0) {
+    throw new SettlementError(
+      "割り勘の参加者がいません (AVAILABLE の出欠が無いか、--member を指定してください)",
+    );
+  }
+
+  const now = ctx.now().toISOString();
+  const settlement: Settlement = {
+    id: ctx.newId(),
+    game_id: game.id,
+    team_id: game.team_id,
+    total_amount: input.totalAmount,
+    payment_link: input.paymentLink,
+    payment_label: input.paymentLabel,
+    note: input.note,
+    status: "OPEN",
+    created_at: now,
+    updated_at: now,
+  };
+  await ctx.repo.settlements.insert(settlement);
+
+  const amounts = splitEvenly(input.totalAmount, memberIds.length);
+  for (let i = 0; i < memberIds.length; i++) {
+    await ctx.repo.settlements.insertShare({
+      id: ctx.newId(),
+      settlement_id: settlement.id,
+      member_id: memberIds[i] as string,
+      amount: amounts[i] as number,
+      paid: false,
+      paid_at: null,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+
+  await writeAuditLog(ctx, {
+    action: "SETTLEMENT_CREATED",
+    targetType: "settlement",
+    targetId: settlement.id,
+    after: settlement,
+  });
+  return settlement;
+}
+
+export interface SettlementShareView extends SettlementShare {
+  member_name: string;
+}
+
+export interface SettlementView {
+  settlement: Settlement;
+  shares: SettlementShareView[];
+  summary: {
+    participants: number;
+    paid_count: number;
+    unpaid_count: number;
+    collected: number;
+    outstanding: number;
+    total: number;
+  };
+}
+
+async function buildView(
+  ctx: UseCaseContext,
+  settlement: Settlement,
+): Promise<SettlementView> {
+  const shares = await ctx.repo.settlements.listShares(settlement.id);
+  const members = await ctx.repo.members.list(settlement.team_id);
+  const nameOf = new Map(members.map((m) => [m.id, m.name]));
+  const views: SettlementShareView[] = shares.map((s) => ({
+    ...s,
+    member_name: nameOf.get(s.member_id) ?? s.member_id,
+  }));
+  const collected = views
+    .filter((s) => s.paid)
+    .reduce((a, s) => a + s.amount, 0);
+  const paidCount = views.filter((s) => s.paid).length;
+  return {
+    settlement,
+    shares: views,
+    summary: {
+      participants: views.length,
+      paid_count: paidCount,
+      unpaid_count: views.length - paidCount,
+      collected,
+      outstanding: settlement.total_amount - collected,
+      total: settlement.total_amount,
+    },
+  };
+}
+
+export async function getSettlement(
+  ctx: UseCaseContext,
+  gameId: string,
+): Promise<SettlementView | null> {
+  const settlement = await ctx.repo.settlements.getByGame(gameId);
+  if (!settlement) return null;
+  return buildView(ctx, settlement);
+}
+
+export interface MarkPaidInput {
+  gameId: string;
+  memberId: string;
+  paid: boolean;
+}
+
+export async function markPaid(
+  ctx: UseCaseContext,
+  input: MarkPaidInput,
+): Promise<SettlementView> {
+  const settlement = await ctx.repo.settlements.getByGame(input.gameId);
+  if (!settlement) {
+    throw new SettlementError(`この試合の精算がありません: ${input.gameId}`);
+  }
+  const share = await ctx.repo.settlements.getShare(
+    settlement.id,
+    input.memberId,
+  );
+  if (!share) {
+    throw new SettlementError(
+      `このメンバーは割り勘対象ではありません: ${input.memberId}`,
+    );
+  }
+  const now = ctx.now().toISOString();
+  await ctx.repo.settlements.updateSharePaid(
+    share.id,
+    input.paid,
+    input.paid ? now : null,
+    now,
+  );
+
+  // 全員払ったら settlement を SETTLED にし、COMPLETED の game も SETTLED へ進める。
+  const shares = await ctx.repo.settlements.listShares(settlement.id);
+  const allPaid = shares.every((s) =>
+    s.id === share.id ? input.paid : s.paid,
+  );
+  const nextStatus = allPaid ? "SETTLED" : "OPEN";
+  if (nextStatus !== settlement.status) {
+    await ctx.repo.settlements.updateStatus(settlement.id, nextStatus, now);
+    await writeAuditLog(ctx, {
+      action: `SETTLEMENT_${nextStatus}`,
+      targetType: "settlement",
+      targetId: settlement.id,
+      after: { ...settlement, status: nextStatus },
+    });
+    if (allPaid) {
+      const game = await ctx.repo.games.get(settlement.game_id);
+      if (game?.status === "COMPLETED") {
+        await transitionGame(ctx, game.id, "SETTLED").catch(() => undefined);
+      }
+    }
+  }
+
+  const updated = await ctx.repo.settlements.getByGame(input.gameId);
+  return buildView(ctx, updated ?? settlement);
+}
+
+// PayPay 割り勘の催促文を組み立てる (notify / autopilot が使う)。
+export function formatSettlementMessage(
+  gameTitle: string,
+  view: SettlementView,
+): string {
+  const { settlement, summary, shares } = view;
+  const perHead =
+    summary.participants > 0
+      ? Math.round(settlement.total_amount / summary.participants)
+      : 0;
+  const lines = [
+    `💰 「${gameTitle}」の精算 (PayPay 割り勘)`,
+    `合計 ¥${settlement.total_amount} / ${summary.participants}人 = 約 ¥${perHead}`,
+  ];
+  if (settlement.payment_link) {
+    const label = settlement.payment_label ?? "PayPay";
+    lines.push(`${label}: ${settlement.payment_link}`);
+  }
+  const unpaid = shares.filter((s) => !s.paid);
+  if (unpaid.length > 0) {
+    lines.push(
+      `未払い ${unpaid.length}人: ${unpaid
+        .map((s) => `${s.member_name} (¥${s.amount})`)
+        .join(", ")}`,
+    );
+  } else {
+    lines.push("全員精算済み 🎉");
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## 概要
草野球マネージャー業務の自動化ループを mound 本体に実装。状態は SQLite (libSQL) に永続化され、駆動エージェント (Hermes/Codex/Claude) を差し替えても同じチーム文脈から動く (agent-portable)。

## 含まれるもの (4スライス)
- 🥉🥇 **記憶層**: `mound observe` (生の観測 / Bronze) + `mound knowledge` (確信度付きの決め事 / Gold)。`origin=HUMAN` はピン留めされ学習で上書きされない。観測のたび `evidence_count` 加算。
- 🥈→🥇 **`mound learn`**: 履歴から `default_ground` / `default_weekday` / メンバー出席率を再導出 (傾向が変われば降格も効く)。
- **autopilot `mound auto`**: agenda から打つべき手を算出。SAFE (公開/完了/リマインド) は `--apply` で自動、CONFIRM (確定) は提案のみ。
- **精算 `mound settle`**: PayPay 割り勘の割り勘計算・未払い把握・催促文生成・全額で自動 SETTLED。

## アーキテクチャ
Clean Architecture (domain←usecases←adapters) を維持。知識データを Medallion (Bronze/Silver/Gold) で層化。`SCHEMA_VERSION` 4→6 の lazy migration。

## テスト
`make check` 緑 (149 tests)。各機能を実バイナリ相当 (source mode) で e2e 確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Team knowledge system: record, retrieve, and forget team decisions with confidence scoring
  * Observation tracking: capture raw team observations with categorization
  * Settlement management: track game expense splits and payments with member-level status
  * Autopilot: plan and execute automatic game actions with risk categorization
  * Learning system: derive team patterns (preferences, attendance rates) from game history

* **Documentation**
  * Expanded team memory guidance in AGENTS.md with persistence targets and learning layers

* **Tests**
  * Comprehensive test coverage added for all new use cases and CLI commands
  * E2E test improvements for date handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->