### PR TITLE
feat(crud): team show/remove + game update (編集・掃除・引き継ぎ)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -214,12 +214,21 @@ Hermes は以下を **必ず守ること**:
 | `init` | — | `{ok:true}` (DB を作るだけ) |
 | `team create` | `--name --area` | `Team` |
 | `team list` | — | `Team[]` |
-| `member add` | `--team --name --email? --role?` | `Member` |
+| `team show` | `<id>` | `{team, members, knowledge}` (profile 引き継ぎ用) |
+| `team update` | `<id> --name? --area?` | `Team` |
+| `team remove` | `<id>` | `{ok, id}` (members/games/決め事も CASCADE) |
+| `member add` | `--team --name --email? --role?` | `Member` (name は表示名/ハンドル, 本名不要) |
 | `member list` | `--team` | `Member[]` |
+| `member update` | `--member --name? --email? --role?` | `Member` |
+| `member remove` | `<id>` | `{ok, id}` |
 | `game create` | `--team --title --date? --ground? --min-players? --note?` | `Game (status=DRAFT)` |
 | `game list` | `--team? --status?` | `Game[]` |
 | `game show` | `<id>` | `GameDetail` |
+| `game update` | `<id> --title? --date? --ground? --min-players? --note?` | `Game` |
 | `game transition` | `<id> --to <STATUS>` | `Game (更新後)` |
+| `export` | `--out?` | JSONL (全データ書き出し) |
+| `import` | `--file` | `{imported}` |
+| `config set` | `--db-url? --db-token?` | 接続先を ~/.mound/config.json に保存 |
 | `rsvp set` | `--game --member --response AVAILABLE\|UNAVAILABLE\|MAYBE\|NO_RESPONSE` | `Rsvp` |
 | `rsvp list` | `--game` | `MemberRsvp[]` |
 | `rsvp summary` | `--game --team?` | `RsvpSummary` |
@@ -545,7 +554,7 @@ mound に永続化したいのに「書く場所が無い」情報は、Hermes �
 | --- | --- | --- |
 | ~~チーム単位の自由メモ (チーム規約 / 連絡網 / 来季の方針 等)~~ | **解消済** → `mound knowledge set --category RULE/NOTE` / `mound observe add` | — |
 | ~~メンバー単位の自由メモ (背番号 / ポジション / 連絡時間帯 / 助っ人かレギュラーか 等)~~ | **解消済** → `mound knowledge set --member <ID> --category ROSTER` | — |
-| 既存 game の `note` を後から更新する API | (なし — 新規時のみ。暫定で `mound observe add --kind NOTE` に逃がせる) | 未起票 |
+| ~~既存 game の `note` を後から更新する API~~ | **解消済** → `mound game update <ID> --note ...`(title/date/ground/min-players も編集可) | — |
 | 対戦相手チームの情報 (連絡先 / 過去戦績 / 信頼度) | (なし) | Phase 2 想定 |
 | ~~試合の精算 / 会計~~ | **解消済** → `mound settle`(PayPay 割り勘: 割り勘計算・未払い把握・催促・自動 SETTLED)。PayPay 個人割り勘に公開 API は無いためリンクは人が貼り入金は人が消し込む | — |
 | 自然言語入力の直接受付 (`mound parse "土曜 9 時から練習試合"`) | (なし — Hermes の責務) | 未起票 |

--- a/packages/cli/src/__tests__/usecases/editability.test.ts
+++ b/packages/cli/src/__tests__/usecases/editability.test.ts
@@ -1,8 +1,10 @@
 // チーム/メンバーの編集 (改名・本拠地変更・削除) のテスト。
 import { describe, expect, it } from "vitest";
+import type { GameStatus } from "../../domain/types";
 import type { UseCaseContext } from "../../ports";
+import { updateGame } from "../../usecases/game";
 import { removeMember, updateMember } from "../../usecases/member";
-import { updateTeam } from "../../usecases/team";
+import { removeTeam, showTeam, updateTeam } from "../../usecases/team";
 import { buildFakeContext } from "./memory-fakes";
 
 async function seedTeam(ctx: UseCaseContext): Promise<void> {
@@ -86,6 +88,77 @@ describe("removeMember use case", () => {
         true,
       );
       expect(await removeMember(ctx, "m")).toBe(false);
+    });
+  });
+});
+
+describe("showTeam use case", () => {
+  describe("メンバーと決め事があるとき", () => {
+    it("team + members + knowledge をまとめて返す", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await seedMember(ctx);
+      await ctx.repo.knowledge.insert({
+        id: "k",
+        team_id: "t",
+        member_id: null,
+        category: "PREFERENCE",
+        key: "default_weekday",
+        value: "sat",
+        origin: "HUMAN",
+        confidence: 1,
+        evidence_count: 1,
+        source: null,
+        last_observed_at: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const profile = await showTeam(ctx, "t");
+      expect(profile.team.name).toBe("Xeros");
+      expect(profile.members).toHaveLength(1);
+      expect(profile.knowledge).toHaveLength(1);
+    });
+  });
+});
+
+describe("removeTeam use case", () => {
+  describe("既存チームのとき", () => {
+    it("削除して true を返し監査 TEAM_REMOVED を残す", async () => {
+      const { ctx, stores } = buildFakeContext();
+      await seedTeam(ctx);
+      expect(await removeTeam(ctx, "t")).toBe(true);
+      expect(stores.teams.has("t")).toBe(false);
+      expect(stores.audit.some((l) => l.action === "TEAM_REMOVED")).toBe(true);
+      expect(await removeTeam(ctx, "t")).toBe(false);
+    });
+  });
+});
+
+describe("updateGame use case", () => {
+  describe("既存 game の note と日付を後から更新するとき", () => {
+    it("該当フィールドだけ更新する (AGENTS.md §9 の note 後更新)", async () => {
+      const { ctx } = buildFakeContext();
+      await seedTeam(ctx);
+      await ctx.repo.games.insert({
+        id: "g",
+        team_id: "t",
+        title: "練習試合",
+        status: "DRAFT" as GameStatus,
+        game_date: null,
+        ground_name: null,
+        min_players: 9,
+        note: null,
+        created_at: "x",
+        updated_at: "x",
+      });
+      const updated = await updateGame(ctx, {
+        gameId: "g",
+        date: "2026-06-20",
+        note: "対戦相手は連絡待ち",
+      });
+      expect(updated.game_date).toBe("2026-06-20");
+      expect(updated.note).toBe("対戦相手は連絡待ち");
+      expect(updated.title).toBe("練習試合"); // 未指定は据え置き
     });
   });
 });

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -66,6 +66,7 @@ function buildFake(): Fake {
       teamStore.set(t.id, t);
       return t;
     },
+    remove: async (id) => teamStore.delete(id),
   };
 
   const members: MemberRepository = {
@@ -98,6 +99,10 @@ function buildFake(): Fake {
     updateStatus: async (id, status, updatedAt) => {
       const g = gameStore.get(id);
       if (g) gameStore.set(id, { ...g, status, updated_at: updatedAt });
+    },
+    update: async (g) => {
+      gameStore.set(g.id, g);
+      return g;
     },
   };
 

--- a/packages/cli/src/__tests__/usecases/ground-watch.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-watch.test.ts
@@ -32,6 +32,7 @@ function buildFake(): {
       teams.set(t.id, t);
       return t;
     },
+    remove: async (id) => teams.delete(id),
   };
   const watchRepo: GroundWatchRepository = {
     insert: async (w) => {

--- a/packages/cli/src/__tests__/usecases/memory-fakes.ts
+++ b/packages/cli/src/__tests__/usecases/memory-fakes.ts
@@ -203,6 +203,7 @@ export function buildFakeContext(
         teams.set(t.id, t);
         return t;
       },
+      remove: async (id) => teams.delete(id),
     },
     members: {
       insert: async (m) => {
@@ -233,6 +234,10 @@ export function buildFakeContext(
       updateStatus: async (id, status, updatedAt) => {
         const g = games.get(id);
         if (g) games.set(id, { ...g, status, updated_at: updatedAt });
+      },
+      update: async (g) => {
+        games.set(g.id, g);
+        return g;
       },
     },
     rsvps: {

--- a/packages/cli/src/__tests__/usecases/notification.test.ts
+++ b/packages/cli/src/__tests__/usecases/notification.test.ts
@@ -49,6 +49,7 @@ function buildFake(opts?: { senderError?: Error }): Fake {
       teams.set(t.id, t);
       return t;
     },
+    remove: async (id) => teams.delete(id),
   };
 
   const notificationRepo: NotificationChannelRepository = {

--- a/packages/cli/src/adapters/cli/commands/game.ts
+++ b/packages/cli/src/adapters/cli/commands/game.ts
@@ -7,6 +7,7 @@ import {
   listGames,
   showGame,
   transitionGame,
+  updateGame,
 } from "../../../usecases/game";
 import {
   type ParsedArgs,
@@ -34,19 +35,70 @@ const statusFilterInput = z
   .optional()
   .or(z.literal("").transform(() => undefined));
 
+const updateInput = z.object({
+  title: z.string().min(1).max(120).optional(),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "date は YYYY-MM-DD 形式")
+    .optional(),
+  ground: z.string().max(80).optional(),
+  minPlayers: z.coerce.number().int().min(1).max(30).optional(),
+  note: z.string().max(500).optional(),
+});
+
 export async function runGame(
   args: ParsedArgs,
   ctx: UseCaseContext,
   opts: RenderOptions,
 ): Promise<void> {
   const sub = args.positional[0];
-  if (!sub)
-    throw new UsageError("使い方: mound game <create|list|show|transition>");
+  if (!sub) {
+    throw new UsageError(
+      "使い方: mound game <create|list|show|update|transition>",
+    );
+  }
   if (sub === "create") return create(args, ctx, opts);
   if (sub === "list") return list(args, ctx, opts);
   if (sub === "show") return show(args, ctx, opts);
+  if (sub === "update") return update(args, ctx, opts);
   if (sub === "transition") return transition(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: game ${sub}`);
+}
+
+async function update(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1];
+  if (!id) throw new UsageError("使い方: mound game update <id> [--flags]");
+  const data = parseOrUsage(updateInput, {
+    title: optionalFlag(args.flags, "title"),
+    date: optionalFlag(args.flags, "date"),
+    ground: optionalFlag(args.flags, "ground"),
+    minPlayers: optionalFlag(args.flags, "min-players"),
+    note: optionalFlag(args.flags, "note"),
+  });
+  if (
+    data.title === undefined &&
+    data.date === undefined &&
+    data.ground === undefined &&
+    data.minPlayers === undefined &&
+    data.note === undefined
+  ) {
+    throw new UsageError(
+      "--title / --date / --ground / --min-players / --note のいずれかを指定してください",
+    );
+  }
+  const game = await updateGame(ctx, {
+    gameId: id,
+    title: data.title,
+    date: data.date,
+    ground: data.ground,
+    minPlayers: data.minPlayers,
+    note: data.note,
+  });
+  emit(game, `試合を更新しました: ${game.id} (${game.title})`, opts);
 }
 
 async function create(

--- a/packages/cli/src/adapters/cli/commands/team.ts
+++ b/packages/cli/src/adapters/cli/commands/team.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import type { UseCaseContext } from "../../../ports";
-import { createTeam, listTeams, updateTeam } from "../../../usecases/team";
+import {
+  createTeam,
+  listTeams,
+  removeTeam,
+  showTeam,
+  updateTeam,
+} from "../../../usecases/team";
 import {
   type ParsedArgs,
   UsageError,
@@ -27,11 +33,50 @@ export async function runTeam(
   opts: RenderOptions,
 ): Promise<void> {
   const sub = args.positional[0];
-  if (!sub) throw new UsageError("使い方: mound team <create|list|update>");
+  if (!sub) {
+    throw new UsageError("使い方: mound team <create|list|show|update|remove>");
+  }
   if (sub === "create") return create(args, ctx, opts);
   if (sub === "list") return list(ctx, opts);
+  if (sub === "show") return show(args, ctx, opts);
   if (sub === "update") return update(args, ctx, opts);
+  if (sub === "remove") return remove(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: team ${sub}`);
+}
+
+async function show(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1] ?? requireFlag(args.flags, "team");
+  const profile = await showTeam(ctx, id);
+  emit(
+    profile,
+    [
+      `${profile.team.name} (${profile.team.home_area ?? "本拠地未設定"}) — ${profile.team.id}`,
+      `メンバー ${profile.members.length}人 / 決め事 ${profile.knowledge.length}件`,
+      formatRows(profile.members, ["id", "name", "role"]),
+    ].join("\n"),
+    opts,
+  );
+}
+
+async function remove(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const id = args.positional[1] ?? optionalFlag(args.flags, "team");
+  if (!id) throw new UsageError("使い方: mound team remove <ID>");
+  const removed = await removeTeam(ctx, id);
+  emit(
+    { ok: removed, id },
+    removed
+      ? `チームを削除しました: ${id} (メンバー・試合・決め事も削除)`
+      : `該当するチームが見つかりません: ${id}`,
+    opts,
+  );
 }
 
 async function update(

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -9,7 +9,9 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   config show                                現在の接続設定 (トークンはマスク)
   team create --name <N> [--area <A>]        チームを作成
   team list                                  チーム一覧
+  team show <ID>                             チームの profile (team+members+決め事)
   team update --team <ID> [--name <N>] [--area <A>]   名前/本拠地を編集
+  team remove <ID>                           チーム削除 (members/games/決め事も)
   member add --team <ID> --name <N> [--email <E>] [--role ADMIN|MEMBER]
   member list --team <ID>
   member update --member <ID> [--name <N>] [--email <E>] [--role ADMIN|MEMBER]
@@ -17,6 +19,7 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   game create --team <ID> --title <T> [--date YYYY-MM-DD] [--ground <G>] [--min-players <N>] [--note <NOTE>]
   game list [--team <ID>] [--status DRAFT|COLLECTING|CONFIRMED|...]
   game show <ID>
+  game update <ID> [--title <T>] [--date YYYY-MM-DD] [--ground <G>] [--min-players <N>] [--note <NOTE>]
   game transition <ID> --to COLLECTING|CONFIRMED|COMPLETED|SETTLED|CANCELLED
   rsvp set --game <ID> --member <ID> --response AVAILABLE|UNAVAILABLE|MAYBE
   rsvp list --game <ID>

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -95,6 +95,14 @@ class LibsqlTeamRepository implements TeamRepository {
     });
     return team;
   }
+
+  async remove(id: string): Promise<boolean> {
+    const r = await this.db.execute({
+      sql: "DELETE FROM teams WHERE id = ?",
+      args: [id],
+    });
+    return r.rowsAffected > 0;
+  }
 }
 
 class LibsqlMemberRepository implements MemberRepository {
@@ -219,6 +227,23 @@ class LibsqlGameRepository implements GameRepository {
       sql: "UPDATE games SET status = ?, updated_at = ? WHERE id = ?",
       args: [status, updatedAt, id],
     });
+  }
+
+  async update(game: Game): Promise<Game> {
+    await this.db.execute({
+      sql: `UPDATE games SET title = ?, game_date = ?, ground_name = ?,
+              min_players = ?, note = ?, updated_at = ? WHERE id = ?`,
+      args: [
+        game.title,
+        game.game_date,
+        game.ground_name,
+        game.min_players,
+        game.note,
+        game.updated_at,
+        game.id,
+      ],
+    });
+    return game;
   }
 }
 

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -27,6 +27,7 @@ export interface TeamRepository {
   list(): Promise<Team[]>;
   get(id: string): Promise<Team | null>;
   update(team: Team): Promise<Team>;
+  remove(id: string): Promise<boolean>;
 }
 
 export interface MemberRepository {
@@ -46,6 +47,7 @@ export interface GameRepository {
     status: GameStatus,
     updatedAt: string,
   ): Promise<void>;
+  update(game: Game): Promise<Game>;
 }
 
 export interface RsvpRepository {

--- a/packages/cli/src/usecases/game.ts
+++ b/packages/cli/src/usecases/game.ts
@@ -53,6 +53,43 @@ export async function createGame(
   return game;
 }
 
+export interface UpdateGameInput {
+  gameId: string;
+  // undefined = 変更しない。既存 game の note 後更新もこれで可能 (AGENTS.md §9 解消)。
+  title?: string;
+  date?: string | null;
+  ground?: string | null;
+  minPlayers?: number;
+  note?: string | null;
+}
+
+export async function updateGame(
+  ctx: UseCaseContext,
+  input: UpdateGameInput,
+): Promise<Game> {
+  const game = await ctx.repo.games.get(input.gameId);
+  if (!game) throw new GameNotFoundError(input.gameId);
+  const before = { ...game };
+  const updated: Game = {
+    ...game,
+    title: input.title ?? game.title,
+    game_date: input.date === undefined ? game.game_date : input.date,
+    ground_name: input.ground === undefined ? game.ground_name : input.ground,
+    min_players: input.minPlayers ?? game.min_players,
+    note: input.note === undefined ? game.note : input.note,
+    updated_at: ctx.now().toISOString(),
+  };
+  await ctx.repo.games.update(updated);
+  await writeAuditLog(ctx, {
+    action: "GAME_UPDATED",
+    targetType: "game",
+    targetId: game.id,
+    before,
+    after: updated,
+  });
+  return updated;
+}
+
 export interface ListGamesInput {
   teamId?: string;
   status?: GameStatus;

--- a/packages/cli/src/usecases/team.ts
+++ b/packages/cli/src/usecases/team.ts
@@ -1,4 +1,4 @@
-import type { Team } from "../domain/types";
+import type { Member, Team, TeamKnowledge } from "../domain/types";
 import type { UseCaseContext } from "../ports";
 import { writeAuditLog } from "./audit";
 import { TeamNotFoundError } from "./errors";
@@ -63,4 +63,44 @@ export async function updateTeam(
     after: updated,
   });
   return updated;
+}
+
+// チームのプロフィールを 1 回で取得する (別セッション/別エージェントへの引き継ぎ用)。
+export interface TeamProfile {
+  team: Team;
+  members: Member[];
+  knowledge: TeamKnowledge[];
+}
+
+export async function showTeam(
+  ctx: UseCaseContext,
+  teamId: string,
+): Promise<TeamProfile> {
+  const team = await ctx.repo.teams.get(teamId);
+  if (!team) throw new TeamNotFoundError(teamId);
+  const [members, knowledge] = await Promise.all([
+    ctx.repo.members.list(team.id),
+    ctx.repo.knowledge.list({ teamId: team.id }),
+  ]);
+  return { team, members, knowledge };
+}
+
+// チームを削除する。members / games / rsvps / knowledge / settlements 等は
+// ON DELETE CASCADE で一緒に消える。
+export async function removeTeam(
+  ctx: UseCaseContext,
+  id: string,
+): Promise<boolean> {
+  const team = await ctx.repo.teams.get(id);
+  if (!team) return false;
+  const removed = await ctx.repo.teams.remove(id);
+  if (removed) {
+    await writeAuditLog(ctx, {
+      action: "TEAM_REMOVED",
+      targetType: "team",
+      targetId: id,
+      before: team,
+    });
+  }
+  return removed;
 }


### PR DESCRIPTION
## 概要
ドッグフーディングで運用エージェントが詰まった編集系の穴を埋める。

## 追加コマンド
- `mound team show <ID>` — team + members + knowledge を 1 回で取得 (別セッション/エージェントへの引き継ぎ)
- `mound team remove <ID>` — チーム削除 (members/games/rsvps/knowledge/settlements も CASCADE)
- `mound game update <ID> [--title --date --ground --min-players --note]` — 試合フィールドを後から編集
  (AGENTS.md §9 の「既存 game の note 後更新」を解消)

## 実装
- ports/libsql: `TeamRepository.remove`, `GameRepository.update`
- usecases: `showTeam` / `removeTeam` / `updateGame` (監査つき)
- docs: AGENTS.md §4 早見表 / §9 を更新

`make check` 緑 (170 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `game update` subcommand to modify game properties (title, date, ground, minimum players, and notes)
  * Added `team show` subcommand to view team profiles including members and knowledge
  * Added `team remove` subcommand to delete teams

* **Documentation**
  * Updated command reference guide with new subcommands and expanded operation listings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->