### PR TITLE
feat(config): mound config — 接続先を config.json に保存 (env 不要)

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,0 +1,83 @@
+// mound config (接続先の永続化) のテスト。env > config.json > 既定 の優先順位を確かめる。
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configFilePath, readConfig, writeConfig } from "../adapters/config";
+import { buildDbConfig } from "../adapters/libsql/client";
+
+let home: string;
+let env: Record<string, string | undefined>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "mound-cfg-"));
+  env = { HOME: home };
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("writeConfig / readConfig", () => {
+  describe("保存して読み直したとき", () => {
+    it("値が往復し、ファイルは 0600 で書かれる", () => {
+      writeConfig(env, {
+        db_url: "libsql://xeros.turso.io",
+        db_auth_token: "secret-token",
+      });
+      const cfg = readConfig(env);
+      expect(cfg.db_url).toBe("libsql://xeros.turso.io");
+      expect(cfg.db_auth_token).toBe("secret-token");
+      const mode = statSync(configFilePath(env)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+  });
+
+  describe("一部だけ更新したとき", () => {
+    it("既存値を保ったままマージする", () => {
+      writeConfig(env, { db_url: "libsql://a.turso.io", db_auth_token: "tok" });
+      writeConfig(env, { db_url: "libsql://b.turso.io" });
+      const cfg = readConfig(env);
+      expect(cfg.db_url).toBe("libsql://b.turso.io");
+      expect(cfg.db_auth_token).toBe("tok"); // token は据え置き
+    });
+  });
+
+  describe("設定ファイルが無いとき", () => {
+    it("空設定を返す (throw しない)", () => {
+      expect(readConfig(env)).toEqual({});
+    });
+  });
+});
+
+describe("buildDbConfig の優先順位", () => {
+  describe("config.json に設定があるとき", () => {
+    it("env が無ければ config.json を使う", () => {
+      writeConfig(env, {
+        db_url: "libsql://xeros.turso.io",
+        db_auth_token: "tok",
+      });
+      const cfg = buildDbConfig(env);
+      expect(cfg.url).toBe("libsql://xeros.turso.io");
+      expect(cfg.authToken).toBe("tok");
+    });
+  });
+
+  describe("env と config.json の両方があるとき", () => {
+    it("env が優先される", () => {
+      writeConfig(env, { db_url: "libsql://from-config.turso.io" });
+      const cfg = buildDbConfig({
+        ...env,
+        MOUND_DB_URL: "libsql://from-env.turso.io",
+      });
+      expect(cfg.url).toBe("libsql://from-env.turso.io");
+    });
+  });
+
+  describe("どちらも無いとき", () => {
+    it("既定の ~/.mound/mound.db を使う", () => {
+      const cfg = buildDbConfig(env);
+      expect(cfg.url).toBe(`file:${home}/.mound/mound.db`);
+    });
+  });
+});

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -28,6 +28,7 @@ import { runAgenda } from "./commands/agenda";
 import { runAudit } from "./commands/audit";
 import { runAuto } from "./commands/auto";
 import { runExport, runImport } from "./commands/backup";
+import { runConfig } from "./commands/config";
 import { runGame } from "./commands/game";
 import { runGround } from "./commands/ground";
 import { runInit } from "./commands/init";
@@ -87,6 +88,11 @@ export async function run(options: RunOptions): Promise<number> {
   let db: DbClient | null = null;
 
   try {
+    // config は接続先そのものを設定するコマンドなので DB を開かずに処理する。
+    if (command === "config") {
+      await runConfig(subArgs, options.env, renderOpts);
+      return 0;
+    }
     db = options.db ?? openDb(buildDbConfig(options.env));
     if (command !== "init") {
       await ensureSchemaUpToDate(db);

--- a/packages/cli/src/adapters/cli/commands/config.ts
+++ b/packages/cli/src/adapters/cli/commands/config.ts
@@ -1,0 +1,81 @@
+import {
+  type MoundConfig,
+  configFilePath,
+  readConfig,
+  writeConfig,
+} from "../../config";
+import { type ParsedArgs, UsageError, optionalFlag } from "../args";
+import { type RenderOptions, emit } from "../output";
+
+// 秘密トークンは全表示しない。設定有無と末尾4文字だけ見せる。
+function maskToken(token: string | undefined): string {
+  if (!token) return "(未設定)";
+  return token.length > 4 ? `****${token.slice(-4)}` : "****";
+}
+
+// mound config — 接続先 (DB URL / 認証トークン) を ~/.mound/config.json に保存。
+// この設定は DB を開く前に読むので、ctx を受け取らず env だけで動く。
+export async function runConfig(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+  opts: RenderOptions,
+): Promise<void> {
+  const sub = args.positional[0] ?? "show";
+  if (sub === "show") return show(env, opts);
+  if (sub === "set") return set(args, env, opts);
+  if (sub === "path") {
+    emit({ path: configFilePath(env) }, configFilePath(env), opts);
+    return;
+  }
+  throw new UsageError(`未知のサブコマンド: config ${sub}`);
+}
+
+async function show(
+  env: Record<string, string | undefined>,
+  opts: RenderOptions,
+): Promise<void> {
+  const cfg = readConfig(env);
+  // JSON ではトークンを生で出さない (マスク)。
+  emit(
+    {
+      path: configFilePath(env),
+      db_url: cfg.db_url ?? null,
+      db_auth_token: cfg.db_auth_token ? maskToken(cfg.db_auth_token) : null,
+    },
+    [
+      `config: ${configFilePath(env)}`,
+      `db_url: ${cfg.db_url ?? "(未設定 → 既定の ~/.mound/mound.db)"}`,
+      `db_auth_token: ${maskToken(cfg.db_auth_token)}`,
+    ].join("\n"),
+    opts,
+  );
+}
+
+async function set(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+  opts: RenderOptions,
+): Promise<void> {
+  const dbUrl = optionalFlag(args.flags, "db-url");
+  const dbToken = optionalFlag(args.flags, "db-token");
+  if (dbUrl === undefined && dbToken === undefined) {
+    throw new UsageError("--db-url か --db-token を指定してください");
+  }
+  const patch: MoundConfig = {};
+  if (dbUrl !== undefined) patch.db_url = dbUrl;
+  if (dbToken !== undefined) patch.db_auth_token = dbToken;
+  const merged = writeConfig(env, patch);
+  emit(
+    {
+      path: configFilePath(env),
+      db_url: merged.db_url ?? null,
+      db_auth_token: merged.db_auth_token
+        ? maskToken(merged.db_auth_token)
+        : null,
+    },
+    `設定を保存しました (${configFilePath(env)}, 0600)\n` +
+      `db_url: ${merged.db_url ?? "(未設定)"}\n` +
+      `db_auth_token: ${maskToken(merged.db_auth_token)}`,
+    opts,
+  );
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -5,6 +5,8 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
 
 コマンド:
   init                                       DB を初期化する
+  config set [--db-url URL] [--db-token TOKEN]  接続先を ~/.mound/config.json に保存
+  config show                                現在の接続設定 (トークンはマスク)
   team create --name <N> [--area <A>]        チームを作成
   team list                                  チーム一覧
   team update --team <ID> [--name <N>] [--area <A>]   名前/本拠地を編集
@@ -61,6 +63,9 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   --help       このヘルプ
   --version    バージョン
 
+接続先の決定順:
+  環境変数 > ~/.mound/config.json (mound config set) > 既定 (~/.mound/mound.db)
+
 環境変数:
   MOUND_DB_URL          libSQL URL (例: file:./mound.db, libsql://...turso.io)
   MOUND_DB_AUTH_TOKEN   Turso 認証トークン
@@ -82,6 +87,29 @@ export const COMMAND_HELP: Record<string, string> = {
 
 JSON 出力:
   { "ok": true }
+`,
+
+  config: `mound config — 接続先 (DB URL / 認証トークン) を保存する
+
+サブコマンド:
+  config set  [--db-url <URL>] [--db-token <TOKEN>] [--json]
+  config show [--json]
+  config path [--json]
+
+説明:
+  ~/.zshrc に環境変数を書く代わりに、~/.mound/config.json に接続先を保存する。
+  ファイルは owner-only (0600)。トークンは表示時に末尾4文字だけ見せる (マスク)。
+  接続先の決定順は 環境変数 > config.json > 既定 (~/.mound/mound.db)。
+  この設定は DB を開く前に読むので、誤った URL でも config set で直せる。
+
+例 (Turso に向ける):
+  mound config set \\
+    --db-url libsql://xeros-<org>.turso.io \\
+    --db-token <TURSO_TOKEN>
+  mound init        # 以降は env 不要で Turso を使う
+
+JSON 出力 (set/show):
+  { "path": string, "db_url": string|null, "db_auth_token": "****xxxx"|null }
 `,
 
   team: `mound team — チーム管理

--- a/packages/cli/src/adapters/config.ts
+++ b/packages/cli/src/adapters/config.ts
@@ -1,0 +1,43 @@
+// mound の接続設定を ~/.mound/config.json に保存/読込する。
+// 環境変数を使わずに `mound config set` で DB URL / 認証トークンを永続化できる。
+// トークンは秘密なのでファイルは owner-only (0600) で書く。
+//
+// libsql/client.ts (buildDbConfig) と cli/commands/config.ts の両方から使うため、
+// adapters/libsql でも adapters/cli でもない中立な場所に置く (依存方向の禁則を侵さない)。
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface MoundConfig {
+  db_url?: string;
+  db_auth_token?: string;
+}
+
+export function configFilePath(
+  env: Record<string, string | undefined>,
+): string {
+  return `${env.HOME ?? "."}/.mound/config.json`;
+}
+
+export function readConfig(
+  env: Record<string, string | undefined>,
+): MoundConfig {
+  try {
+    const parsed = JSON.parse(readFileSync(configFilePath(env), "utf-8"));
+    if (parsed && typeof parsed === "object") return parsed as MoundConfig;
+  } catch {
+    // ファイルが無い / 壊れている場合は空設定として扱う
+  }
+  return {};
+}
+
+export function writeConfig(
+  env: Record<string, string | undefined>,
+  patch: MoundConfig,
+): MoundConfig {
+  const path = configFilePath(env);
+  mkdirSync(dirname(path), { recursive: true });
+  const merged: MoundConfig = { ...readConfig(env), ...patch };
+  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(path, 0o600); // 既存ファイルにも owner-only を保証する
+  return merged;
+}

--- a/packages/cli/src/adapters/libsql/client.ts
+++ b/packages/cli/src/adapters/libsql/client.ts
@@ -1,6 +1,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { type Client, createClient } from "@libsql/client";
+import { readConfig } from "../config";
 import { SCHEMA_SQL, SCHEMA_VERSION } from "./schema";
 
 export type DbClient = Client;
@@ -10,14 +11,18 @@ export interface DbConfig {
   authToken?: string;
 }
 
+// 接続先の決定順: 環境変数 > ~/.mound/config.json (mound config set) > 既定ファイル。
 export function buildDbConfig(
   env: Record<string, string | undefined>,
 ): DbConfig {
+  const file = readConfig(env);
   const url =
     env.MOUND_DB_URL ??
     env.TURSO_DATABASE_URL ??
+    file.db_url ??
     `file:${env.HOME ?? "."}/.mound/mound.db`;
-  const authToken = env.MOUND_DB_AUTH_TOKEN ?? env.TURSO_AUTH_TOKEN;
+  const authToken =
+    env.MOUND_DB_AUTH_TOKEN ?? env.TURSO_AUTH_TOKEN ?? file.db_auth_token;
   return { url, authToken };
 }
 


### PR DESCRIPTION
## 概要
`~/.zshrc` に環境変数を書く代わりに、**`mound config set` で接続先 (DB URL / 認証トークン) を `~/.mound/config.json` に永続化**できるようにする。Turso 利用時にトークンをシェル profile に置かなくて済む。

## コマンド
- `mound config set [--db-url URL] [--db-token TOKEN]`
- `mound config show` (トークンはマスク: `****xxxx`)
- `mound config path`

## 仕様
- 接続先の決定順: **環境変数 > config.json > 既定 (`~/.mound/mound.db`)**
- config ファイルは **owner-only `0600`**(トークンを含むため)
- `config` は DB を開く前に処理 → 誤った URL でも直せる

## 実装
- `adapters/config.ts`(libsql でも cli でもない中立層・依存方向の禁則を侵さない)
- `buildDbConfig` が config.json を読む
- `config.test.ts`: 往復 / 0600 / env>file>default の優先順位

`make check` 緑 (163 tests)。実機で set/show(マスク)/接続切替を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)