### PR TITLE
feat(view): mound view — 状態の構造化スナップショット (動的 UI の土台)

### DIFF
--- a/packages/cli/src/__tests__/usecases/dashboard.test.ts
+++ b/packages/cli/src/__tests__/usecases/dashboard.test.ts
@@ -1,0 +1,80 @@
+// view (ダッシュボード) のデータ集計テスト。UI 生成の土台が正しく集まるか。
+import { describe, expect, it } from "vitest";
+import type { UseCaseContext } from "../../ports";
+import { buildDashboard } from "../../usecases/dashboard";
+import { buildFakeContext } from "./memory-fakes";
+
+async function seed(ctx: UseCaseContext): Promise<void> {
+  await ctx.repo.teams.insert({
+    id: "t",
+    name: "Xeros",
+    home_area: "横浜",
+    created_at: "x",
+    updated_at: "x",
+  });
+  await ctx.repo.members.insert({
+    id: "m1",
+    team_id: "t",
+    name: "トミー",
+    email: null,
+    role: "MEMBER",
+    created_at: "x",
+    updated_at: "x",
+  });
+  await ctx.repo.games.insert({
+    id: "g",
+    team_id: "t",
+    title: "練習試合",
+    status: "COLLECTING",
+    game_date: "2026-06-06",
+    ground_name: "岡村公園",
+    ground_status: "SECURED",
+    min_players: 9,
+    note: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+  // CANCELLED は出さない
+  await ctx.repo.games.insert({
+    id: "x",
+    team_id: "t",
+    title: "中止試合",
+    status: "CANCELLED",
+    game_date: "2026-06-07",
+    ground_name: null,
+    ground_status: null,
+    min_players: 9,
+    note: null,
+    created_at: "x",
+    updated_at: "x",
+  });
+}
+
+describe("buildDashboard use case", () => {
+  describe("進行中の試合があるとき", () => {
+    it("team / agenda / games(出欠込み) / 空き / 決め事を 1 度に集める", async () => {
+      const { ctx } = buildFakeContext("2026-06-03T09:00:00.000Z");
+      await seed(ctx);
+      const d = await buildDashboard(ctx, { teamId: "t", horizonDays: 14 });
+
+      expect(d.team.name).toBe("Xeros");
+      expect(d.agenda).toBeDefined();
+      // CANCELLED は除外、COLLECTING の練習試合だけ
+      expect(d.games).toHaveLength(1);
+      const g = d.games[0];
+      expect(g?.game.title).toBe("練習試合");
+      expect(g?.game.ground_status).toBe("SECURED");
+      expect(g?.no_response).toBe(1); // トミー未回答
+      expect(g?.shortage).toBe(9); // 参加可 0 / min 9
+    });
+  });
+
+  describe("チームが存在しないとき", () => {
+    it("TeamNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await expect(
+        buildDashboard(ctx, { teamId: "nope", horizonDays: 14 }),
+      ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+});

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -41,6 +41,7 @@ import { runObserve } from "./commands/observe";
 import { runRsvp } from "./commands/rsvp";
 import { runSettle } from "./commands/settle";
 import { runTeam } from "./commands/team";
+import { runView } from "./commands/view";
 import { runWatch } from "./commands/watch";
 import { composeContext } from "./compose";
 import { HELP, VERSION, findCommandHelp } from "./help";
@@ -142,6 +143,9 @@ export async function run(options: RunOptions): Promise<number> {
         return 0;
       case "knowledge":
         await runKnowledge(subArgs, ctx, renderOpts);
+        return 0;
+      case "view":
+        await runView(subArgs, ctx, renderOpts);
         return 0;
       case "learn":
         await runLearn(subArgs, ctx, renderOpts);

--- a/packages/cli/src/adapters/cli/commands/view.ts
+++ b/packages/cli/src/adapters/cli/commands/view.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import type { UseCaseContext } from "../../../ports";
+import { buildDashboard } from "../../../usecases/dashboard";
+import { type ParsedArgs, optionalFlag, requireFlag } from "../args";
+import { type RenderOptions, emit } from "../output";
+import { parseOrUsage } from "../zod-helper";
+
+const horizonInput = z.coerce.number().int().min(0).max(365).default(14);
+
+// mound view — 今のチーム状態を 1 コマンドで構造化スナップショットする。
+// 固定 UI は持たない: これはデータ供給。UI(HTML 等)はエージェントがこの JSON から
+// 「今の関心事」だけに絞って動的生成する想定 (--json を使うこと)。
+export async function runView(
+  args: ParsedArgs,
+  ctx: UseCaseContext,
+  opts: RenderOptions,
+): Promise<void> {
+  const teamId = requireFlag(args.flags, "team");
+  const horizonDays = parseOrUsage(
+    horizonInput,
+    optionalFlag(args.flags, "horizon-days"),
+  );
+  const dashboard = await buildDashboard(ctx, { teamId, horizonDays });
+
+  const a = dashboard.agenda;
+  const text = [
+    `${dashboard.team.name} (${dashboard.team.home_area ?? "本拠地未設定"}) — ${dashboard.generated_at.slice(0, 16)}`,
+    `今やること: 公開待ち ${a.needs_publish.length} / 出欠集め ${a.collecting.length} / 直近 ${a.upcoming.length} / 要完了 ${a.needs_completion.length} / 要精算 ${a.needs_settlement.length}`,
+    `試合 ${dashboard.games.length} 件 / 実行時点以降の空き ${dashboard.ground_slots.length} 件 / 決め事 ${dashboard.knowledge.length} 件`,
+    "(UI は --json を取ってエージェントが動的生成する)",
+  ].join("\n");
+  emit(dashboard, text, opts);
+}

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -27,6 +27,7 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   rsvp summary --game <ID>
   audit --target <ID> [--type game|team|member]
   agenda [--team <ID>] [--horizon-days N]    いま注意すべき試合 (メニューバー向け)
+  view --team <ID> [--horizon-days N] --json  今の状態を 1 コマンドで構造化スナップショット (UI 生成の土台)
   ground import [--file PATH | --stdin]      外部スクレイパの JSON を取り込む
   ground list [--source S] [--date YYYY-MM-DD] [--all]  既定=実行時点以降の空き
   ground prune [--before-date YYYY-MM-DD] [--max-age-hours N]  過去/古い/テストを掃除
@@ -888,6 +889,29 @@ JSONL の各行:
 
 JSON 出力:
   { "imported": number }
+`,
+
+  view: `mound view — 今のチーム状態を 1 コマンドで構造化スナップショット
+
+使い方:
+  mound view --team <TEAM_ID> [--horizon-days N] [--json]
+
+狙い:
+  固定 UI は持たない (デザインに縛られない)。これは「今の関心事」を判断するための
+  データ供給。エージェントが --json を取り、現状に合わせて UI (HTML 等) を動的生成する。
+  SPEC の「UI が文脈に合わせて変わる / 今やるべきことだけ表示」を、テンプレではなく
+  AI 生成で実現するための土台。
+
+JSON 出力:
+  {
+    "team": Team,
+    "generated_at": ISO8601,
+    "horizon_days": number,
+    "agenda": Agenda,
+    "games": [{ game, rsvp, available, unavailable, maybe, no_response, shortage, settlement }],
+    "ground_slots": GroundSlot[],   // 実行時点以降
+    "knowledge": TeamKnowledge[]
+  }
 `,
 
   agenda: `mound agenda — いま注意すべき試合 (メニューバー向け)

--- a/packages/cli/src/usecases/dashboard.ts
+++ b/packages/cli/src/usecases/dashboard.ts
@@ -1,0 +1,96 @@
+// ビューアー(HTML ダッシュボード)用のデータ集計。
+// 「トモがスマホで今の状況をパッと見る」ためのスナップショット。既存 usecase を再利用。
+import type {
+  Game,
+  GroundSlot,
+  RsvpBreakdown,
+  Team,
+  TeamKnowledge,
+} from "../domain/types";
+import type { UseCaseContext } from "../ports";
+import { type Agenda, computeAgenda } from "./agenda";
+import { TeamNotFoundError } from "./errors";
+import { listGroundSlots } from "./ground";
+import { listKnowledge } from "./knowledge";
+import { type SettlementView, getSettlement } from "./settlement";
+
+export interface DashboardGame {
+  game: Game;
+  rsvp: RsvpBreakdown;
+  available: number;
+  unavailable: number;
+  maybe: number;
+  no_response: number;
+  shortage: number; // 成立まであと何人 (min_players - available, 0 以上)
+  settlement: SettlementView | null;
+}
+
+export interface Dashboard {
+  team: Team;
+  generated_at: string;
+  horizon_days: number;
+  agenda: Agenda;
+  games: DashboardGame[]; // 進行中の試合 (CANCELLED/SETTLED 以外) を日付順
+  ground_slots: GroundSlot[]; // 実行時点以降の空き
+  knowledge: TeamKnowledge[];
+}
+
+export interface BuildDashboardInput {
+  teamId: string;
+  horizonDays: number;
+}
+
+export async function buildDashboard(
+  ctx: UseCaseContext,
+  input: BuildDashboardInput,
+): Promise<Dashboard> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+
+  const agenda = await computeAgenda(ctx, {
+    teamId: team.id,
+    horizonDays: input.horizonDays,
+  });
+
+  const all = await ctx.repo.games.list({ teamId: team.id });
+  const active = all.filter(
+    (g) => g.status !== "CANCELLED" && g.status !== "SETTLED",
+  );
+  active.sort((a, b) =>
+    (a.game_date ?? "9999").localeCompare(b.game_date ?? "9999"),
+  );
+
+  const games: DashboardGame[] = [];
+  for (const game of active) {
+    const rsvp = await ctx.repo.rsvps.breakdown(game.id, game.team_id);
+    const available = rsvp.available.length;
+    const settlement =
+      game.status === "COMPLETED" ? await getSettlement(ctx, game.id) : null;
+    games.push({
+      game,
+      rsvp,
+      available,
+      unavailable: rsvp.unavailable.length,
+      maybe: rsvp.maybe.length,
+      no_response: rsvp.no_response.length,
+      shortage: Math.max(0, game.min_players - available),
+      settlement,
+    });
+  }
+
+  const today = ctx.now().toISOString().slice(0, 10);
+  const [groundSlots, knowledge] = await Promise.all([
+    listGroundSlots(ctx, { sinceDate: today }),
+    listKnowledge(ctx, { teamId: team.id }),
+  ]);
+
+  return {
+    team,
+    generated_at: ctx.now().toISOString(),
+    horizon_days: input.horizonDays,
+    agenda,
+    games,
+    ground_slots: groundSlots,
+    knowledge,
+  };
+}


### PR DESCRIPTION
## 概要
固定 UI テンプレに縛られず、**エージェントが「今の関心事」だけの UI を動的生成**するための**データ供給**コマンド。`mound view --team T --json` で team / agenda / 試合(出欠込み)/ 実行時点以降の空き / 決め事を 1 度に集約。

mound = 決定的データ、エージェント = 動的 UI、という分担。SPEC の「UI が文脈に合わせて変わる / 今やるべきことだけ表示」を AI 生成で実現する土台。

- `usecases/dashboard.ts`: `buildDashboard`(既存 usecase を再利用、ports/スキーマ非変更)
- `mound view --team [--horizon-days] --json`

`make check` 緑 (181 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)