### PR TITLE
feat(view): mound view --member — 各自の関心事だけ (必要十分)

### DIFF
--- a/packages/cli/src/__tests__/usecases/dashboard.test.ts
+++ b/packages/cli/src/__tests__/usecases/dashboard.test.ts
@@ -1,7 +1,7 @@
 // view (ダッシュボード) のデータ集計テスト。UI 生成の土台が正しく集まるか。
 import { describe, expect, it } from "vitest";
 import type { UseCaseContext } from "../../ports";
-import { buildDashboard } from "../../usecases/dashboard";
+import { buildDashboard, buildMemberView } from "../../usecases/dashboard";
 import { buildFakeContext } from "./memory-fakes";
 
 async function seed(ctx: UseCaseContext): Promise<void> {
@@ -75,6 +75,49 @@ describe("buildDashboard use case", () => {
       await expect(
         buildDashboard(ctx, { teamId: "nope", horizonDays: 14 }),
       ).rejects.toThrow(/team が存在しません/);
+    });
+  });
+});
+
+describe("buildMemberView use case", () => {
+  describe("出欠未回答の COLLECTING があるとき", () => {
+    it("そのメンバーの『要回答』に出る", async () => {
+      const { ctx } = buildFakeContext("2026-06-03T09:00:00.000Z");
+      await seed(ctx); // g = COLLECTING 6/6, トミー未回答
+      const v = await buildMemberView(ctx, { teamId: "t", memberId: "m1" });
+      expect(v.member.name).toBe("トミー");
+      expect(v.needs_response.map((g) => g.id)).toEqual(["g"]);
+      expect(v.upcoming).toHaveLength(0);
+      expect(v.dues).toHaveLength(0);
+    });
+  });
+
+  describe("AVAILABLE で回答したとき", () => {
+    it("要回答から消え、参加予定に入る", async () => {
+      const { ctx } = buildFakeContext("2026-06-03T09:00:00.000Z");
+      await seed(ctx);
+      await ctx.repo.rsvps.upsert({
+        id: "r",
+        game_id: "g",
+        member_id: "m1",
+        response: "AVAILABLE",
+        responded_at: "x",
+        created_at: "x",
+        updated_at: "x",
+      });
+      const v = await buildMemberView(ctx, { teamId: "t", memberId: "m1" });
+      expect(v.needs_response).toHaveLength(0);
+      expect(v.upcoming.map((u) => u.game.id)).toEqual(["g"]);
+    });
+  });
+
+  describe("別チームのメンバー ID のとき", () => {
+    it("MemberNotFoundError を投げる", async () => {
+      const { ctx } = buildFakeContext();
+      await seed(ctx);
+      await expect(
+        buildMemberView(ctx, { teamId: "t", memberId: "ghost" }),
+      ).rejects.toThrow(/member が存在しません/);
     });
   });
 });

--- a/packages/cli/src/adapters/cli/commands/view.ts
+++ b/packages/cli/src/adapters/cli/commands/view.ts
@@ -1,27 +1,40 @@
 import { z } from "zod";
 import type { UseCaseContext } from "../../../ports";
-import { buildDashboard } from "../../../usecases/dashboard";
+import { buildDashboard, buildMemberView } from "../../../usecases/dashboard";
 import { type ParsedArgs, optionalFlag, requireFlag } from "../args";
 import { type RenderOptions, emit } from "../output";
 import { parseOrUsage } from "../zod-helper";
 
 const horizonInput = z.coerce.number().int().min(0).max(365).default(14);
 
-// mound view — 今のチーム状態を 1 コマンドで構造化スナップショットする。
-// 固定 UI は持たない: これはデータ供給。UI(HTML 等)はエージェントがこの JSON から
-// 「今の関心事」だけに絞って動的生成する想定 (--json を使うこと)。
+// mound view — 今の状態を 1 コマンドで構造化スナップショットする。固定 UI は持たない。
+// UI はエージェントがこの JSON から「今の関心事」だけに絞って動的生成する (--json)。
+//   --member 無し: 代表/全体ビュー (管理の関心事)
+//   --member M  : そのメンバー個人ビュー (自分の出欠・予定・支払いだけ。必要十分)
 export async function runView(
   args: ParsedArgs,
   ctx: UseCaseContext,
   opts: RenderOptions,
 ): Promise<void> {
   const teamId = requireFlag(args.flags, "team");
+  const memberId = optionalFlag(args.flags, "member");
+
+  if (memberId) {
+    const v = await buildMemberView(ctx, { teamId, memberId });
+    const text = [
+      `${v.member.name} の関心事 — ${v.generated_at.slice(0, 16)}`,
+      `要回答 ${v.needs_response.length} / 参加予定 ${v.upcoming.length} / 未払い ${v.dues.length}`,
+      "(UI は --json を取ってエージェントが各自向けに動的生成する)",
+    ].join("\n");
+    emit(v, text, opts);
+    return;
+  }
+
   const horizonDays = parseOrUsage(
     horizonInput,
     optionalFlag(args.flags, "horizon-days"),
   );
   const dashboard = await buildDashboard(ctx, { teamId, horizonDays });
-
   const a = dashboard.agenda;
   const text = [
     `${dashboard.team.name} (${dashboard.team.home_area ?? "本拠地未設定"}) — ${dashboard.generated_at.slice(0, 16)}`,

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -27,7 +27,7 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   rsvp summary --game <ID>
   audit --target <ID> [--type game|team|member]
   agenda [--team <ID>] [--horizon-days N]    いま注意すべき試合 (メニューバー向け)
-  view --team <ID> [--horizon-days N] --json  今の状態を 1 コマンドで構造化スナップショット (UI 生成の土台)
+  view --team <ID> [--member <ID>] [--horizon-days N] --json  状態スナップショット (--member で個人の関心事だけ)
   ground import [--file PATH | --stdin]      外部スクレイパの JSON を取り込む
   ground list [--source S] [--date YYYY-MM-DD] [--all]  既定=実行時点以降の空き
   ground prune [--before-date YYYY-MM-DD] [--max-age-hours N]  過去/古い/テストを掃除
@@ -902,15 +902,21 @@ JSON 出力:
   SPEC の「UI が文脈に合わせて変わる / 今やるべきことだけ表示」を、テンプレではなく
   AI 生成で実現するための土台。
 
-JSON 出力:
+JSON 出力 (--member 無し = 代表/全体ビュー):
   {
-    "team": Team,
-    "generated_at": ISO8601,
-    "horizon_days": number,
+    "team": Team, "generated_at": ISO8601, "horizon_days": number,
     "agenda": Agenda,
     "games": [{ game, rsvp, available, unavailable, maybe, no_response, shortage, settlement }],
     "ground_slots": GroundSlot[],   // 実行時点以降
     "knowledge": TeamKnowledge[]
+  }
+
+JSON 出力 (--member M = その人の関心事だけ。必要十分):
+  {
+    "team": Team, "member": Member, "generated_at": ISO8601,
+    "needs_response": Game[],   // 出欠まだ (要アクション)
+    "upcoming": [{ game, my_response }],   // 参加予定
+    "dues": [{ game, amount, payment_link, payment_label }]   // 自分の未払い精算
   }
 `,
 

--- a/packages/cli/src/usecases/dashboard.ts
+++ b/packages/cli/src/usecases/dashboard.ts
@@ -3,13 +3,15 @@
 import type {
   Game,
   GroundSlot,
+  Member,
   RsvpBreakdown,
+  RsvpResponse,
   Team,
   TeamKnowledge,
 } from "../domain/types";
 import type { UseCaseContext } from "../ports";
 import { type Agenda, computeAgenda } from "./agenda";
-import { TeamNotFoundError } from "./errors";
+import { MemberNotFoundError, TeamNotFoundError } from "./errors";
 import { listGroundSlots } from "./ground";
 import { listKnowledge } from "./knowledge";
 import { type SettlementView, getSettlement } from "./settlement";
@@ -92,5 +94,91 @@ export async function buildDashboard(
     games,
     ground_slots: groundSlots,
     knowledge,
+  };
+}
+
+// === メンバー個人ビュー: その人の関心事だけ (必要十分) ===
+// 代表は全体管理、メンバーは「自分の出欠・予定・支払い」だけ見たい。
+export interface MemberDue {
+  game: Game;
+  amount: number;
+  payment_link: string | null;
+  payment_label: string | null;
+}
+
+export interface MemberView {
+  team: Team;
+  member: Member;
+  generated_at: string;
+  needs_response: Game[]; // 出欠未回答/未定の試合 (要アクション)
+  upcoming: { game: Game; my_response: RsvpResponse }[]; // 参加予定 (自分が AVAILABLE)
+  dues: MemberDue[]; // 自分の未払い精算
+}
+
+export async function buildMemberView(
+  ctx: UseCaseContext,
+  input: { teamId: string; memberId: string },
+): Promise<MemberView> {
+  const team = await ctx.repo.teams.get(input.teamId);
+  if (!team) throw new TeamNotFoundError(input.teamId);
+  const member = await ctx.repo.members.get(input.memberId);
+  if (!member || member.team_id !== team.id) {
+    throw new MemberNotFoundError(input.memberId);
+  }
+
+  const today = ctx.now().toISOString().slice(0, 10);
+  const games = await ctx.repo.games.list({ teamId: team.id });
+
+  const needsResponse: Game[] = [];
+  const upcoming: { game: Game; my_response: RsvpResponse }[] = [];
+  const dues: MemberDue[] = [];
+
+  for (const game of games) {
+    const future = !game.game_date || game.game_date >= today;
+    const mine = (await ctx.repo.rsvps.list(game.id)).find(
+      (r) => r.member_id === member.id,
+    );
+    const resp: RsvpResponse = mine?.response ?? "NO_RESPONSE";
+
+    if (
+      game.status === "COLLECTING" &&
+      future &&
+      (resp === "NO_RESPONSE" || resp === "MAYBE")
+    ) {
+      needsResponse.push(game);
+    }
+    if (
+      future &&
+      resp === "AVAILABLE" &&
+      (game.status === "COLLECTING" || game.status === "CONFIRMED")
+    ) {
+      upcoming.push({ game, my_response: resp });
+    }
+    if (game.status === "COMPLETED") {
+      const view = await getSettlement(ctx, game.id);
+      const share = view?.shares.find((s) => s.member_id === member.id);
+      if (share && !share.paid) {
+        dues.push({
+          game,
+          amount: share.amount,
+          payment_link: view?.settlement.payment_link ?? null,
+          payment_label: view?.settlement.payment_label ?? null,
+        });
+      }
+    }
+  }
+
+  const byDate = (a: Game, b: Game) =>
+    (a.game_date ?? "9999").localeCompare(b.game_date ?? "9999");
+  needsResponse.sort(byDate);
+  upcoming.sort((a, b) => byDate(a.game, b.game));
+
+  return {
+    team,
+    member,
+    generated_at: ctx.now().toISOString(),
+    needs_response: needsResponse,
+    upcoming,
+    dues,
   };
 }


### PR DESCRIPTION
## 概要
役割で関心事が違う。代表は全体管理、メンバーは「自分の出欠・予定・支払い」だけ。`mound view --member M` でその人の個人ビューを返す:
- `needs_response`: 出欠未回答/未定(要アクション)
- `upcoming`: 参加予定(自分が AVAILABLE)
- `dues`: 自分の未払い精算(PayPay リンク付き)

ロスター管理・抽選・精算全体は出さない = **過不足なく**。UI はこの JSON からエージェントが各自向けに動的生成する(SPEC「相手に合わせる / 必要十分な情報だけ」)。

- `usecases/dashboard.ts`: `buildMemberView`(既存 repo 再利用、ports/スキーマ非変更)
- `mound view --team --member`

`make check` 緑 (184 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)