### PR TITLE
feat(cli): --output text|json|tsv|csv (AWS CLI 風)

### DIFF
--- a/packages/cli/src/__tests__/adapters/cli/output.test.ts
+++ b/packages/cli/src/__tests__/adapters/cli/output.test.ts
@@ -1,0 +1,86 @@
+// --output text|json|tsv|csv の整形テスト。
+import { describe, expect, it } from "vitest";
+import {
+  type OutputSink,
+  type RenderOptions,
+  emit,
+  renderDelimited,
+} from "../../../adapters/cli/output";
+
+function capture(): { sink: OutputSink; out: () => string } {
+  const lines: string[] = [];
+  return {
+    sink: {
+      write: (l) => {
+        lines.push(l);
+      },
+    },
+    out: () => lines.join(""),
+  };
+}
+
+const opts = (
+  format: RenderOptions["format"],
+  sink: OutputSink,
+): RenderOptions => ({
+  format,
+  json: format === "json",
+  sink,
+});
+
+describe("renderDelimited", () => {
+  describe("オブジェクト配列を tsv にするとき", () => {
+    it("先頭レコードのキーをヘッダにし、タブ区切りで並べる", () => {
+      const rows = [
+        { id: "g1", title: "練習", n: 9 },
+        { id: "g2", title: "本番", n: 12 },
+      ];
+      expect(renderDelimited(rows, "\t")).toBe(
+        ["id\ttitle\tn", "g1\t練習\t9", "g2\t本番\t12"].join("\n"),
+      );
+    });
+  });
+
+  describe("csv でカンマ/引用符を含むとき", () => {
+    it("RFC4180 風に quote/エスケープする", () => {
+      const rows = [{ name: "a,b", note: 'he said "hi"' }];
+      expect(renderDelimited(rows, ",")).toBe(
+        ["name,note", '"a,b","he said ""hi"""'].join("\n"),
+      );
+    });
+  });
+
+  describe("ネストした値とスカラーのとき", () => {
+    it("セルは JSON 文字列に、スカラーは value 列になる", () => {
+      expect(renderDelimited([{ a: { x: 1 }, b: null }], "\t")).toBe(
+        ["a\tb", '{"x":1}\t'].join("\n"),
+      );
+      expect(renderDelimited(42, "\t")).toBe(["value", "42"].join("\n"));
+    });
+  });
+
+  describe("空配列のとき", () => {
+    it("空文字を返す", () => {
+      expect(renderDelimited([], ",")).toBe("");
+    });
+  });
+});
+
+describe("emit の format 切替", () => {
+  const value = [{ id: "x", v: 1 }];
+  it("text は渡したテキストをそのまま出す", () => {
+    const c = capture();
+    emit(value, "ヒト向けテキスト", opts("text", c.sink));
+    expect(c.out()).toBe("ヒト向けテキスト");
+  });
+  it("json は JSON を出す", () => {
+    const c = capture();
+    emit(value, "x", opts("json", c.sink));
+    expect(c.out()).toBe(JSON.stringify(value));
+  });
+  it("csv は表を出す", () => {
+    const c = capture();
+    emit(value, "x", opts("csv", c.sink));
+    expect(c.out()).toBe(["id,v", "x,1"].join("\n"));
+  });
+});

--- a/packages/cli/src/adapters/cli/cli.ts
+++ b/packages/cli/src/adapters/cli/cli.ts
@@ -4,7 +4,13 @@ import {
   ensureSchemaUpToDate,
   openDb,
 } from "../libsql/client";
-import { type ParsedArgs, UsageError, boolFlag, parseArgs } from "./args";
+import {
+  type ParsedArgs,
+  UsageError,
+  boolFlag,
+  optionalFlag,
+  parseArgs,
+} from "./args";
 
 const USER_ERROR_NAMES = new Set([
   "UsageError",
@@ -46,6 +52,8 @@ import { runWatch } from "./commands/watch";
 import { composeContext } from "./compose";
 import { HELP, VERSION, findCommandHelp } from "./help";
 import {
+  OUTPUT_FORMATS,
+  type OutputFormat,
   type OutputSink,
   emit,
   emitError,
@@ -68,8 +76,23 @@ export async function run(options: RunOptions): Promise<number> {
   const stdout = options.stdout ?? stdoutSink;
   const stderr = options.stderr ?? stderrSink;
   const parsed = parseArgs(options.argv);
-  const json = boolFlag(parsed.flags, "json");
-  const renderOpts = { json, sink: stdout };
+  // AWS CLI 風の --output text|json|tsv|csv。--json は --output json の別名。
+  const outFlag = optionalFlag(parsed.flags, "output");
+  if (
+    outFlag !== undefined &&
+    !(OUTPUT_FORMATS as readonly string[]).includes(outFlag)
+  ) {
+    emitError(`--output は ${OUTPUT_FORMATS.join(" | ")} のいずれかです`, {
+      json: false,
+      sink: stderr,
+    });
+    return 2;
+  }
+  const format: OutputFormat =
+    (outFlag as OutputFormat | undefined) ??
+    (boolFlag(parsed.flags, "json") ? "json" : "text");
+  const json = format === "json";
+  const renderOpts = { format, json, sink: stdout };
 
   if (boolFlag(parsed.flags, "version")) {
     emit({ version: VERSION }, `mound ${VERSION}`, renderOpts);

--- a/packages/cli/src/adapters/cli/help.ts
+++ b/packages/cli/src/adapters/cli/help.ts
@@ -65,9 +65,10 @@ export const HELP = `mound — 草野球チーム向け試合成立 CLI
   mound <command> [subcommand] --help        例: mound game create --help
 
 グローバルフラグ:
-  --json       JSON 出力 (エージェント連携向け)
-  --help       このヘルプ
-  --version    バージョン
+  --output FMT  出力形式 text | json | tsv | csv (既定 text)。AWS CLI 風
+  --json        --output json の別名 (エージェント連携向け)
+  --help        このヘルプ
+  --version     バージョン
 
 接続先の決定順:
   環境変数 > ~/.mound/config.json (mound config set) > 既定 (~/.mound/mound.db)

--- a/packages/cli/src/adapters/cli/output.ts
+++ b/packages/cli/src/adapters/cli/output.ts
@@ -14,17 +14,68 @@ export const stderrSink: OutputSink = {
   },
 };
 
+export const OUTPUT_FORMATS = ["text", "json", "tsv", "csv"] as const;
+export type OutputFormat = (typeof OUTPUT_FORMATS)[number];
+
 export interface RenderOptions {
+  format: OutputFormat;
+  // format === "json" の後方互換ショートカット (一部コマンドが opts.json を見る)。
   json: boolean;
   sink: OutputSink;
 }
 
 export function emit<T>(value: T, text: string, opts: RenderOptions): void {
-  if (opts.json) {
-    opts.sink.write(JSON.stringify(value));
-  } else {
-    opts.sink.write(text);
+  switch (opts.format) {
+    case "json":
+      opts.sink.write(JSON.stringify(value));
+      return;
+    case "tsv":
+      opts.sink.write(renderDelimited(value, "\t"));
+      return;
+    case "csv":
+      opts.sink.write(renderDelimited(value, ","));
+      return;
+    default:
+      opts.sink.write(text);
   }
+}
+
+// 値を区切り文字つきの表に整形する (tsv / csv)。
+//   - 配列      → 1 レコード 1 行 (列 = 先頭レコードのキー)
+//   - オブジェクト → 1 行
+//   - スカラー   → value 列 1 行
+// ネストした値はセル内で JSON 文字列にする。csv はカンマ/引用符/改行を含む値を quote。
+export function renderDelimited(value: unknown, sep: string): string {
+  const records = toRecords(value);
+  if (records.length === 0) return "";
+  const cols = Object.keys(records[0] ?? {});
+  const esc = sep === "," ? csvField : (s: string) => s;
+  const header = cols.map(esc).join(sep);
+  const lines = records.map((r) => cols.map((c) => esc(cell(r[c]))).join(sep));
+  return [header, ...lines].join("\n");
+}
+
+function toRecords(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) return value.map(asRecord);
+  if (value && typeof value === "object")
+    return [value as Record<string, unknown>];
+  return [{ value }];
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : { value: v };
+}
+
+function cell(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+function csvField(s: string): string {
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
 export function emitError(


### PR DESCRIPTION
出力形式をグローバルに選べる `--output text|json|tsv|csv`。`--json` は `--output json` の別名(後方互換)。list 系は tsv/csv でサマリ行なしの純データになる。`make check` 緑 (191 tests)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)