### PR TITLE
fix(ground): ground list が古い/過去/テストデータを出す問題を修正

### DIFF
--- a/packages/cli/src/__tests__/e2e-binary.test.ts
+++ b/packages/cli/src/__tests__/e2e-binary.test.ts
@@ -338,7 +338,8 @@ describe("e2e: CLI を subprocess で起動する Phase 1 シナリオ", () => {
       expect(summary.inserted).toBe(1);
 
       const listR = runMound(
-        ["ground", "list", "--source", "yokohama", "--json"],
+        // --all で日付/鮮度フィルタを外し、取り込んだ固定日付の slot を確実に見る
+        ["ground", "list", "--source", "yokohama", "--all", "--json"],
         env,
       );
       expect(listR.code).toBe(0);

--- a/packages/cli/src/__tests__/usecases/game.test.ts
+++ b/packages/cli/src/__tests__/usecases/game.test.ts
@@ -196,6 +196,7 @@ function buildFake(): Fake {
           (!filter.dateIso || s.date_iso === filter.dateIso),
       ),
     getByKey: async (slotKey) => groundStore.get(slotKey) ?? null,
+    prune: async () => 0,
   };
 
   const notificationStore = new Map<string, NotificationChannel>();

--- a/packages/cli/src/__tests__/usecases/ground-quality.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground-quality.test.ts
@@ -1,0 +1,147 @@
+// ground_slots の鮮度フィルタ / prune / テストデータ除外のテスト。
+// 古い・過去・テスト (動作確認) を既定で出さないことを確かめる。
+import { describe, expect, it } from "vitest";
+import type { GroundSlot } from "../../domain/types";
+import type { UseCaseContext } from "../../ports";
+import {
+  importGroundAvailability,
+  listGroundSlots,
+  pruneGroundSlots,
+} from "../../usecases/ground";
+import { buildFakeContext } from "./memory-fakes";
+
+function slot(over: Partial<GroundSlot>): GroundSlot {
+  return {
+    id: over.slot_key ?? "s",
+    slot_key: over.slot_key ?? "s",
+    source: "yokohama",
+    facility_name: "岡村公園",
+    date_iso: "2026-07-04",
+    date_raw: "x",
+    time_range: "11:00-13:00",
+    status: "空き",
+    raw: "",
+    scraped_at: "x",
+    first_seen_at: "x",
+    ingested_at: "2026-06-03T00:00:00.000Z",
+    ...over,
+  };
+}
+
+async function seed(ctx: UseCaseContext): Promise<void> {
+  // 直近取得・未来日 (= 出すべき)
+  await ctx.repo.groundSlots.upsert(
+    slot({
+      slot_key: "fresh",
+      date_iso: "2026-06-06",
+      ingested_at: "2026-06-03T07:00:00.000Z",
+    }),
+  );
+  // 過去日 (= 隠す)
+  await ctx.repo.groundSlots.upsert(
+    slot({
+      slot_key: "past",
+      date_iso: "2026-05-23",
+      ingested_at: "2026-06-03T07:00:00.000Z",
+    }),
+  );
+  // 古い取得 (= 隠す)
+  await ctx.repo.groundSlots.upsert(
+    slot({
+      slot_key: "stale",
+      date_iso: "2026-07-04",
+      ingested_at: "2026-05-22T11:00:00.000Z",
+    }),
+  );
+  // テストデータ (= 隠す/掃除)
+  await ctx.repo.groundSlots.upsert(
+    slot({
+      slot_key: "test",
+      facility_name: "動作確認球場",
+      ingested_at: "2026-05-22T11:00:00.000Z",
+    }),
+  );
+}
+
+const TODAY = "2026-06-03";
+const FRESH_SINCE = "2026-06-01T00:00:00.000Z"; // 48h 窓相当
+
+describe("listGroundSlots の鮮度/未来フィルタ", () => {
+  describe("今日以降 × 直近取得で絞るとき", () => {
+    it("過去日・古い取得・テストを除外して直近の空きだけ返す", async () => {
+      const { ctx } = buildFakeContext();
+      await seed(ctx);
+      const slots = await listGroundSlots(ctx, {
+        sinceDate: TODAY,
+        ingestedSince: FRESH_SINCE,
+      });
+      expect(slots.map((s) => s.slot_key)).toEqual(["fresh"]);
+    });
+  });
+
+  describe("フィルタ無し (--all 相当) のとき", () => {
+    it("全件返す", async () => {
+      const { ctx } = buildFakeContext();
+      await seed(ctx);
+      const slots = await listGroundSlots(ctx, {});
+      expect(slots).toHaveLength(4);
+    });
+  });
+});
+
+describe("pruneGroundSlots", () => {
+  describe("過去日 + 古い取得 + テストを掃除するとき", () => {
+    it("該当を削除し、直近の空きだけ残る", async () => {
+      const { ctx } = buildFakeContext();
+      await seed(ctx);
+      const deleted = await pruneGroundSlots(ctx, {
+        beforeDate: TODAY,
+        ingestedBefore: FRESH_SINCE,
+      });
+      expect(deleted).toBe(3); // past + stale + test
+      const remaining = await listGroundSlots(ctx, {});
+      expect(remaining.map((s) => s.slot_key)).toEqual(["fresh"]);
+    });
+  });
+});
+
+describe("importGroundAvailability のテストデータ除外", () => {
+  describe("動作確認会場が混ざっているとき", () => {
+    it("取り込まない", async () => {
+      const { ctx } = buildFakeContext();
+      const result = await importGroundAvailability(ctx, {
+        schema_version: 1,
+        scraped_at: "2026-06-03T07:00:00.000Z",
+        regions: [
+          {
+            region: "yokohama",
+            errors: [],
+            records: [
+              {
+                region: "yokohama",
+                facility_name: "岡村公園",
+                date_raw: "x",
+                date_iso: "2026-06-06",
+                time_range: "11:00-13:00",
+                status: "空き",
+                raw: "",
+              },
+              {
+                region: "yokohama",
+                facility_name: "動作確認球場",
+                date_raw: "x",
+                date_iso: "2026-07-01",
+                time_range: "09:00-12:00",
+                status: "",
+                raw: "",
+              },
+            ],
+          },
+        ],
+      });
+      expect(result.total_records).toBe(1); // 動作確認は除外
+      const slots = await listGroundSlots(ctx, {});
+      expect(slots.map((s) => s.facility_name)).toEqual(["岡村公園"]);
+    });
+  });
+});

--- a/packages/cli/src/__tests__/usecases/ground.test.ts
+++ b/packages/cli/src/__tests__/usecases/ground.test.ts
@@ -37,6 +37,7 @@ function fakeRepo(): {
           (!filter.dateIso || s.date_iso === filter.dateIso),
       ),
     getByKey: async (k) => store.get(k) ?? null,
+    prune: async () => 0,
   };
   return { store, repo };
 }

--- a/packages/cli/src/__tests__/usecases/memory-fakes.ts
+++ b/packages/cli/src/__tests__/usecases/memory-fakes.ts
@@ -152,6 +152,7 @@ export function buildFakeContext(
   const members = new Map<string, Member>();
   const games = new Map<string, Game>();
   const rsvps = new Map<string, Rsvp>();
+  const groundSlots = new Map<string, GroundSlot>();
   const audit: AuditLog[] = [];
   const { store: observations, repo: observationRepo } = buildObservationRepo();
   const { store: knowledge, repo: knowledgeRepo } = buildKnowledgeRepo();
@@ -273,10 +274,45 @@ export function buildFakeContext(
         ),
     },
     groundSlots: {
-      upsert: async (s: GroundSlot) => s,
-      list: async () => [],
-      listNewerThan: async () => [],
-      getByKey: async () => null,
+      upsert: async (s) => {
+        groundSlots.set(s.slot_key, s);
+        return s;
+      },
+      list: async (f) =>
+        Array.from(groundSlots.values()).filter(
+          (s) =>
+            (!f.source || s.source === f.source) &&
+            (!f.dateIso || s.date_iso === f.dateIso) &&
+            (!f.sinceDate ||
+              (s.date_iso !== null && s.date_iso >= f.sinceDate)) &&
+            (!f.ingestedSince || s.ingested_at >= f.ingestedSince),
+        ),
+      listNewerThan: async (f) =>
+        Array.from(groundSlots.values()).filter(
+          (s) =>
+            s.first_seen_at >= f.since &&
+            (!f.source || s.source === f.source) &&
+            (!f.dateIso || s.date_iso === f.dateIso),
+        ),
+      getByKey: async (k) =>
+        Array.from(groundSlots.values()).find((s) => s.slot_key === k) ?? null,
+      prune: async (f) => {
+        let n = 0;
+        for (const [k, s] of groundSlots) {
+          const isTest = s.facility_name.includes("動作確認");
+          const isPast =
+            f.beforeDate !== undefined &&
+            s.date_iso !== null &&
+            s.date_iso < f.beforeDate;
+          const isStale =
+            f.ingestedBefore !== undefined && s.ingested_at < f.ingestedBefore;
+          if (isTest || isPast || isStale) {
+            groundSlots.delete(k);
+            n++;
+          }
+        }
+        return n;
+      },
     },
     notifications: {
       insert: async (c: NotificationChannel) => c,

--- a/packages/cli/src/adapters/cli/commands/ground.ts
+++ b/packages/cli/src/adapters/cli/commands/ground.ts
@@ -8,6 +8,7 @@ import {
   findSlotsMatchingGame,
   importGroundAvailability,
   listGroundSlots,
+  pruneGroundSlots,
 } from "../../../usecases/ground";
 import { notifyGroundCancellation } from "../../../usecases/notification";
 import {
@@ -33,6 +34,7 @@ export async function runGround(
   if (sub === "diff") return diffCommand(args, ctx, opts);
   if (sub === "sync") return syncCommand(args, ctx, opts);
   if (sub === "match") return matchCommand(args, ctx, opts);
+  if (sub === "prune") return pruneCommand(args, ctx, opts);
   throw new UsageError(`未知のサブコマンド: ground ${sub}`);
 }
 
@@ -114,25 +116,89 @@ async function importCommand(
   emit(result, text, opts);
 }
 
+const maxAgeHoursInput = z.coerce
+  .number()
+  .int()
+  .min(0)
+  .max(24 * 365);
+
+// 既定の鮮度窓 (時間)。これより古い取得は「もう空いてないかも」なので隠す。
+const DEFAULT_MAX_AGE_HOURS = 48;
+
+function todayIso(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
 async function listCommand(
   args: ParsedArgs,
   ctx: UseCaseContext,
   opts: RenderOptions,
 ): Promise<void> {
+  const showAll = boolFlag(args.flags, "all");
+  const explicitDate = optionalFlag(args.flags, "date");
+  const now = ctx.now();
+
+  // 既定は「今日以降 × 直近 N 時間以内に取得」だけ。--all で全件、--date で特定日。
+  const maxAgeFlag = optionalFlag(args.flags, "max-age-hours");
+  const maxAgeHours = maxAgeFlag
+    ? parseOrUsage(maxAgeHoursInput, maxAgeFlag)
+    : DEFAULT_MAX_AGE_HOURS;
+  const sinceDate = showAll
+    ? undefined
+    : (optionalFlag(args.flags, "since-date") ?? todayIso(now));
+  const ingestedSince =
+    showAll || maxAgeHours === 0
+      ? undefined
+      : new Date(now.getTime() - maxAgeHours * 3_600_000).toISOString();
+
   const slots = await listGroundSlots(ctx, {
     source: optionalFlag(args.flags, "source"),
-    dateIso: optionalFlag(args.flags, "date"),
+    dateIso: explicitDate,
+    sinceDate: explicitDate ? undefined : sinceDate,
+    ingestedSince,
   });
+  const header = showAll
+    ? `${slots.length} 件 (全件)`
+    : `${slots.length} 件 (今日以降 × 直近 ${maxAgeHours}h 取得ぶん。全件は --all)`;
   emit(
     slots,
-    formatRows(slots, [
-      "source",
-      "facility_name",
-      "date_iso",
-      "time_range",
-      "status",
-      "first_seen_at",
-    ]),
+    [
+      header,
+      formatRows(slots, [
+        "source",
+        "facility_name",
+        "date_iso",
+        "time_range",
+        "status",
+        "ingested_at",
+      ]),
+    ].join("\n"),
+    opts,
+  );
+}
+
+async function pruneCommand(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const now = ctx.now();
+  // 既定: 過去日 + テストデータを削除。--max-age-hours で古い取得も対象に。
+  const beforeDate = optionalFlag(args.flags, "before-date") ?? todayIso(now);
+  const maxAgeFlag = optionalFlag(args.flags, "max-age-hours");
+  const ingestedBefore = maxAgeFlag
+    ? new Date(
+        now.getTime() - parseOrUsage(maxAgeHoursInput, maxAgeFlag) * 3_600_000,
+      ).toISOString()
+    : undefined;
+  const deleted = await pruneGroundSlots(ctx, { beforeDate, ingestedBefore });
+  emit(
+    {
+      deleted,
+      before_date: beforeDate,
+      ingested_before: ingestedBefore ?? null,
+    },
+    `古い/過去/テストの空き枠を ${deleted} 件削除しました (${beforeDate} より前の日付・テストデータ${ingestedBefore ? ` + ${maxAgeFlag}h より前の取得` : ""})`,
     opts,
   );
 }

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -28,7 +28,8 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   audit --target <ID> [--type game|team|member]
   agenda [--team <ID>] [--horizon-days N]    いま注意すべき試合 (メニューバー向け)
   ground import [--file PATH | --stdin]      外部スクレイパの JSON を取り込む
-  ground list [--source S] [--date YYYY-MM-DD]
+  ground list [--source S] [--date YYYY-MM-DD] [--all] [--max-age-hours N]  既定=今日以降×直近48h
+  ground prune [--before-date YYYY-MM-DD] [--max-age-hours N]  過去/古い/テストを掃除
   ground diff [--since ISO | --minutes N] [--source S] [--game-date YYYY-MM-DD]
   ground sync [--region R] [--bin PATH] [--timeout-ms N] [--notify --team T]
   ground match --game <GAME_ID>              試合の date+会場に合う空きを列挙
@@ -538,15 +539,37 @@ JSON 出力:
   "ground list": `mound ground list — 取り込み済みの空き枠を表示
 
 使い方:
-  mound ground list [--source <SOURCE>] [--date YYYY-MM-DD] [--json]
+  mound ground list [--source <SOURCE>] [--date YYYY-MM-DD] [--all] [--max-age-hours N] [--since-date YYYY-MM-DD] [--json]
+
+既定の絞り込み (古い/過去のゴミを出さないため):
+  - 今日以降の日付 (date_iso >= today) のみ
+  - 直近 48h 以内に取得 (ingested_at) した枠のみ
+  → cron で定期 sync していれば「いま本当に空いている枠」だけが出る。
 
 フラグ:
-  --source  (任意) スクレイパ source ID (yokohama, kanagawa, ...)
-  --date    (任意) 日付 (YYYY-MM-DD) で絞り込み
+  --source         (任意) スクレイパ source ID (yokohama, kanagawa, ...)
+  --date           (任意) 特定日 (YYYY-MM-DD) だけ
+  --all            (任意) 既定フィルタを外して全件
+  --max-age-hours  (任意) 鮮度窓を時間で変更 (既定 48, 0=無制限)
+  --since-date     (任意) この日以降に変更 (既定 today)
 
 JSON 出力:
   GroundSlot[] { id, slot_key, source, facility_name, date_iso, date_raw,
                  time_range, status, raw, scraped_at, first_seen_at, ingested_at }
+`,
+
+  "ground prune": `mound ground prune — 古い/過去/テストの空き枠を物理削除
+
+使い方:
+  mound ground prune [--before-date YYYY-MM-DD] [--max-age-hours N] [--json]
+
+削除対象 (いずれかに該当):
+  - テストデータ (facility_name に「動作確認」を含む) ← 常に削除
+  - --before-date より前の日付 (既定: today)
+  - --max-age-hours より前に取得した枠 (指定時のみ)
+
+JSON 出力:
+  { "deleted": number, "before_date": string, "ingested_before": string|null }
 `,
 
   notify: `mound notify — Discord / Slack / LINE への通知チャネル

--- a/packages/cli/src/adapters/libsql/repositories.ts
+++ b/packages/cli/src/adapters/libsql/repositories.ts
@@ -25,6 +25,7 @@ import type {
   GameRepository,
   GroundSlotDiffFilter,
   GroundSlotFilter,
+  GroundSlotPruneFilter,
   GroundSlotRepository,
   GroundWatchRepository,
   KnowledgeFilter,
@@ -437,11 +438,39 @@ class LibsqlGroundSlotRepository implements GroundSlotRepository {
       where.push("date_iso = ?");
       args.push(filter.dateIso);
     }
+    if (filter.sinceDate) {
+      // date_iso が null の枠は日付フィルタ時は除外する。
+      where.push("date_iso IS NOT NULL AND date_iso >= ?");
+      args.push(filter.sinceDate);
+    }
+    if (filter.ingestedSince) {
+      where.push("ingested_at >= ?");
+      args.push(filter.ingestedSince);
+    }
     const sql = `SELECT * FROM ground_slots${
       where.length ? ` WHERE ${where.join(" AND ")}` : ""
     } ORDER BY date_iso ASC, time_range ASC, facility_name ASC`;
     const r = await this.db.execute({ sql, args });
     return r.rows.map(rowToGroundSlot);
+  }
+
+  async prune(filter: GroundSlotPruneFilter): Promise<number> {
+    // 過去日 OR 古い取得 OR テストデータ (動作確認) を削除する。
+    const or: string[] = ["facility_name LIKE '%動作確認%'"];
+    const args: InValue[] = [];
+    if (filter.beforeDate) {
+      or.push("(date_iso IS NOT NULL AND date_iso < ?)");
+      args.push(filter.beforeDate);
+    }
+    if (filter.ingestedBefore) {
+      or.push("ingested_at < ?");
+      args.push(filter.ingestedBefore);
+    }
+    const r = await this.db.execute({
+      sql: `DELETE FROM ground_slots WHERE ${or.join(" OR ")}`,
+      args,
+    });
+    return r.rowsAffected;
   }
 
   async getByKey(slotKey: string): Promise<GroundSlot | null> {

--- a/packages/cli/src/ports.ts
+++ b/packages/cli/src/ports.ts
@@ -66,6 +66,14 @@ export interface AuditRepository {
 export interface GroundSlotFilter {
   source?: string;
   dateIso?: string;
+  sinceDate?: string; // date_iso >= この日 (YYYY-MM-DD)。過去日を除外する用。
+  ingestedSince?: string; // ingested_at >= この時刻 (ISO)。古い取得を除外する用。
+}
+
+// 古い/過去/テストの slot を物理削除する条件。
+export interface GroundSlotPruneFilter {
+  beforeDate?: string; // date_iso < この日 を削除
+  ingestedBefore?: string; // ingested_at < この時刻 を削除
 }
 
 export interface GroundSlotDiffFilter extends GroundSlotFilter {
@@ -79,6 +87,8 @@ export interface GroundSlotRepository {
   list(filter: GroundSlotFilter): Promise<GroundSlot[]>;
   listNewerThan(filter: GroundSlotDiffFilter): Promise<GroundSlot[]>;
   getByKey(slotKey: string): Promise<GroundSlot | null>;
+  // 過去日 / 古い取得 / テストデータ (動作確認) を削除し、削除件数を返す。
+  prune(filter: GroundSlotPruneFilter): Promise<number>;
 }
 
 export interface GroundWatchRepository {

--- a/packages/cli/src/usecases/ground.ts
+++ b/packages/cli/src/usecases/ground.ts
@@ -3,8 +3,12 @@ import type { Game, GroundSlot } from "../domain/types";
 import type {
   GroundSlotDiffFilter,
   GroundSlotFilter,
+  GroundSlotPruneFilter,
   UseCaseContext,
 } from "../ports";
+
+// スクレイパが健全性チェックで出すダミー会場。実空きではないので取り込まない/掃除する。
+export const TEST_FACILITY_MARKER = "動作確認";
 
 // ground-reservation (susumutomita/ground-reservation) の `--json` 出力 schema。
 // 破壊的変更が必要になったら schema_version を上げる。
@@ -69,6 +73,8 @@ export async function importGroundAvailability(
       regionsWithErrors.push({ region: region.region, errors: region.errors });
     }
     for (const rec of region.records) {
+      // テスト用ダミー会場 (動作確認…) は取り込まない。
+      if (rec.facility_name.includes(TEST_FACILITY_MARKER)) continue;
       total += 1;
       const slotKey = makeSlotKey(
         rec.region,
@@ -115,6 +121,14 @@ export async function listGroundSlots(
   filter: GroundSlotFilter,
 ): Promise<GroundSlot[]> {
   return ctx.repo.groundSlots.list(filter);
+}
+
+// 過去日 / 古い取得 / テストデータを物理削除して、削除件数を返す。
+export async function pruneGroundSlots(
+  ctx: UseCaseContext,
+  filter: GroundSlotPruneFilter,
+): Promise<number> {
+  return ctx.repo.groundSlots.prune(filter);
 }
 
 // 「直近キャンセル候補」を返す: first_seen_at >= since の slot を抽出する。


### PR DESCRIPTION
## 問題
`mound ground list` が 2 週間前のキャッシュ・**過去日付**・**テスト会場(動作確認球場)** まで全部出していて、実運用で使い物にならなかった。

## 修正
- **`ground list` は既定で「今日以降 × 直近 48h 取得」だけ**表示(`--all` で全件、`--max-age-hours`/`--since-date` で調整)。cron で定期 sync していれば「いま本当に空いている枠」だけが出る。
- **取り込み時にテスト会場(`動作確認`)を捨てる**。
- **`ground prune`** 追加:過去日 / 古い取得 / テストデータを物理削除。

## 実装
- ports: `GroundSlotFilter` に `sinceDate`/`ingestedSince`、`prune()`
- usecases/ground: import 時のテスト除外、`pruneGroundSlots`
- libsql: list の鮮度/未来フィルタ、prune の DELETE
- test: `ground-quality.test.ts`、e2e は `--all` で roundtrip 検証

`make check` 緑 (179 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)