### PR TITLE
feat(edit): team/member の編集・削除 (改名・本拠地・退団)

### DIFF
--- a/packages/cli/src/__tests__/usecases/editability.test.ts
+++ b/packages/cli/src/__tests__/usecases/editability.test.ts
@@ -1,0 +1,91 @@
+// チーム/メンバーの編集 (改名・本拠地変更・削除) のテスト。
+import { describe, expect, it } from "vitest";
+import type { UseCaseContext } from "../../ports";
+import { removeMember, updateMember } from "../../usecases/member";
+import { updateTeam } from "../../usecases/team";
+import { buildFakeContext } from "./memory-fakes";
+
+async function seedTeam(ctx: UseCaseContext): Promise<void> {
+  await ctx.repo.teams.insert({
+    id: "t",
+    name: "Xeros",
+    home_area: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+async function seedMember(ctx: UseCaseContext): Promise<void> {
+  await ctx.repo.members.insert({
+    id: "m",
+    team_id: "t",
+    name: "冨田進",
+    email: null,
+    role: "MEMBER",
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+describe("updateTeam use case", () => {
+  describe("本拠地を後から設定するとき", () => {
+    it("home_area を更新し監査 TEAM_UPDATED を残す", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      const updated = await updateTeam(ctx, { teamId: "t", homeArea: "横浜" });
+      expect(updated.home_area).toBe("横浜");
+      expect(updated.name).toBe("Xeros"); // 未指定は据え置き
+      expect(stores.audit.some((l) => l.action === "TEAM_UPDATED")).toBe(true);
+    });
+  });
+
+  describe("存在しないチームのとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await expect(
+        updateTeam(ctx, { teamId: "nope", name: "X" }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+});
+
+describe("updateMember use case", () => {
+  describe("本名からニックネームへ改名するとき", () => {
+    it("name を更新する (本名は不要)", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await seedMember(ctx);
+      const updated = await updateMember(ctx, {
+        memberId: "m",
+        name: "トミー",
+      });
+      expect(updated.name).toBe("トミー");
+      expect(updated.role).toBe("MEMBER"); // 未指定は据え置き
+    });
+  });
+
+  describe("存在しないメンバーのとき", () => {
+    it("MemberNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await expect(
+        updateMember(ctx, { memberId: "ghost", name: "X" }),
+      ).rejects.toThrow(/member が存在しません/);
+    });
+  });
+});
+
+describe("removeMember use case", () => {
+  describe("既存メンバーのとき", () => {
+    it("削除して true を返し、2 回目は false", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      await seedMember(ctx);
+      expect(await removeMember(ctx, "m")).toBe(true);
+      expect(stores.members.has("m")).toBe(false);
+      expect(stores.audit.some((l) => l.action === "MEMBER_REMOVED")).toBe(
+        true,
+      );
+      expect(await removeMember(ctx, "m")).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -62,6 +62,10 @@ function buildFake(): Fake {
     },
     list: async () => Array.from(teamStore.values()),
     get: async (id) => teamStore.get(id) ?? null,
+    update: async (t) => {
+      teamStore.set(t.id, t);
+      return t;
+    },
   };
 
   const members: MemberRepository = {
@@ -72,6 +76,11 @@ function buildFake(): Fake {
     list: async (teamId) =>
       Array.from(memberStore.values()).filter((m) => m.team_id === teamId),
     get: async (id) => memberStore.get(id) ?? null,
+    update: async (m) => {
+      memberStore.set(m.id, m);
+      return m;
+    },
+    remove: async (id) => memberStore.delete(id),
   };
 
   const games: GameRepository = {

--- a/packages/cli/src/__tests__/usecases/ground-watch.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-watch.test.ts
@@ -28,6 +28,10 @@ function buildFake(): {
     },
     list: async () => Array.from(teams.values()),
     get: async (id) => teams.get(id) ?? null,
+    update: async (t) => {
+      teams.set(t.id, t);
+      return t;
+    },
   };
   const watchRepo: GroundWatchRepository = {
     insert: async (w) => {

--- a/packages/cli/src/__tests__/usecases/memory-fakes.ts
+++ b/packages/cli/src/__tests__/usecases/memory-fakes.ts
@@ -199,6 +199,10 @@ export function buildFakeContext(
       },
       list: async () => Array.from(teams.values()),
       get: async (id) => teams.get(id) ?? null,
+      update: async (t) => {
+        teams.set(t.id, t);
+        return t;
+      },
     },
     members: {
       insert: async (m) => {
@@ -208,6 +212,11 @@ export function buildFakeContext(
       list: async (teamId) =>
         Array.from(members.values()).filter((m) => m.team_id === teamId),
       get: async (id) => members.get(id) ?? null,
+      update: async (m) => {
+        members.set(m.id, m);
+        return m;
+      },
+      remove: async (id) => members.delete(id),
     },
     games: {
       insert: async (g) => {

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -45,6 +45,10 @@ function buildFake(opts?: { senderError?: Error }): Fake {
     },
     list: async () => Array.from(teams.values()),
     get: async (id) => teams.get(id) ?? null,
+    update: async (t) => {
+      teams.set(t.id, t);
+      return t;
+    },
   };
 
   const notificationRepo: NotificationChannelRepository = {

--- a/packages/cli/src/adapters/cli/commands/member.ts
+++ b/packages/cli/src/adapters/cli/commands/member.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { MEMBER_ROLES } from "../../../domain/types";
 import type { UseCaseContext } from "../../../ports";
-import { addMember, listMembers } from "../../../usecases/member";
+import {
+  addMember,
+  listMembers,
+  removeMember,
+  updateMember,
+} from "../../../usecases/member";
 import {
   type ParsedArgs,
   UsageError,
@@ -13,9 +18,16 @@ import { parseOrUsage } from "../zod-helper";
 
 const addInput = z.object({
   teamId: z.string().min(1),
+  // name は表示名/ハンドル。本名でなくニックネーム単体で構わない。
   name: z.string().min(1, "name は必須です").max(80),
   email: z.string().email().optional(),
   role: z.enum(MEMBER_ROLES).default("MEMBER"),
+});
+
+const updateInput = z.object({
+  name: z.string().min(1).max(80).optional(),
+  email: z.string().email().optional(),
+  role: z.enum(MEMBER_ROLES).optional(),
 });
 
 export async function runMember(
@@ -24,10 +36,59 @@ export async function runMember(
   opts: RenderOptions,
 ): Promise<void> {
   const sub = args.positional[0];
-  if (!sub) throw new UsageError("使い方: mound member <add|list>");
+  if (!sub)
+    throw new UsageError("使い方: mound member <add|list|update|remove>");
   if (sub === "add") return add(args, ctx, opts);
   if (sub === "list") return list(args, ctx, opts);
+  if (sub === "update") return update(args, ctx, opts);
+  if (sub === "remove") return remove(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: member ${sub}`);
+}
+
+async function update(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const memberId = requireFlag(args.flags, "member");
+  const data = parseOrUsage(updateInput, {
+    name: optionalFlag(args.flags, "name"),
+    email: optionalFlag(args.flags, "email"),
+    role: optionalFlag(args.flags, "role"),
+  });
+  if (
+    data.name === undefined &&
+    data.email === undefined &&
+    data.role === undefined
+  ) {
+    throw new UsageError(
+      "--name / --email / --role のいずれかを指定してください",
+    );
+  }
+  const member = await updateMember(ctx, {
+    memberId,
+    name: data.name,
+    email: data.email,
+    role: data.role,
+  });
+  emit(member, `メンバーを更新しました: ${member.id} (${member.name})`, opts);
+}
+
+async function remove(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1] ?? optionalFlag(args.flags, "member");
+  if (!id) throw new UsageError("使い方: mound member remove <ID>");
+  const removed = await removeMember(ctx, id);
+  emit(
+    { ok: removed, id },
+    removed
+      ? `メンバーを削除しました: ${id}`
+      : `該当するメンバーが見つかりません: ${id}`,
+    opts,
+  );
 }
 
 async function add(

--- a/packages/cli/src/adapters/cli/commands/team.ts
+++ b/packages/cli/src/adapters/cli/commands/team.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { UseCaseContext } from "../../../ports";
-import { createTeam, listTeams } from "../../../usecases/team";
+import { createTeam, listTeams, updateTeam } from "../../../usecases/team";
 import {
   type ParsedArgs,
   UsageError,
@@ -16,16 +16,43 @@ const createInput = z.object({
   area: z.string().max(80).optional(),
 });
 
+const updateInput = z.object({
+  name: z.string().min(1).max(80).optional(),
+  area: z.string().max(80).optional(),
+});
+
 export async function runTeam(
   args: ParsedArgs,
   ctx: UseCaseContext,
   opts: RenderOptions,
 ): Promise<void> {
   const sub = args.positional[0];
-  if (!sub) throw new UsageError("使い方: mound team <create|list>");
+  if (!sub) throw new UsageError("使い方: mound team <create|list|update>");
   if (sub === "create") return create(args, ctx, opts);
   if (sub === "list") return list(ctx, opts);
+  if (sub === "update") return update(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: team ${sub}`);
+}
+
+async function update(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const data = parseOrUsage(updateInput, {
+    name: optionalFlag(args.flags, "name"),
+    area: optionalFlag(args.flags, "area"),
+  });
+  if (data.name === undefined && data.area === undefined) {
+    throw new UsageError("--name か --area のどちらかを指定してください");
+  }
+  const team = await updateTeam(ctx, {
+    teamId,
+    name: data.name,
+    homeArea: data.area,
+  });
+  emit(team, `チームを更新しました: ${team.id} (${team.name})`, opts);
 }
 
 async function create(

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -7,8 +7,11 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   init                                       DB を初期化する
   team create --name <N> [--area <A>]        チームを作成
   team list                                  チーム一覧
+  team update --team <ID> [--name <N>] [--area <A>]   名前/本拠地を編集
   member add --team <ID> --name <N> [--email <E>] [--role ADMIN|MEMBER]
   member list --team <ID>
+  member update --member <ID> [--name <N>] [--email <E>] [--role ADMIN|MEMBER]
+  member remove <ID>
   game create --team <ID> --title <T> [--date YYYY-MM-DD] [--ground <G>] [--min-players <N>] [--note <NOTE>]
   game list [--team <ID>] [--status DRAFT|COLLECTING|CONFIRMED|...]
   game show <ID>
@@ -84,10 +87,28 @@ JSON 出力:
 サブコマンド:
   team create --name <N> [--area <A>] [--json]
   team list [--json]
+  team update --team <TEAM_ID> [--name <N>] [--area <A>] [--json]
 
 詳細:
   mound team create --help
   mound team list --help
+`,
+
+  "team update": `mound team update — チームの名前/本拠地を編集する
+
+使い方:
+  mound team update --team <TEAM_ID> [--name <NAME>] [--area <AREA>] [--json]
+
+フラグ (--name / --area のどちらか必須):
+  --team   (必須) チーム ID
+  --name   (任意) 新しいチーム名
+  --area   (任意) 新しい本拠地エリア
+
+JSON 出力:
+  Team (更新後)
+
+エラー:
+  - TeamNotFoundError (exit 2)
 `,
 
   "team create": `mound team create — チームを作成する
@@ -118,12 +139,49 @@ JSON 出力:
   member: `mound member — メンバー管理
 
 サブコマンド:
-  member add  --team <TEAM_ID> --name <N> [--email <E>] [--role ADMIN|MEMBER] [--json]
-  member list --team <TEAM_ID> [--json]
+  member add    --team <TEAM_ID> --name <N> [--email <E>] [--role ADMIN|MEMBER] [--json]
+  member list   --team <TEAM_ID> [--json]
+  member update --member <MEMBER_ID> [--name <N>] [--email <E>] [--role ADMIN|MEMBER] [--json]
+  member remove <MEMBER_ID> [--json]
+
+備考:
+  name は「表示名/ハンドル」。本名でなくニックネーム単体で構わない (本名は不要)。
+  あだ名・ポジション等の属性は mound knowledge (--category ROSTER --member) に持たせる。
 
 詳細:
   mound member add --help
   mound member list --help
+`,
+
+  "member update": `mound member update — メンバーの表示名/email/role を編集する
+
+使い方:
+  mound member update --member <MEMBER_ID> [--name <N>] [--email <E>] [--role ADMIN|MEMBER] [--json]
+
+フラグ (--name / --email / --role のいずれか必須):
+  --member  (必須) メンバー ID
+  --name    (任意) 新しい表示名 (ニックネーム可)
+  --email   (任意) 新しい email
+  --role    (任意) ADMIN | MEMBER
+
+JSON 出力:
+  Member (更新後)
+
+エラー:
+  - MemberNotFoundError (exit 2)
+`,
+
+  "member remove": `mound member remove — メンバーを削除する
+
+使い方:
+  mound member remove <MEMBER_ID> [--json]
+
+説明:
+  メンバーを削除する。出欠 (rsvps) や割り勘 (settlement_shares) は
+  ON DELETE CASCADE で一緒に消える。退団・本名を残したくない等に使う。
+
+JSON 出力:
+  { "ok": boolean, "id": string }
 `,
 
   "member add": `mound member add — メンバーを追加する

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -85,6 +85,14 @@ class LibsqlTeamRepository implements TeamRepository {
     });
     return r.rows[0] ? rowToTeam(r.rows[0]) : null;
   }
+
+  async update(team: Team): Promise<Team> {
+    await this.db.execute({
+      sql: "UPDATE teams SET name = ?, home_area = ?, updated_at = ? WHERE id = ?",
+      args: [team.name, team.home_area, team.updated_at, team.id],
+    });
+    return team;
+  }
 }
 
 class LibsqlMemberRepository implements MemberRepository {
@@ -121,6 +129,28 @@ class LibsqlMemberRepository implements MemberRepository {
       args: [id],
     });
     return r.rows[0] ? rowToMember(r.rows[0]) : null;
+  }
+
+  async update(member: Member): Promise<Member> {
+    await this.db.execute({
+      sql: "UPDATE members SET name = ?, email = ?, role = ?, updated_at = ? WHERE id = ?",
+      args: [
+        member.name,
+        member.email,
+        member.role,
+        member.updated_at,
+        member.id,
+      ],
+    });
+    return member;
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const r = await this.db.execute({
+      sql: "DELETE FROM members WHERE id = ?",
+      args: [id],
+    });
+    return r.rowsAffected > 0;
   }
 }
 

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -26,12 +26,15 @@ export interface TeamRepository {
   insert(team: Team): Promise<Team>;
   list(): Promise<Team[]>;
   get(id: string): Promise<Team | null>;
+  update(team: Team): Promise<Team>;
 }
 
 export interface MemberRepository {
   insert(member: Member): Promise<Member>;
   list(teamId: string): Promise<Member[]>;
   get(id: string): Promise<Member | null>;
+  update(member: Member): Promise<Member>;
+  remove(id: string): Promise<boolean>;
 }
 
 export interface GameRepository {

--- a/packages/cli/src/usecases/member.ts
+++ b/packages/cli/src/usecases/member.ts
@@ -1,7 +1,7 @@
 import type { Member, MemberRole } from "../domain/types";
 import type { UseCaseContext } from "../ports";
 import { writeAuditLog } from "./audit";
-import { TeamNotFoundError } from "./errors";
+import { MemberNotFoundError, TeamNotFoundError } from "./errors";
 
 export interface AddMemberInput {
   teamId: string;
@@ -41,4 +41,55 @@ export async function listMembers(
   teamId: string,
 ): Promise<Member[]> {
   return ctx.repo.members.list(teamId);
+}
+
+export interface UpdateMemberInput {
+  memberId: string;
+  // undefined = 変更しない。本名は必須でなく、name は表示名/ニックネームでよい。
+  name?: string;
+  email?: string;
+  role?: MemberRole;
+}
+
+export async function updateMember(
+  ctx: UseCaseContext,
+  input: UpdateMemberInput,
+): Promise<Member> {
+  const member = await ctx.repo.members.get(input.memberId);
+  if (!member) throw new MemberNotFoundError(input.memberId);
+  const before = { ...member };
+  const updated: Member = {
+    ...member,
+    name: input.name ?? member.name,
+    email: input.email ?? member.email,
+    role: input.role ?? member.role,
+    updated_at: ctx.now().toISOString(),
+  };
+  await ctx.repo.members.update(updated);
+  await writeAuditLog(ctx, {
+    action: "MEMBER_UPDATED",
+    targetType: "member",
+    targetId: member.id,
+    before,
+    after: updated,
+  });
+  return updated;
+}
+
+export async function removeMember(
+  ctx: UseCaseContext,
+  id: string,
+): Promise<boolean> {
+  const member = await ctx.repo.members.get(id);
+  if (!member) return false;
+  const removed = await ctx.repo.members.remove(id);
+  if (removed) {
+    await writeAuditLog(ctx, {
+      action: "MEMBER_REMOVED",
+      targetType: "member",
+      targetId: id,
+      before: member,
+    });
+  }
+  return removed;
 }

--- a/packages/cli/src/usecases/team.ts
+++ b/packages/cli/src/usecases/team.ts
@@ -1,6 +1,7 @@
 import type { Team } from "../domain/types";
 import type { UseCaseContext } from "../ports";
 import { writeAuditLog } from "./audit";
+import { TeamNotFoundError } from "./errors";
 
 export interface CreateTeamInput {
   name: string;
@@ -31,4 +32,35 @@ export async function createTeam(
 
 export async function listTeams(ctx: UseCaseContext): Promise<Team[]> {
   return ctx.repo.teams.list();
+}
+
+export interface UpdateTeamInput {
+  teamId: string;
+  // undefined = 変更しない。string = その値に更新。
+  name?: string;
+  homeArea?: string;
+}
+
+export async function updateTeam(
+  ctx: UseCaseContext,
+  input: UpdateTeamInput,
+): Promise<Team> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const before = { ...team };
+  const updated: Team = {
+    ...team,
+    name: input.name ?? team.name,
+    home_area: input.homeArea ?? team.home_area,
+    updated_at: ctx.now().toISOString(),
+  };
+  await ctx.repo.teams.update(updated);
+  await writeAuditLog(ctx, {
+    action: "TEAM_UPDATED",
+    targetType: "team",
+    targetId: team.id,
+    before,
+    after: updated,
+  });
+  return updated;
 }


### PR DESCRIPTION
## 概要
作成後に team / member を変えられない問題を解消。**本名を必須にしない方針** (Member.name は表示名/ハンドルでよく、ニックネーム単体で可) に合わせ、後から改名・本拠地変更・退団 (削除) ができるようにした。

## 追加コマンド
- `mound team update --team <ID> [--name] [--area]`
- `mound member update --member <ID> [--name] [--email] [--role]`
- `mound member remove <ID>` (rsvps / settlement_shares は CASCADE)

## 実装
- usecases: `updateTeam` / `updateMember` / `removeMember` (監査ログつき)
- ports / libsql: `TeamRepository.update`, `MemberRepository.update` / `remove`
- test: `editability.test.ts`

`make check` 緑 (154 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)