### PR TITLE
feat(backup): mound export / import (JSONL バックアップ)

### DIFF
--- a/packages/cli/src/__tests__/backup.test.ts
+++ b/packages/cli/src/__tests__/backup.test.ts
@@ -1,0 +1,96 @@
+// export / import を実 libSQL (in-memory) で往復させ、別 DB に復元できることを確かめる。
+import { describe, expect, it } from "vitest";
+import { migrate, openDb } from "../adapters/libsql/client";
+import { buildRepositories } from "../adapters/libsql/repositories";
+import type { Member, Team } from "../domain/types";
+
+function team(): Team {
+  return {
+    id: "t1",
+    name: "Xeros",
+    home_area: "横浜",
+    created_at: "2026-06-03T00:00:00.000Z",
+    updated_at: "2026-06-03T00:00:00.000Z",
+  };
+}
+
+function member(): Member {
+  return {
+    id: "m1",
+    team_id: "t1",
+    name: "トミー",
+    email: null,
+    role: "MEMBER",
+    created_at: "2026-06-03T00:00:00.000Z",
+    updated_at: "2026-06-03T00:00:00.000Z",
+  };
+}
+
+describe("backup export/import", () => {
+  describe("別 DB へ書き出して取り込んだとき", () => {
+    it("teams と members が復元される", async () => {
+      const src = openDb({ url: ":memory:" });
+      await migrate(src);
+      const srcRepo = buildRepositories(src);
+      await srcRepo.teams.insert(team());
+      await srcRepo.members.insert(member());
+
+      const rows = await srcRepo.backup.exportAll();
+      expect(rows.some((r) => r.table === "teams")).toBe(true);
+      expect(rows.some((r) => r.table === "members")).toBe(true);
+
+      const dst = openDb({ url: ":memory:" });
+      await migrate(dst);
+      const dstRepo = buildRepositories(dst);
+      const imported = await dstRepo.backup.importAll(rows);
+      expect(imported).toBe(rows.length);
+
+      const t = await dstRepo.teams.get("t1");
+      expect(t?.name).toBe("Xeros");
+      expect(t?.home_area).toBe("横浜");
+      const m = await dstRepo.members.get("m1");
+      expect(m?.name).toBe("トミー");
+
+      src.close();
+      dst.close();
+    });
+  });
+
+  describe("同じデータを二度取り込んだとき", () => {
+    it("冪等 (INSERT OR REPLACE) で重複しない", async () => {
+      const src = openDb({ url: ":memory:" });
+      await migrate(src);
+      const srcRepo = buildRepositories(src);
+      await srcRepo.teams.insert(team());
+      const rows = await srcRepo.backup.exportAll();
+
+      const dst = openDb({ url: ":memory:" });
+      await migrate(dst);
+      const dstRepo = buildRepositories(dst);
+      await dstRepo.backup.importAll(rows);
+      await dstRepo.backup.importAll(rows);
+
+      const teams = await dstRepo.teams.list();
+      expect(teams.filter((t) => t.id === "t1")).toHaveLength(1);
+
+      src.close();
+      dst.close();
+    });
+  });
+
+  describe("未知テーブル / 不正な列名の行のとき", () => {
+    it("安全にスキップする", async () => {
+      const dst = openDb({ url: ":memory:" });
+      await migrate(dst);
+      const dstRepo = buildRepositories(dst);
+      const imported = await dstRepo.backup.importAll([
+        { table: "evil; DROP TABLE teams", data: { id: "x" } },
+        { table: "teams", data: { "id) VALUES ('x'); --": "x" } },
+      ]);
+      expect(imported).toBe(0);
+      // teams テーブルは無事
+      expect(await dstRepo.teams.list()).toEqual([]);
+      dst.close();
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -248,6 +248,7 @@ function buildFake(): Fake {
       observations: buildObservationRepo().repo,
       knowledge: buildKnowledgeRepo().repo,
       settlements: buildSettlementRepo().repo,
+      backup: { exportAll: async () => [], importAll: async (r) => r.length },
     },
   };
 }

--- a/packages/cli/src/__tests__/usecases/ground-watch.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-watch.test.ts
@@ -60,6 +60,7 @@ function buildFake(): {
     observations: stub,
     knowledge: stub,
     settlements: stub,
+    backup: stub,
   };
   let seq = 0;
   const ctx: UseCaseContext = {

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -60,6 +60,7 @@ function buildCtx(opts: { now: Date; idSeed?: number }): {
     observations: stub,
     knowledge: stub,
     settlements: stub,
+    backup: stub,
   };
   const notifier = {
     send: async () => ({

--- a/packages/cli/src/__tests__/usecases/memory-fakes.ts
+++ b/packages/cli/src/__tests__/usecases/memory-fakes.ts
@@ -290,6 +290,10 @@ export function buildFakeContext(
     observations: observationRepo,
     knowledge: knowledgeRepo,
     settlements: buildSettlementRepo().repo,
+    backup: {
+      exportAll: async () => [],
+      importAll: async (rows) => rows.length,
+    },
   };
 
   const notifier: NotificationSender = {

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -93,6 +93,7 @@ function buildFake(opts?: { senderError?: Error }): Fake {
     observations: stub,
     knowledge: stub,
     settlements: stub,
+    backup: stub,
   };
 
   const notifier: NotificationSender = {

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -27,6 +27,7 @@ import { TransitionDeniedError } from "../../usecases/errors";
 import { runAgenda } from "./commands/agenda";
 import { runAudit } from "./commands/audit";
 import { runAuto } from "./commands/auto";
+import { runExport, runImport } from "./commands/backup";
 import { runGame } from "./commands/game";
 import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
@@ -143,6 +144,12 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "settle":
         await runSettle(subArgs, ctx, renderOpts);
+        return 0;
+      case "export":
+        await runExport(subArgs, ctx, renderOpts);
+        return 0;
+      case "import":
+        await runImport(subArgs, ctx, renderOpts);
         return 0;
       default:
         emitError(`未知のコマンド: ${command}`, { json, sink: stderr });

--- a/packages/cli/src/adapters/cli/commands/backup.ts
+++ b/packages/cli/src/adapters/cli/commands/backup.ts
@@ -1,0 +1,64 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import type { BackupRow, UseCaseContext } from "../../../ports";
+import { exportData, importData } from "../../../usecases/backup";
+import { type ParsedArgs, UsageError, optionalFlag } from "../args";
+import { type RenderOptions, emit } from "../output";
+
+// mound export — 全データを JSONL で書き出す (--out PATH か stdout)。
+export async function runExport(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const rows = await exportData(ctx);
+  const jsonl = rows.map((r) => JSON.stringify(r)).join("\n");
+  const out = optionalFlag(args.flags, "out");
+  if (out) {
+    writeFileSync(out, `${jsonl}\n`, "utf-8");
+    emit(
+      { exported: rows.length, out },
+      `${rows.length} 行を書き出しました: ${out}`,
+      opts,
+    );
+    return;
+  }
+  // --out 無しは JSONL をそのまま stdout へ (`mound export > backup.jsonl`)。
+  opts.sink.write(jsonl);
+}
+
+// mound import — JSONL を取り込む (INSERT OR REPLACE で冪等)。
+export async function runImport(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const file = optionalFlag(args.flags, "file");
+  if (!file) throw new UsageError("使い方: mound import --file <PATH>");
+  let text: string;
+  try {
+    text = readFileSync(file, "utf-8");
+  } catch {
+    throw new UsageError(`ファイルを読めません: ${file}`);
+  }
+  const rows: BackupRow[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new UsageError("JSONL の行を parse できません");
+    }
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as BackupRow).table === "string" &&
+      typeof (parsed as BackupRow).data === "object"
+    ) {
+      rows.push(parsed as BackupRow);
+    }
+  }
+  const result = await importData(ctx, rows);
+  emit(result, `${result.imported} 行を取り込みました`, opts);
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -47,6 +47,8 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   settle show --game <ID>
   settle pay --game <ID> --member <ID> [--unpaid]
   settle remind --game <ID>                   PayPay 割り勘の催促を通知
+  export [--out PATH]                          全データを JSONL で書き出す
+  import --file PATH                           JSONL を取り込む (冪等)
 
 環境変数 (追加):
   MOUND_NOTIFY_MODE     log-only | disabled | (未指定=実 HTTP)
@@ -789,6 +791,39 @@ JSON 出力 (auto run):
     "proposed": AutoAction[]
   }
   AutoAction = { kind, risk, game_id, game_title, reason, transition_to, message }
+`,
+
+  export: `mound export — 全データを JSONL で書き出す (バックアップ / GitHub ミラー)
+
+使い方:
+  mound export [--out PATH] [--json]
+  mound export > backup.jsonl
+
+説明:
+  全テーブル (teams/members/games/rsvps/observations/team_knowledge/settlements 等) を
+  1 行 1 レコードの JSONL で出力する。テキストなので git で diff/merge/履歴が効く。
+  --out 無しは stdout、--out PATH でファイルに書き出す。
+
+  運用: ライブの読み書きは SQLite/Turso、git にはこの JSONL を置く2層が推奨。
+  チームごとに DB を分ける (MOUND_DB_URL=file:~/.mound/teams/<team>.db) と
+  per-team private repo へのバックアップになる。
+
+JSONL の各行:
+  { "table": string, "data": { ...row... } }
+`,
+
+  import: `mound import — JSONL を取り込む (INSERT OR REPLACE で冪等)
+
+使い方:
+  mound import --file backup.jsonl [--json]
+
+説明:
+  mound export が出した JSONL を読み、各行を INSERT OR REPLACE で復元する。
+  同じファイルを二度入れても結果は同じ (冪等)。新しい DB へのリストアや、
+  別環境への移送に使う。未知テーブル / 不正な列名の行は安全にスキップする。
+
+JSON 出力:
+  { "imported": number }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -20,6 +20,8 @@ import type {
 } from "../../domain/types";
 import type {
   AuditRepository,
+  BackupRepository,
+  BackupRow,
   GameRepository,
   GroundSlotDiffFilter,
   GroundSlotFilter,
@@ -805,6 +807,60 @@ class LibsqlSettlementRepository implements SettlementRepository {
   }
 }
 
+// バックアップ対象テーブル。FK 順 (取り込み時に親→子の順で復元できる)。
+const BACKUP_TABLES = [
+  "teams",
+  "members",
+  "games",
+  "rsvps",
+  "ground_slots",
+  "notification_channels",
+  "ground_watches",
+  "observations",
+  "team_knowledge",
+  "settlements",
+  "settlement_shares",
+  "audit_logs",
+] as const;
+// 列名は schema 由来のみ許可 (取り込みファイル経由の SQL インジェクション防止)。
+const SAFE_COLUMN = /^[a-z_][a-z0-9_]*$/;
+
+class LibsqlBackupRepository implements BackupRepository {
+  constructor(private readonly db: DbClient) {}
+
+  async exportAll(): Promise<BackupRow[]> {
+    const out: BackupRow[] = [];
+    for (const table of BACKUP_TABLES) {
+      const r = await this.db.execute(`SELECT * FROM ${table}`);
+      for (const row of r.rows) {
+        const data: Record<string, unknown> = {};
+        for (const col of r.columns) {
+          data[col] = (row as unknown as Record<string, unknown>)[col];
+        }
+        out.push({ table, data });
+      }
+    }
+    return out;
+  }
+
+  async importAll(rows: BackupRow[]): Promise<number> {
+    const allowed = new Set<string>(BACKUP_TABLES);
+    let n = 0;
+    for (const { table, data } of rows) {
+      if (!allowed.has(table)) continue;
+      const cols = Object.keys(data).filter((c) => SAFE_COLUMN.test(c));
+      if (cols.length === 0) continue;
+      const placeholders = cols.map(() => "?").join(", ");
+      await this.db.execute({
+        sql: `INSERT OR REPLACE INTO ${table} (${cols.join(", ")}) VALUES (${placeholders})`,
+        args: cols.map((c) => data[c] as InValue),
+      });
+      n++;
+    }
+    return n;
+  }
+}
+
 export function buildRepositories(db: DbClient): Repositories {
   return {
     teams: new LibsqlTeamRepository(db),
@@ -818,5 +874,6 @@ export function buildRepositories(db: DbClient): Repositories {
     observations: new LibsqlObservationRepository(db),
     knowledge: new LibsqlTeamKnowledgeRepository(db),
     settlements: new LibsqlSettlementRepository(db),
+    backup: new LibsqlBackupRepository(db),
   };
 }

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -168,6 +168,19 @@ export interface NotificationSender {
   ): Promise<NotificationDeliveryResult>;
 }
 
+// 全テーブルのテキスト書き出し/取り込み (バックアップ / GitHub ミラー用)。
+// 1 行 = 1 レコード (JSONL にしやすい形)。Clean Architecture を保つため、
+// 生 SQL でのダンプ/復元は adapters/libsql の実装に閉じ込め、ここは境界だけ定義する。
+export interface BackupRow {
+  table: string;
+  data: Record<string, unknown>;
+}
+
+export interface BackupRepository {
+  exportAll(): Promise<BackupRow[]>;
+  importAll(rows: BackupRow[]): Promise<number>; // 取り込んだ行数
+}
+
 export interface Repositories {
   teams: TeamRepository;
   members: MemberRepository;
@@ -180,6 +193,7 @@ export interface Repositories {
   observations: ObservationRepository;
   knowledge: TeamKnowledgeRepository;
   settlements: SettlementRepository;
+  backup: BackupRepository;
 }
 
 export interface Clock {

--- a/packages/cli/src/usecases/backup.ts
+++ b/packages/cli/src/usecases/backup.ts
@@ -1,0 +1,20 @@
+// 全データのテキスト書き出し / 取り込み。
+// ライブの読み書きは SQLite/Turso、git にはここで出した JSONL (テキスト) を置く、
+// という二層運用のための薄いユースケース (実体は adapters/libsql の BackupRepository)。
+import type { BackupRow, UseCaseContext } from "../ports";
+
+export async function exportData(ctx: UseCaseContext): Promise<BackupRow[]> {
+  return ctx.repo.backup.exportAll();
+}
+
+export interface ImportResult {
+  imported: number;
+}
+
+export async function importData(
+  ctx: UseCaseContext,
+  rows: BackupRow[],
+): Promise<ImportResult> {
+  const imported = await ctx.repo.backup.importAll(rows);
+  return { imported };
+}


### PR DESCRIPTION
## 概要
ライブの読み書きは SQLite/Turso、**git にはテキスト (JSONL) を置く2層運用**のための書き出し/復元。チームデータを per-team private repo にバックアップできるようにする土台。

## コマンド
- `mound export [--out PATH]` — 全テーブルを JSONL で出力 (stdout か file)
- `mound import --file PATH` — JSONL を INSERT OR REPLACE で冪等に取り込む

## 実装
- `BackupRepository` (libsql): FK 順に `SELECT *`、列名は `^[a-z_][a-z0-9_]*$` のみ許可しインジェクション防止
- `usecases/backup.ts`: 薄い delegation
- `backup.test.ts`: 実 libSQL での往復・冪等・未知テーブル/不正列のスキップ

`make check` 緑 (157 tests)。CLI 往復も実機確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)