### PR TITLE
fix(libsql): Turso でのマイグレーション失敗 (PRAGMA user_version) を修正

### DIFF
--- a/packages/cli/src/__tests__/migration.test.ts
+++ b/packages/cli/src/__tests__/migration.test.ts
@@ -1,0 +1,58 @@
+// スキーマ版の管理が PRAGMA user_version の "書き込み" に依存しないことを確かめる。
+// Turso (sqld) は PRAGMA user_version 書き込みを禁止するため、schema_meta テーブルで管理する。
+import { describe, expect, it } from "vitest";
+import {
+  ensureSchemaUpToDate,
+  migrate,
+  openDb,
+  readSchemaVersion,
+} from "../adapters/libsql/client";
+import { SCHEMA_VERSION } from "../adapters/libsql/schema";
+
+describe("schema migration", () => {
+  describe("migrate したとき", () => {
+    it("schema_meta に版を記録し、PRAGMA user_version は書かない", async () => {
+      const db = openDb({ url: ":memory:" });
+      await migrate(db);
+
+      expect(await readSchemaVersion(db)).toBe(SCHEMA_VERSION);
+      const r = await db.execute(
+        "SELECT value FROM schema_meta WHERE key = 'schema_version'",
+      );
+      expect(Number(r.rows[0]?.value)).toBe(SCHEMA_VERSION);
+
+      // PRAGMA user_version は書いていない (= Turso でも弾かれない)。
+      const p = await db.execute("PRAGMA user_version");
+      expect(Number(p.rows[0]?.user_version)).toBe(0);
+      db.close();
+    });
+  });
+
+  describe("2 回 migrate したとき", () => {
+    it("冪等 (エラーにならず版は据え置き)", async () => {
+      const db = openDb({ url: ":memory:" });
+      await migrate(db);
+      await migrate(db);
+      expect(await readSchemaVersion(db)).toBe(SCHEMA_VERSION);
+      db.close();
+    });
+  });
+
+  describe("schema_meta が無く PRAGMA user_version だけある旧ローカル DB のとき", () => {
+    it("PRAGMA フォールバックで版を読む", async () => {
+      const db = openDb({ url: ":memory:" });
+      await db.execute("PRAGMA user_version = 3");
+      expect(await readSchemaVersion(db)).toBe(3);
+      db.close();
+    });
+  });
+
+  describe("ensureSchemaUpToDate", () => {
+    it("未マイグレーションの DB を最新スキーマにする", async () => {
+      const db = openDb({ url: ":memory:" });
+      await ensureSchemaUpToDate(db);
+      expect(await readSchemaVersion(db)).toBe(SCHEMA_VERSION);
+      db.close();
+    });
+  });
+});

--- a/packages/cli/src/adapters/libsql/client.ts
+++ b/packages/cli/src/adapters/libsql/client.ts
@@ -42,14 +42,35 @@ export function openDb(config: DbConfig): DbClient {
 }
 
 export async function readSchemaVersion(db: DbClient): Promise<number> {
-  const r = await db.execute("PRAGMA user_version");
-  const v = r.rows[0]?.user_version;
-  return typeof v === "number" ? v : Number(v ?? 0);
+  // 新方式: schema_meta テーブル (local/remote 両対応)。
+  try {
+    const r = await db.execute(
+      "SELECT value FROM schema_meta WHERE key = 'schema_version'",
+    );
+    const v = r.rows[0]?.value;
+    if (v !== undefined && v !== null) return Number(v);
+  } catch {
+    // schema_meta がまだ無い (初回 / 旧 DB)。下の PRAGMA フォールバックへ。
+  }
+  // 旧方式フォールバック: 既存ローカル DB は PRAGMA user_version を持つ。
+  // remote では PRAGMA 読み取りが弾かれることがあるので try で握りつぶす。
+  try {
+    const r = await db.execute("PRAGMA user_version");
+    const v = r.rows[0]?.user_version;
+    return typeof v === "number" ? v : Number(v ?? 0);
+  } catch {
+    return 0;
+  }
 }
 
 export async function migrate(db: DbClient): Promise<void> {
   await db.executeMultiple(SCHEMA_SQL);
-  await db.execute(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+  // PRAGMA user_version の "書き込み" は Turso (sqld) で許可されないため、
+  // スキーマ版は schema_meta テーブルに記録する (local/remote 両対応)。
+  await db.execute({
+    sql: "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', ?)",
+    args: [String(SCHEMA_VERSION)],
+  });
 }
 
 export async function ensureSchemaUpToDate(db: DbClient): Promise<void> {

--- a/packages/cli/src/adapters/libsql/schema.ts
+++ b/packages/cli/src/adapters/libsql/schema.ts
@@ -1,6 +1,13 @@
 export const SCHEMA_VERSION = 6;
 
 export const SCHEMA_SQL = `
+-- スキーマ版を記録するメタテーブル。PRAGMA user_version の書き込みは Turso (sqld)
+-- で許可されないため、バージョンはここに普通の SQL で記録する (local/remote 両対応)。
+CREATE TABLE IF NOT EXISTS schema_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS teams (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,


### PR DESCRIPTION
## 問題
Turso (libSQL リモート / sqld) に接続して `mound` を実行すると、マイグレーションが
`SQL_PARSE_ERROR: SQL not allowed statement: PRAGMA user_version = 6` で失敗する。
sqld が `PRAGMA user_version` の**書き込み**を許可しないため。ローカル SQLite では
通るのでテストで検出できていなかった。

## 修正
スキーマ版を **`schema_meta` テーブル**に普通の SQL (`INSERT OR REPLACE`) で記録する
方式に変更 (local/remote 両対応)。読み取りは `schema_meta` を見て、無ければ旧ローカル
DB 向けに `PRAGMA user_version` 読み取りへフォールバック。`PRAGMA` の書き込みは廃止。

- `schema.ts`: `schema_meta(key, value)` を追加
- `client.ts`: `migrate` / `readSchemaVersion` を schema_meta ベースに
- `migration.test.ts`: 記録 / 冪等 / PRAGMA フォールバックを検証

`make check` 緑 (167 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)